### PR TITLE
Update dynamic sentence

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -754,8 +754,6 @@
       {name: 'min_experience', template: 'minimum <a>{value} years</a> of experience'},
       {name: 'site', template: 'worksite: <a>{value}</a>'},
       {name: 'business_size', template: 'size: <a>{label}</a>'},
-      {name: 'price__gte', template: 'price &ge; <a>${value}</a>'},
-      {name: 'price__lte', template: 'price &le; <a>${value}</a>'},
       {name: 'schedule', template: 'schedule: <a>{value}</a>'}
     ])
     .map(function(d) {

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -751,7 +751,7 @@
     var inputs = ([
       {name: 'q', template: '&ldquo;<a>{value}</a>&rdquo;'},
       {name: 'min_education', template: 'minimum education level: <a>{label}</a>'},
-      {name: 'min_experience', template: 'minimum <a>{value} years</a> of experience'},
+      {name: 'experience_range', template: '<a>{label}</a> of experience'},
       {name: 'site', template: 'worksite: <a>{value}</a>'},
       {name: 'business_size', template: 'size: <a>{label}</a>'},
       {name: 'schedule', template: 'schedule: <a>{value}</a>'}


### PR DESCRIPTION
This updates the dynamic sentence (mad-libs style) created above the histogram when selecting filters. I've removed the min/max price and changed min experience to experience range.

This is what it looks like now:
![screen shot 2015-05-11 at 6 41 14 am](https://cloud.githubusercontent.com/assets/5249443/7565930/ccc9d38c-f7a8-11e4-8a16-b18171bd4180.png)
