### PR TITLE
Fix color contrast for 508 accessibility

### DIFF
--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -90,7 +90,6 @@ span.dollars {
 .schedule-info {
   float: right;
   font-size: 70%;
-  color: #666;
 }
 
 .graph-block {
@@ -131,7 +130,7 @@ span.dollars {
 }
 
 #avg-price-highlight {
-  color: #29A0C5;
+  color: #17779f;
   font-weight: 400;
 }
 

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -90,7 +90,7 @@ span.dollars {
 .schedule-info {
   float: right;
   font-size: 70%;
-  color: #bbb;
+  color: #666;
 }
 
 .graph-block {

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -20,12 +20,25 @@ a:hover {
   color: #0c4c6f;
 }
 
-.button.button-primary, button.button-primary, input.button-primary[type="submit"], input.button-primary[type="reset"], input.button-primary[type="button"] {
+.button.button-primary, 
+button.button-primary, 
+input.button-primary[type="submit"], 
+input.button-primary[type="reset"], 
+input.button-primary[type="button"] {
   background-color: #17779f;
   border-color: #17779f;
 }
 
-.button.button-primary:hover, button.button-primary:hover, input.button-primary[type="submit"]:hover, input.button-primary[type="reset"]:hover, input.button-primary[type="button"]:hover, .button.button-primary:focus, button.button-primary:focus, input.button-primary[type="submit"]:focus, input.button-primary[type="reset"]:focus, input.button-primary[type="button"]:focus {
+.button.button-primary:hover, 
+button.button-primary:hover, 
+input.button-primary[type="submit"]:hover, 
+input.button-primary[type="reset"]:hover, 
+input.button-primary[type="button"]:hover, 
+.button.button-primary:focus, 
+button.button-primary:focus, 
+input.button-primary[type="submit"]:focus, 
+input.button-primary[type="reset"]:focus, 
+input.button-primary[type="button"]:focus {
   background-color: #0c4c6f;
   border-color: #0c4c6f;
 }

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -12,6 +12,23 @@ body {
   -webkit-box-sizing: border-box;
 }
 
+a {
+  color: #17779f;
+}
+
+a:hover {
+  color: #0c4c6f;
+}
+
+.button.button-primary, button.button-primary, input.button-primary[type="submit"], input.button-primary[type="reset"], input.button-primary[type="button"] {
+  background-color: #17779f;
+  border-color: #17779f;
+}
+
+.button.button-primary:hover, button.button-primary:hover, input.button-primary[type="submit"]:hover, input.button-primary[type="reset"]:hover, input.button-primary[type="button"]:hover, .button.button-primary:focus, button.button-primary:focus, input.button-primary[type="submit"]:focus, input.button-primary[type="reset"]:focus, input.button-primary[type="button"]:focus {
+  background-color: #0c4c6f;
+  border-color: #0c4c6f;
+}
 .container {
   width: 100%;
   padding-left: 20px;

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -222,7 +222,7 @@ footer {
     list-style-type: none;
     float: left;
 }
-#footer_nav a {
+#footer_nav a, #site-status a {
     color: #FFF;
     list-style-type: none;   
 }

--- a/hourglass_site/static/hourglass_site/style/tables.css
+++ b/hourglass_site/static/hourglass_site/style/tables.css
@@ -112,7 +112,7 @@ th.exclude a.restore {
   /* border: 1px solid red; */
   text-transform: uppercase;
   text-decoration: underline;
-  color: #999;
+  color: #666;
   white-space: nowrap;
   vertical-align: bottom;
   bottom: 100%;


### PR DESCRIPTION
While I do love our bright and fresh blue, @brethauer noted they didn't pass color contrast checks for 508 accessibility here: https://github.com/18F/calc/issues/152

Here's how it looks with accessible colors:

![screen shot 2015-05-12 at 2 22 55 pm](https://cloud.githubusercontent.com/assets/5249443/7598875/6daa32b0-f8b2-11e4-9824-3b4edba27f37.png)
