### PR TITLE
Fix IE labels

### DIFF
--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -118,6 +118,10 @@ th.column-idv_piid {              width: 12%; }
 th.column-vendor_name {           width: 25%; }
 th.column-schedule {              width: 10%; }
 
+th.column-education_level {
+  white-space: nowrap;
+}
+
 td.column-idv_piid {
   white-space: nowrap;
 }

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -192,3 +192,20 @@ svg .axis .label {
 
 .selenium #search.error { border-color: red; }
 .selenium #search.loaded { border-color: green; }
+
+/**
+ * IE tweaks!
+ *
+ * In any version of IE, the <body> gets two
+ * classes:
+ *
+ * 1. "ie"
+ * 2. "ie{version}", where {version} is the
+ *    major version number, e.g. 8, 9, 10, or 11.
+ *
+ * So, to target IE8, you would prefix your
+ * selector with ".ie8", and so on.
+ */
+.ie #results-table thead th a {
+  top: -20px;
+}

--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -99,5 +99,15 @@
     </script>
     <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
 
+    <![if gt IE 8]>
+    <script>
+      if (typeof aight === 'object') {
+        d3.select('body')
+          .classed('ie', true)
+          .classed('ie' + aight.browser.ie, true);
+      }
+    </script>
+    <![endif]>
+
   </body>
 </html>

--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -61,13 +61,12 @@
         <div class="row">
 
           <div id="code" class="three columns">
-                <div id="footer_nav">
-                    <ul>
-                        <li><a href="https://github.com/18F/calc"><img alt="GitHub Logo" src="https://mirage-gsa-gov.s3.amazonaws.com:443/mirage_site/images/github_icon.png"> View our code on GitHub</a></li>
-                    <!--    <li><a href="/docs/">Read the API documentation</a></li>-->
-                    </ul>
-                </div><!--end footer_nav<!-->
-           
+            <div id="footer_nav">
+              <ul>
+                <li><a href="https://github.com/18F/calc"><img alt="GitHub Logo" src="https://mirage-gsa-gov.s3.amazonaws.com:443/mirage_site/images/github_icon.png"> View our code on GitHub</a></li>
+                <!-- <li><a href="/docs/">Read the API documentation</a></li> -->
+              </ul>
+            </div><!-- /.footer_nav -->
           </div>
 
           <div id="help-wanted" class="six columns">


### PR DESCRIPTION
This is a slight rewrite of #126 that adds IE-specific classes to the `<body>` and addresses the label positioning with a qualified CSS selector: `.ie etc.`.