### PR TITLE
Fix #95: truncate price values on histogram x-axis

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -15,7 +15,7 @@
   var search = d3.select("#search"),
       form = new formdb.Form(search.node()),
       inputs = search.selectAll("*[name]"),
-      formatPrice = d3.format(",.02f"),
+      formatPrice = d3.format(",.0f"),
       formatCommas = d3.format(","),
       api = new hourglass.API(),
       $search = $("#labor_category"),

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -11,6 +11,9 @@
 
   // for IE9: History API polyfill
   var location = window.history.location || window.location;
+  // TODO: if location.hash, read that
+  // e.g. if an IE9 user sends a link to a Chrome user, they should see the
+  // same stuff.
 
   var search = d3.select("#search"),
       form = new formdb.Form(search.node()),


### PR DESCRIPTION
The histogram x-axis labels are now all rounded to remove the cent values:

![image](https://cloud.githubusercontent.com/assets/113896/7328284/1928b5c2-ea89-11e4-9d50-5d6dd4205ca9.png)
