### PR TITLE
Link contracts from GSA eLibrary in table

### DIFF
--- a/hourglass_site/static/hourglass_site/images/document.svg
+++ b/hourglass_site/static/hourglass_site/images/document.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
+  <path d="M0 0v8h7v-4h-4v-4h-3zm4 0v3h3l-3-3zm-3 2h1v1h-1v-1zm0 2h1v1h-1v-1zm0 2h4v1h-4v-1z" />
+</svg>

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -524,7 +524,8 @@
     .html(function(d) {
       var id = d.string.split('-').join('');
       return '<a target="_blank" href="https://www.gsaadvantage.gov/ref_text/' 
-             + id + '/' + id + '_online.htm">' + d.string + '</a>';
+             + id + '/' + id + '_online.htm">' + d.string
+             + '<img class="document-icon" src="static/hourglass_site/images/document.svg" alt="document icon"></a>';
     });
 
     // add a link to incoming exclusion cells

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -517,6 +517,16 @@
       return d.string + ' <span class="years hidden">' + label + '</span>';
     });
 
+    // add links to contracts
+    td.filter(function(d) {
+      return d.key === 'idv_piid';
+    })
+    .html(function(d) {
+      var id = d.string.split('-').join('');
+      return '<a target="_blank" href="https://www.gsaadvantage.gov/ref_text/' 
+             + id + '/' + id + '_online.htm">' + d.string + '</a>';
+    });
+
     // add a link to incoming exclusion cells
     enter.filter(function(d) {
       return d.key === 'exclude';

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -196,6 +196,11 @@ td.column-min_years_experience .years {
   color: #bbb;
 }
 
+.document-icon {
+  height: 12px;
+  margin-left: 3px;
+}
+
 a.focus-input {
   text-decoration: none;
   border-bottom: 1px dotted;

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -266,6 +266,15 @@ class FunctionalTests(LiveServerTestCase):
         self.assertIsNone(re.search(r'4 years of experience\d+', driver.page_source))
         self.assertIsNotNone(re.search(r'5 years of experience\d+', driver.page_source))
 
+    def test_contract_link(self):
+        get_contract_recipe().make(_quantity=1, idv_piid='GS-23F-0062P')
+        driver = self.load_and_wait()
+        form = self.get_form()
+
+        contract_link = driver.find_element_by_xpath('//*[@id="results-table"]/tbody/tr[1]/td[5]/a')
+        redirect_url = 'https://www.gsaadvantage.gov/ref_text/GS23F0062P/GS23F0062P_online.htm'
+        self.assertEqual(contract_link.get_attribute('href'), redirect_url)
+
     def test_there_is_no_business_size_column(self):
         get_contract_recipe().make(_quantity=5, vendor_name=seq("Large Biz"), business_size='o')
         driver = self.load()


### PR DESCRIPTION
Adds a link to each contract ID that goes to the contract in the form a PDF or other document type hosted on the GSA eLibrary.

Notes:
- If more markup ends up in the JS, we should probably come up with a cleaner plan.
- I tried to add a test to make sure that the document we link to in our test case still exists, but the redirect on the GSA side didn't appear to be working. Its kind of testing someone else's functionality, so maybe that's for the best, but inevitably these urls will change and it'd be nice to find out from a test.