### PR TITLE
Clear excluded rows on form reset

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -7,10 +7,13 @@ class WhiteListPermission(permissions.BasePermission):
     """
     def has_permission(self, request, view):
         ip_addr = None
-        try:
-            forwarded = request.META['HTTP_X_FORWARDED_FOR']
-            ip_addr = forwarded.split(',')[-2].strip()
-        except KeyError:    
+        forwarded = request.META.get('HTTP_X_FORWARDED_FOR')
+        if forwarded:
+            try:
+                ip_addr = forwarded.split(',')[-2].strip()
+            except:
+                ip_addr = forwarded
+        else:
             ip_addr = request.META['REMOTE_ADDR']
 
         if settings.REST_FRAMEWORK['WHITELIST']:

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -46,6 +46,10 @@
   search.select('input[type="reset"]')
     .on('click', function reset() {
       form.reset();
+      // NB: form.reset() doesn't reset hidden inputs,
+      // so we need to do it ourselves.
+      search.selectAll('input[type="hidden"]')
+        .property('value', '');
       console.log("reset:", form.getData());
       submit(true);
       d3.event.preventDefault();

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -168,7 +168,7 @@ class FunctionalTests(LiveServerTestCase):
     def test_titles_are_correct(self):
         get_contract_recipe().make(_quantity=1, labor_category=seq("Architect"))
         driver = self.load_and_wait()
-        self.assertTrue(driver.title.startswith('Hourglass'), 'Title mismatch, {} does not start with Hourglass'.format(driver.title))
+        self.assertTrue(driver.title.startswith('CALC'), 'Title mismatch, {} does not start with CALC'.format(driver.title))
 
     def test_filter_order_is_correct(self):
         get_contract_recipe().make(_quantity=1, labor_category=seq("Architect"))
@@ -398,7 +398,7 @@ class FunctionalTests(LiveServerTestCase):
         form = self.get_form()
         self.search_for('engineer')
         self.submit_form_and_wait()
-        cells = driver.find_elements_by_css_selector('table.results tbody td.column-labor_category')
+        cells = driver.find_elements_by_css_selector('table.results tbody .column-labor_category')
         self.assertEqual(len(cells), 2, 'wrong cell count: %d (expected 2)' % len(cells))
         for cell in cells:
             self.assertTrue('Engineer' in cell.text, 'found cell without "Engineer": "%s"' % cell.text)
@@ -410,7 +410,7 @@ class FunctionalTests(LiveServerTestCase):
         self.search_for('software engineer')
         self.set_form_values(form, query_type='match_phrase')
         self.submit_form_and_wait()
-        cells = driver.find_elements_by_css_selector('table.results tbody td.column-labor_category')
+        cells = driver.find_elements_by_css_selector('table.results tbody .column-labor_category')
         self.assertEqual(len(cells), 1, 'wrong cell count: %d (expected 1)' % len(cells))
         self.assertEqual(cells[0].text, 'Software Engineer II', 'bad cell text: "%s"' % cells[0].text)
 
@@ -422,7 +422,7 @@ class FunctionalTests(LiveServerTestCase):
         self.set_form_values(form, query_type='match_exact')
         # self.assertEqual(driver.execute_script('document.querySelector("input[value=\'match_exact\']").checked'), True, 'match_exact not checked!')
         self.submit_form_and_wait()
-        cells = driver.find_elements_by_css_selector('table.results tbody td.column-labor_category')
+        cells = driver.find_elements_by_css_selector('table.results tbody .column-labor_category')
         self.assertEqual(len(cells), 1, 'wrong cell count: %d (expected 1)' % len(cells))
         self.assertEqual(cells[0].text, 'Software Engineer', 'bad cell text: "%s"' % cells[0].text)
 


### PR DESCRIPTION
This PR includes a fix for #117 and some miscellaneous fixes for the Selenium tests. @kaitlin I could use your eye on the `api/permissions.py` change, specifically. The deal there was that when running the Selenium tests on Sauce through https://localtunnel.me, the `X-Forwarded-For` header is set to a raw IP address, so the line that parses out the comma-separated bits was failing.