### PR TITLE
Adding experience range dropdown filter and corresponding API functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For example, if you wanted results with more than five years and less
 than ten years of experience:
 
 ```
-http://localhost:8000/api/rates/?experience=5,10
+http://localhost:8000/api/rates/?experience_range=5,10
 ```
 
 The valid values for `min_education` are `HS` (high school), `AA` (associates),

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ experience, and maximum years of experience. For example:
 http://localhost:8000/api/rates/?min_education=MA&min_experience=5&max_experience=10&q=technical
 ```
 
+Or, you can filter with a single, comma-separated range.
+For example, if you wanted results with more than five years and less 
+than ten years of experience:
+
+```
+http://localhost:8000/api/rates/?experience=5,10
+```
+
 The valid values for `min_education` are `HS` (high school), `AA` (associates),
 `BA` (bachelors), `MA` (masters), and `PHD` (Ph.D).
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -341,6 +341,23 @@ class ContractsTest(TestCase):
            'contractor_site': None,
            'business_size': None}])
 
+    def test_filter_by_experience_range(self):
+        self.make_test_set()
+        resp = self.c.get(self.path, {'experience': '10,15'})
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertResultsEqual(resp.data['results'], 
+         [{'idv_piid': 'ABC123',
+           'vendor_name': 'ACME Corp.',
+           'labor_category': 'Legal Services',
+           'education_level': None,
+           'min_years_experience': 10,
+           'hourly_rate_year1': 18.0,
+           'current_price': 18.0,
+           'schedule': None,
+           'contractor_site': None,
+           'business_size': None}])
+
     def test_filter_by_schedule(self):
         get_contract_recipe().make(_quantity=3)
         resp = self.c.get(self.path, {'schedule': 'MOBIS'})

--- a/api/tests.py
+++ b/api/tests.py
@@ -342,11 +342,38 @@ class ContractsTest(TestCase):
            'business_size': None}])
 
     def test_filter_by_experience_range(self):
-        self.make_test_set()
-        resp = self.c.get(self.path, {'experience': '10,15'})
+        get_contract_recipe().make(_quantity=2)
+        resp = self.c.get(self.path, {'experience': '6,8'})
         self.assertEqual(resp.status_code, 200)
 
         self.assertResultsEqual(resp.data['results'], 
+         [{'idv_piid': 'ABC1231',
+           'vendor_name': 'CompanyName1',
+           'labor_category': 'Business Analyst II',
+           'education_level': None,
+           'min_years_experience': 6,
+           'hourly_rate_year1': 21.0,
+           'current_price': 21.0,
+           'schedule': 'MOBIS',
+           'contractor_site': None,
+           'business_size': None},
+         {'idv_piid': 'ABC1232',
+           'vendor_name': 'CompanyName2',
+           'labor_category': 'Business Analyst II',
+           'education_level': None,
+           'min_years_experience': 7,
+           'hourly_rate_year1': 22.0,
+           'current_price': 22.0,
+           'schedule': 'PES',
+           'contractor_site': None,
+           'business_size': None}])
+
+    def test_filter_by_experience_single(self):
+        self.make_test_set()
+        resp = self.c.get(self.path, {'experience': '10'})
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertResultsEqual(resp.data['results'],
          [{'idv_piid': 'ABC123',
            'vendor_name': 'ACME Corp.',
            'labor_category': 'Legal Services',

--- a/api/tests.py
+++ b/api/tests.py
@@ -343,7 +343,7 @@ class ContractsTest(TestCase):
 
     def test_filter_by_experience_range(self):
         get_contract_recipe().make(_quantity=3)
-        resp = self.c.get(self.path, {'experience': '6,8'})
+        resp = self.c.get(self.path, {'experience_range': '6,8'})
         self.assertEqual(resp.status_code, 200)
 
         self.assertResultsEqual(resp.data['results'], 
@@ -380,7 +380,7 @@ class ContractsTest(TestCase):
 
     def test_filter_by_experience_single(self):
         self.make_test_set()
-        resp = self.c.get(self.path, {'experience': '10'})
+        resp = self.c.get(self.path, {'experience_range': '10'})
         self.assertEqual(resp.status_code, 200)
 
         self.assertResultsEqual(resp.data['results'],

--- a/api/tests.py
+++ b/api/tests.py
@@ -342,7 +342,7 @@ class ContractsTest(TestCase):
            'business_size': None}])
 
     def test_filter_by_experience_range(self):
-        get_contract_recipe().make(_quantity=2)
+        get_contract_recipe().make(_quantity=3)
         resp = self.c.get(self.path, {'experience': '6,8'})
         self.assertEqual(resp.status_code, 200)
 
@@ -365,6 +365,16 @@ class ContractsTest(TestCase):
            'hourly_rate_year1': 22.0,
            'current_price': 22.0,
            'schedule': 'PES',
+           'contractor_site': None,
+           'business_size': None},
+         {'idv_piid': 'ABC1233',
+           'vendor_name': 'CompanyName3',
+           'labor_category': 'Business Analyst II',
+           'education_level': None,
+           'min_years_experience': 8,
+           'hourly_rate_year1': 23.0,
+           'current_price': 23.0,
+           'schedule': 'MOBIS',
            'contractor_site': None,
            'business_size': None}])
 

--- a/api/views.py
+++ b/api/views.py
@@ -36,7 +36,7 @@ def get_contracts_queryset(request_params, wage_field):
 
     Query Params:
         q (str): keywords to search by
-        experience(str): filter by a range of years of experience
+        experience_range(str): filter by a range of years of experience
         min_experience (int): filter by minimum years of experience
         max_experience (int): filter by maximum years of experience
         min_education (str): filter by a minimum level of education (see EDUCATION_CHOICES)

--- a/api/views.py
+++ b/api/views.py
@@ -55,7 +55,7 @@ def get_contracts_queryset(request_params, wage_field):
     """
 
     query = request_params.get('q', None)
-    experience = request_params.get('experience', None)
+    experience_range = request_params.get('experience_range', None)
     min_experience = request_params.get('min_experience', None)
     max_experience = request_params.get('max_experience', None)
     min_education = request_params.get('min_education', None)
@@ -86,8 +86,8 @@ def get_contracts_queryset(request_params, wage_field):
             query = convert_to_tsquery(query)
             contracts = contracts.search(query, raw=True)
 
-    if experience:
-        years = experience.split(',')
+    if experience_range:
+        years = experience_range.split(',')
         min_experience = int(years[0])
         if len(years) > 1:
             max_experience = int(years[1])

--- a/api/views.py
+++ b/api/views.py
@@ -36,6 +36,7 @@ def get_contracts_queryset(request_params, wage_field):
 
     Query Params:
         q (str): keywords to search by
+        experience(str): filter by a range of years of experience
         min_experience (int): filter by minimum years of experience
         max_experience (int): filter by maximum years of experience
         min_education (str): filter by a minimum level of education (see EDUCATION_CHOICES)
@@ -54,6 +55,7 @@ def get_contracts_queryset(request_params, wage_field):
     """
 
     query = request_params.get('q', None)
+    experience = request_params.get('experience', None)
     min_experience = request_params.get('min_experience', None)
     max_experience = request_params.get('max_experience', None)
     min_education = request_params.get('min_education', None)
@@ -83,6 +85,12 @@ def get_contracts_queryset(request_params, wage_field):
         else:
             query = convert_to_tsquery(query)
             contracts = contracts.search(query, raw=True)
+
+    if experience:
+        years = experience.split(',')
+        min_experience = int(years[0])
+        if len(years) > 1:
+            max_experience = int(years[1])
 
     if min_experience:
         contracts = contracts.filter(min_years_experience__gte=min_experience)

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -119,13 +119,13 @@ form {
           <a href="/about#schedules" class="info">what's this?</a>
           <select id="schedule" name="schedule">
             <option value="">(all)</option>
-            <option>Environmental</option>
             <option>AIMS</option>
+            <option>Consolidated</option>
+            <option>Environmental</option>
             <option>Logistics</option>
             <option>Language Services</option>
-            <option>PES</option>
             <option>MOBIS</option>
-            <option>Consolidated</option>
+            <option>PES</option>
           </select>
         </div>
 

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -75,8 +75,8 @@ form {
         </div>
 
         <div class="filter three columns">
-          <label for="min_experience">Experience:</label>
-          <select id="experience" name="experience">
+          <label for="experience_range">Experience:</label>
+          <select id="experience_range" name="experience_range">
             <option value="">(all)</option>
             <option value="0,5">0-5 years</option>
             <option value="5,10">5-10 years</option>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -78,7 +78,7 @@ form {
           <label for="min_experience">Experience:</label>
           <select id="experience" name="experience">
             <option value="">(all)</option>
-            <option value="1,5">1-5 years</option>
+            <option value="0,5">0-5 years</option>
             <option value="5,10">5-10 years</option>
             <option value="10,15">10-15 years</option>
             <option value="15,20">15-20 years</option>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -75,9 +75,16 @@ form {
         </div>
 
         <div class="filter three columns">
-          <label for="min_experience">Min. Experience:</label>
-          <input id="min_experience" name="min_experience" type="text" placeholder="0">
-          years
+          <label for="min_experience">Experience:</label>
+          <select id="experience" name="experience">
+            <option value="">(all)</option>
+            <option value="1,5">1-5 years</option>
+            <option value="5,10">5-10 years</option>
+            <option value="10,15">10-15 years</option>
+            <option value="15,20">15-20 years</option>
+            <option value="20,25">20-25 years</option>
+            <option value="25">25+ years</option>
+          </select>
         </div>
 
         <div class="filter three columns">


### PR DESCRIPTION
Instead of the user filtering on a minimum level of experience, the user can now choose a range of experience, in increments of five years. 

This also adds the `experience_range` API filter, which takes a range of years and delegates to `min_experience` and `max_experience`.