### PR TITLE
Add vendor sortability back

### DIFF
--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -172,7 +172,7 @@ form {
             <th scope="col" class="sortable" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
             <th scope="col" class="sortable" data-key="current_price" data-format="$%,.02f">Price</th>
             <th scope="col" data-key="idv_piid">Contract #</th>
-            <th scope="col" data-key="vendor_name">Vendor</th>
+            <th scope="col" class="sortable" data-key="vendor_name">Vendor</th>
             <th scope="col" class="sortable collapsible" data-key="schedule">Schedule</th>
           </tr>
         </thead>


### PR DESCRIPTION
I added back in sortability for the Vendor column. This is what it looks like:
![screen shot 2015-05-08 at 11 38 06 am](https://cloud.githubusercontent.com/assets/5249443/7543099/c754a8ac-f576-11e4-9c92-1b1cf48cf492.png)
