### PR TITLE
Fix table for responsive

### DIFF
--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -164,6 +164,11 @@ label[for=schedule] {
   display: inline-block;
 }
 
+.table-container {
+  width: 100%;
+  overflow: scroll;
+}
+
 th.column-exclude {               width:  2%; }
 th.column-labor_category {        width: 23%; }
 th.column-education_level {       width: 10%; }

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -166,28 +166,30 @@ form {
         <div class="error-message"></div>
       </div>
 
-      <table id="results-table" class="results has-data">
-        <thead>
-          <tr>
-            <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params" href="?exclude="></a></th>
-            <th scope="col" class="sortable" data-key="labor_category">Labor Category</th>
-            <th scope="col" class="sortable" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
-            <th scope="col" class="sortable" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
-            <th scope="col" class="sortable" data-key="current_price" data-format="$%,.02f">Price</th>
-            <th scope="col" data-key="idv_piid">Contract #</th>
-            <th scope="col" class="sortable" data-key="vendor_name">Vendor</th>
-            <th scope="col" class="sortable collapsible" data-key="schedule">Schedule</th>
-          </tr>
-        </thead>
-        <tbody>
-        </tbody>
-        <tfoot>
-          <tr>
-            <td colspan="8">
-              <a href="#results-table">Return to the top</a>
-            </td>
-        </tfoot>
-      </table>
+      <div class="table-container">
+        <table id="results-table" class="results has-data">
+          <thead>
+            <tr>
+              <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params" href="?exclude="></a></th>
+              <th scope="col" class="sortable" data-key="labor_category">Labor Category</th>
+              <th scope="col" class="sortable" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
+              <th scope="col" class="sortable" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
+              <th scope="col" class="sortable" data-key="current_price" data-format="$%,.02f">Price</th>
+              <th scope="col" data-key="idv_piid">Contract #</th>
+              <th scope="col" class="sortable" data-key="vendor_name">Vendor</th>
+              <th scope="col" class="sortable collapsible" data-key="schedule">Schedule</th>
+            </tr>
+          </thead>
+          <tbody>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="8">
+                <a href="#results-table">Return to the top</a>
+              </td>
+          </tfoot>
+        </table>
+      </div>
 
     </div><!-- /.container -->
   </section><!-- /.graphs -->


### PR DESCRIPTION
This will preserve the mobile layout and allow people to scroll horizontally to view the table. Before the whole page shifted.

This implements this fix found here: https://github.com/18F/calc/issues/158 thanks to @blacktm

This is how it looks now:
![screen shot 2015-05-13 at 10 37 21 am](https://cloud.githubusercontent.com/assets/5249443/7616869/96648958-f95c-11e4-8976-15810f933a4d.png)