### PR TITLE
Add Travis continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+- 2.7
+- 3.4
+
+install:
+- "pip install -r requirements.txt"
+- "pip install -r requirements.txt"
+
+# install python 2 requirements iff we're in py2
+before_script:
+- "[ `python -c 'import sys; print sys.version_info.major'` == 2 ] && pip install -r requirements_python2.txt"
+
+script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 before_script:
   - cp hourglass/local_settings{.travis,}.py
   - createuser hourglass
-  - cat hourglass/setup.sql | psql
+  - cat hourglass/setup.sql | psql -U hourglass hourglass
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  # - 2.7
   - 3.4
+  # - 2.7
 
 addons:
   postgresql: 9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,26 @@
 language: python
 python:
-- 2.7
-- 3.4
+  - 2.7
+  - 3.4
 
-install:
-- "pip install -r requirements.txt"
+addons:
+  postgresql: "9.3"
 
 matrix:
   # finish on the first failure
   fast_finish: true
   include:
     # install python 2 requirements iff we're in py2
-    - python: "2.7"
-      before_script: "pip install -r requirements_python2.txt"
+    - python: 2.7
+      before_script: pip install -r requirements_python2.txt
+
+install:
+- pip install -r requirements.txt
+
+before_script:
+  - cp hourglass/local_settings{.travis,}.py
+  - createuser hourglass
+  - cat hourglass/setup.sql | psql
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ install:
 
 before_script:
   - cp hourglass/local_settings{.travis,}.py
-  - createuser hourglass
-  - createdb -U hourglass
-  - cat hourglass/setup.sql | psql -U hourglass hourglass
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
 install:
   - pip install -r requirements.txt
 
-before_script:
-  - cp hourglass/local_settings{.travis,}.py
-
 script:
+  - cp hourglass/local_settings{.travis,}.py
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.4
 
 addons:
-  postgresql: "9.3"
+  postgresql: 9.3
 
 matrix:
   # finish on the first failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ matrix:
     - python: "2.7"
       before_script: "pip install -r requirements_python2.txt"
 
-script: make test
+script:
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ python:
 
 install:
 - "pip install -r requirements.txt"
-- "pip install -r requirements.txt"
 
-# install python 2 requirements iff we're in py2
-before_script:
-- "[ `python -c 'import sys; print sys.version_info.major'` == 2 ] && pip install -r requirements_python2.txt"
+matrix:
+  # finish on the first failure
+  fast_finish: true
+  include:
+    # install python 2 requirements iff we're in py2
+    - python: "2.7"
+      before_script: "pip install -r requirements_python2.txt"
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 before_script:
   - cp hourglass/local_settings{.travis,}.py
   - createuser hourglass
+  - createdb -U hourglass
   - cat hourglass/setup.sql | psql -U hourglass hourglass
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 2.7
+  # - 2.7
   - 3.4
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       before_script: pip install -r requirements_python2.txt
 
 install:
-- pip install -r requirements.txt
+  - pip install -r requirements.txt
 
 before_script:
   - cp hourglass/local_settings{.travis,}.py

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default_options ?= --nologcapture --liveserver=localhost:$(port)
 lt_run ?= ./node_modules/.bin/lt-run
 options ?=
 
-test:
+test: static
 	$(manage) test \
 		$(default_options) \
 		$(options)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ node_modules:
 static:
 	@# using --link allows us to work on the JS and CSS
 	@# without having to run collectstatic to see changes
-	$(manage) collectstatic --link
+	echo "yes" | $(manage) collectstatic --link > /dev/null
 
 clean:
 	rm -rf static

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ node_modules:
 static:
 	@# using --link allows us to work on the JS and CSS
 	@# without having to run collectstatic to see changes
-	echo "yes" | $(manage) collectstatic --link > /dev/null
+	$(manage) collectstatic -c --noinput --link > /dev/null
 
 clean:
 	rm -rf static

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-manage ?= ./manage.py
+manage ?= python manage.py
 port ?= 8081
 default_options ?= --nologcapture --liveserver=localhost:$(port)
 lt_run ?= ./node_modules/.bin/lt-run

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ node_modules:
 static:
 	@# using --link allows us to work on the JS and CSS
 	@# without having to run collectstatic to see changes
-	$(manage) collectstatic -c --noinput --link > /dev/null
+	$(manage) collectstatic --noinput --link > /dev/null
 
 clean:
 	rm -rf static

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CALC
 
+[![Build Status](https://travis-ci.org/18F/calc.svg?branch=add-travis)](https://travis-ci.org/18F/calc)
+
 CALC (formerly known as "Hourglass"), which stands for Contracts Awarded Labor Category, is a tool to help contracting personnel estimate their per-hour labor costs for a contract, based on historical pricing information. The tool is in the very early stages of development. You can track our progress on our [trello board](https://trello.com/b/LjXJaVbZ/prices) or file an issue on this repo. 
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CALC
 
-[![Build Status](https://travis-ci.org/18F/calc.svg?branch=add-travis)](https://travis-ci.org/18F/calc)
+[![Build Status](https://travis-ci.org/18F/calc.svg)](https://travis-ci.org/18F/calc)
 
 CALC (formerly known as "Hourglass"), which stands for Contracts Awarded Labor Category, is a tool to help contracting personnel estimate their per-hour labor costs for a contract, based on historical pricing information. The tool is in the very early stages of development. You can track our progress on our [trello board](https://trello.com/b/LjXJaVbZ/prices) or file an issue on this repo. 
 

--- a/hourglass/local_settings.travis.py
+++ b/hourglass/local_settings.travis.py
@@ -4,7 +4,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'hourglass',
-        'USER': 'hourglass',
+        'USER': 'postgres',
         'PASSWORD': '',
     }
 }

--- a/hourglass/local_settings.travis.py
+++ b/hourglass/local_settings.travis.py
@@ -9,7 +9,7 @@ DATABASES = {
     }
 }
 
-SECRET_KEY = ''
+SECRET_KEY = 'travistravistravis'
 
 # for front-end testing with Sauce
 REMOTE_TESTING = {

--- a/hourglass/local_settings.travis.py
+++ b/hourglass/local_settings.travis.py
@@ -1,0 +1,25 @@
+DEBUG = True
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'hourglass',
+        'USER': 'hourglass',
+        'PASSWORD': '',
+    }
+}
+
+SECRET_KEY = ''
+
+# for front-end testing with Sauce
+REMOTE_TESTING = {
+    'enabled': False,
+    'hub_url': 'http://%s:%s@ondemand.saucelabs.com:80/wd/hub',
+    'username': '',
+    'access_key': '',
+    'capabilities': {
+        # 'browser': 'internet explorer',
+        # 'version': '9.0',
+        # 'platform': 'Windows 7'
+    }
+}

--- a/hourglass/local_settings.travis.py
+++ b/hourglass/local_settings.travis.py
@@ -1,5 +1,7 @@
 DEBUG = True
 
+from django.utils.crypto import get_random_string
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -9,7 +11,7 @@ DATABASES = {
     }
 }
 
-SECRET_KEY = 'travistravistravis'
+SECRET_KEY = get_random_string(50)
 
 # for front-end testing with Sauce
 REMOTE_TESTING = {

--- a/hourglass/setup.sql
+++ b/hourglass/setup.sql
@@ -1,0 +1,2 @@
+ALTER USER hourglass CREATEDB;
+GRANT ALL ON DATABASE hourglass TO hourglass;


### PR DESCRIPTION
This fixes #76 by adding a `.travis.yml` file that runs the tests in both Python 2.7 and 3.4 (which will be handy for detecting changes that break 2.x installs).