### PR TITLE
Fix y-axis labels in #94

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -267,9 +267,11 @@
         x = d3.scale.linear()
           .domain(extent)
           .range([left, right]),
+        countExtent = d3.extent(bins, function(d) { return d.count; }),
         height = d3.scale.linear()
-          .domain([0].concat(d3.extent(bins, function(d) { return d.count; })))
+          .domain([0].concat(countExtent))
           .range([0, 1, bottom - top]);
+    console.log('count extent:', countExtent);
 
     var xAxis = svg.select(".axis.x");
     if (xAxis.empty()) {
@@ -392,12 +394,13 @@
           .style("text-anchor", "end")
           .attr("transform", "rotate(-35)");
 
+    var yd = d3.extent(height.domain());
     var ya = d3.svg.axis()
       .orient("left")
       .scale(d3.scale.linear()
-        .domain(height.domain())
+        .domain(yd)
         .range([bottom, top]))
-      .tickValues(height.domain());
+      .tickValues(yd);
     ya.tickFormat(formatCommas);
     yAxis.call(ya)
       .attr("transform", "translate(" + [left - 2, 0] + ")");


### PR DESCRIPTION
The problem was a regression in my fix to #77, where I added a step in the linear scale for 1, which made the domain of the y-axis scale `[0, 1, max]`. It does the right thing now:

![image](https://cloud.githubusercontent.com/assets/113896/7143516/0b8d0eb4-e295-11e4-89c0-c11c5e9d78d5.png)
