### PR TITLE
Add query description

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -369,65 +369,6 @@
     histogramUpdated = true;
   }
 
-  function updateHourlyWages(stats, domain) {
-    var graph = d3.select("#hourly-wages"),
-        row = graph.selectAll(".row")
-          .data(stats, function(d) {
-            return d.min_years_experience;
-          });
-
-    row.exit().remove();
-
-    var enter = row.enter().append("div")
-      .attr("class", "row");
-
-    enter.append("span")
-      .attr("class", "row-label years");
-
-    var bar = enter.append("div")
-      .attr("class", "bar")
-      .style({
-        "margin-left": "0%",
-        "margin-right": "0%"
-      });
-    bar.append("span")
-      .attr("class", "average")
-      .style("left", "0%")
-      .append("span")
-        .attr("class", "label")
-        .html('$<b class="value"></b><i class="count"></i>');
-
-    var wageScale = d3.scale.linear()
-      .domain(domain)
-      .range([0, 100]);
-
-    row.select(".years")
-      .text(function(d) {
-        return d.min_years_experience;
-      });
-
-    var bar = row.select(".bar")
-      .style("margin-left", function(d) {
-        return wageScale(d.min_wage) + "%";
-      })
-      .style("margin-right", function(d) {
-        return wageScale(d.max_wage) + "%";
-      });
-
-    var avg = bar.select(".average")
-      .style("left", function(d) {
-        return wageScale(d.average_wage) + "%";
-      });
-    avg.select(".value")
-      .text(function(d) {
-        return d.average_wage;
-      });
-    avg.select(".count")
-      .text(function(d) {
-        return d.num_contracts;
-      });
-  }
-
   function updateResults(results) {
     d3.select("#results-count")
       .text(formatCommas(results.length));

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -25,7 +25,7 @@ span.dollars {
   color: #999;
 }
 
-.filters {
+div.filters {
   background: #f9f9f9;
   padding: 1rem;
   border-radius: 4px;
@@ -35,7 +35,7 @@ span.dollars {
   padding: 1rem 0;
 }
 
-.filters .filter {
+div.filters .filter {
   width: 50%;
   float: left;
 }
@@ -58,7 +58,27 @@ td.column-min_years_experience i {
   color: #999;
 }
 
+#results-table {
+  margin-top: 2em;
+}
+
 #export-data {
-  position: absolute;
-  right: 0;
+  margin: 0;
+}
+
+#description {
+  color: #333;
+  font-weight: normal;
+}
+
+#description .total {
+  font-weight: bold;
+}
+
+#description .empty .not-empty {
+  display: none;
+}
+
+#results-actions {
+  text-align: right;
 }

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -50,9 +50,9 @@ thead th {
 }
 
 table caption {
-  color: #666;
+  color: inherit;
   text-align: left;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 th.sortable {
@@ -227,6 +227,11 @@ svg.histogram .avg line {
 
 .filter_active  {
   border: 2px solid #ffd855 !important;
+}
+
+input:focus,
+select:focus {
+  border: 2px solid #33C3F0 !important;
 }
 
 #labor_category {

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -149,8 +149,19 @@
 
     <table id="results-table" class="results has-data">
       <caption>
-        <span id="results-total">...</span> matching row(s), showing <span id="results-count">...</span>
-        <a id="export-data" class="button button-secondary" title="Click to export your search results to an Excel file (CSV)" href="/api/rates/csv/">Export Data</a>
+        <div class="row">
+          <div id="description" class="nine columns">
+            Showing <span data-key="count">0</span> of
+            <span class="total" data-key="total">0</span>
+            <span data-key="results">results</span>
+            <span class="filters">
+              <span class="not-empty">matching</span>
+            </span>
+          </div>
+          <div id="results-actions" class="three columns">
+            <a id="export-data" class="button button-secondary" title="Click to export your search results to an Excel file (CSV)" href="/api/rates/csv/">Export Data</a>
+          </div>
+        </div>
       </caption>
       <thead>
         <tr>


### PR DESCRIPTION
This updates the text above the results table to dynamically list all of the active filters, per [this card](https://trello.com/c/do7QFAAg/29-help-users-understand-state-of-their-search-and-the-data-in-results-what-is-loaded-based-on-their-search-filters). Here's how it works:

* When there are no active filters (or search terms), it simply reads, `Showing 200 of 49,528 results`
* When you search for a labor category, it changes to `Showing 121 of 121 results matching “labor category”`

Any additional filters will tack on bits that read something like `, and [field] {value}`, with slight variations for each filter. These are defined as string templates [here](https://github.com/18F/calc/blob/query-description/hourglass_site/static/hourglass_site/js/index.js#L568-L574), in which the `{value}` placeholder is replaced with the filter's value. For select inputs, the `{label}` placeholder is replaced with the selected option's text (so you get "High School" instead of "HS"). The `<a>` links in these templates get dynamic click handlers that focus the corresponding form input.

I've also added some `:focus` styles to input and select elements that give them a blue border so you can tell when they're selected.