### PR TITLE
Update price label on x-axis

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -414,7 +414,7 @@
       .attr('class', 'label')
       .attr('transform', 'translate(' + [left + (right - left) / 2, 45] + ')')
       .attr('text-anchor', 'middle')
-      .text('price')
+      .text('price (hourly rate)')
 
     var yd = d3.extent(heightScale.domain());
     var ya = d3.svg.axis()


### PR DESCRIPTION
This updates the x-axis label on the histogram from price to "price (hourly rate)"

It is currently lowercase italics, but happy to change to uppercase if people prefer.
![duel](https://cloud.githubusercontent.com/assets/5249443/7527646/7b1f5a44-f4d2-11e4-9764-caa5a9e62a07.jpg)
