### PR TITLE
Add tooltips and use aria-label

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -870,3 +870,8 @@
   }
 
 })(this);
+
+// initialize tooltipster.js
+$(document).ready(function() {
+    $('.tooltip').tooltipster();
+});

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -632,8 +632,9 @@
         this.classList.add('column-' + d.key);
       });
 
-    headers.filter(function(d) { return d.collapsible; })
-      .call(setupCollapsibleHeaders);
+    // removed temporarily to prevent collision with tooltips [TS]
+    // headers.filter(function(d) { return d.collapsible; })
+    //   .call(setupCollapsibleHeaders);
 
     headers.filter(function(d) { return d.sortable; })
       .call(setupSortHeaders);
@@ -705,6 +706,7 @@
       });
   }
 
+  // temporarily not in use to prevent tooltip collision [TS]
   function setupCollapsibleHeaders(headers) {
     headers
       .each(function(d) {

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -873,5 +873,9 @@
 
 // initialize tooltipster.js
 $(document).ready(function() {
-    $('.tooltip').tooltipster();
+    $('.tooltip').tooltipster({
+        functionInit: function(origin, content) {
+            return $(this).attr('aria-label');
+        }
+    });
 });

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -29,6 +29,18 @@
       loadingIndicator = search.select(".loading-indicator"),
       request;
 
+  // set default options for all future tooltip instantiations
+  $.fn.tooltipster('setDefaults', {
+    speed: 200
+  });
+
+  // initialize tooltipster.js
+  $('.tooltip').tooltipster({
+      functionInit: function(origin, content) {
+          return $(this).attr('aria-label');
+      }
+  });
+
   // JFYI
   var HISTOGRAM_BINS = 12;
 
@@ -534,7 +546,12 @@
     })
     .append('a')
       .attr('class', 'exclude-row')
-      .html('&times;');
+      .html('&times;')
+      .each(function(){
+        $(this).tooltipster({
+          position: 'bottom'
+        })
+      });
 
 
     // update the links on all exclude cells
@@ -545,8 +562,11 @@
       .attr('href', function(d) {
         return '?exclude=' + d.row.id;
       })
-      .attr('title', function(d){
+      .attr('aria-label', function(d){
           return 'Exclude ' + d.row.labor_category + ' from your search';
+      })
+      .each(function(){
+        $(this).tooltipster('content', this.getAttribute('aria-label'))
       })
 
       .on('click', function(d) {
@@ -674,8 +694,10 @@
         .classed('descending', function(c) {
           return c.sorted && c.descending;
         })
-        // .attr('aria-label', title)
-        .attr('title', title);
+        .attr('aria-label', title)
+        .each(function (){
+          $(this).tooltipster('content', this.getAttribute ('aria-label'));
+        })
 
     resultsTable.selectAll('tbody td')
       .classed('sorted', function(c) {
@@ -870,12 +892,3 @@
   }
 
 })(this);
-
-// initialize tooltipster.js
-$(document).ready(function() {
-    $('.tooltip').tooltipster({
-        functionInit: function(origin, content) {
-            return $(this).attr('aria-label');
-        }
-    });
-});

--- a/hourglass_site/static/hourglass_site/js/vendor/jquery.tooltipster.js
+++ b/hourglass_site/static/hourglass_site/js/vendor/jquery.tooltipster.js
@@ -1,0 +1,1327 @@
+/*
+
+Tooltipster 3.3.0 | 2014-11-08
+A rockin' custom tooltip jQuery plugin
+
+Developed by Caleb Jacob under the MIT license http://opensource.org/licenses/MIT
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+;(function ($, window, document) {
+
+	var pluginName = "tooltipster",
+		defaults = {
+			animation: 'fade',
+			arrow: true,
+			arrowColor: '',
+			autoClose: true,
+			content: null,
+			contentAsHTML: false,
+			contentCloning: true,
+			debug: true,
+			delay: 200,
+			minWidth: 0,
+			maxWidth: null,
+			functionInit: function(origin, content) {},
+			functionBefore: function(origin, continueTooltip) {
+				continueTooltip();
+			},
+			functionReady: function(origin, tooltip) {},
+			functionAfter: function(origin) {},
+			hideOnClick: false,
+			icon: '(?)',
+			iconCloning: true,
+			iconDesktop: false,
+			iconTouch: false,
+			iconTheme: 'tooltipster-icon',
+			interactive: false,
+			interactiveTolerance: 350,
+			multiple: false,
+			offsetX: 0,
+			offsetY: 0,
+			onlyOne: false,
+			position: 'top',
+			positionTracker: false,
+			positionTrackerCallback: function(origin){
+				// the default tracker callback will close the tooltip when the trigger is
+				// 'hover' (see https://github.com/iamceege/tooltipster/pull/253)
+				if(this.option('trigger') == 'hover' && this.option('autoClose')) {
+					this.hide();
+				}
+			},
+			restoration: 'current',
+			speed: 350,
+			timer: 0,
+			theme: 'tooltipster-default',
+			touchDevices: true,
+			trigger: 'hover',
+			updateAnimation: true
+		};
+	
+	function Plugin(element, options) {
+		
+		// list of instance variables
+		
+		this.bodyOverflowX;
+		// stack of custom callbacks provided as parameters to API methods
+		this.callbacks = {
+			hide: [],
+			show: []
+		};
+		this.checkInterval = null;
+		// this will be the user content shown in the tooltip. A capital "C" is used because there is also a method called content()
+		this.Content;
+		// this is the original element which is being applied the tooltipster plugin
+		this.$el = $(element);
+		// this will be the element which triggers the appearance of the tooltip on hover/click/custom events.
+		// it will be the same as this.$el if icons are not used (see in the options), otherwise it will correspond to the created icon
+		this.$elProxy;
+		this.elProxyPosition;
+		this.enabled = true;
+		this.options = $.extend({}, defaults, options);
+		this.mouseIsOverProxy = false;
+		// a unique namespace per instance, for easy selective unbinding
+		this.namespace = 'tooltipster-'+ Math.round(Math.random()*100000);
+		// Status (capital S) can be either : appearing, shown, disappearing, hidden
+		this.Status = 'hidden';
+		this.timerHide = null;
+		this.timerShow = null;
+		// this will be the tooltip element (jQuery wrapped HTML element)
+		this.$tooltip;
+		
+		// for backward compatibility
+		this.options.iconTheme = this.options.iconTheme.replace('.', '');
+		this.options.theme = this.options.theme.replace('.', '');
+		
+		// launch
+		
+		this._init();
+	}
+	
+	Plugin.prototype = {
+		
+		_init: function() {
+			
+			var self = this;
+			
+			// disable the plugin on old browsers (including IE7 and lower)
+			if (document.querySelector) {
+				
+				// note : the content is null (empty) by default and can stay that way if the plugin remains initialized but not fed any content. The tooltip will just not appear.
+				
+				// let's save the initial value of the title attribute for later restoration if need be.
+				var initialTitle = null;
+				// it will already have been saved in case of multiple tooltips
+				if (self.$el.data('tooltipster-initialTitle') === undefined) {
+					
+					initialTitle = self.$el.attr('title');
+					
+					// we do not want initialTitle to have the value "undefined" because of how jQuery's .data() method works
+					if (initialTitle === undefined) initialTitle = null;
+					
+					self.$el.data('tooltipster-initialTitle', initialTitle);
+				}
+				
+				// if content is provided in the options, its has precedence over the title attribute.
+				// Note : an empty string is considered content, only 'null' represents the absence of content.
+				// Also, an existing title="" attribute will result in an empty string content
+				if (self.options.content !== null){
+					self._content_set(self.options.content);
+				}
+				else {
+					self._content_set(initialTitle);
+				}
+				
+				var c = self.options.functionInit.call(self.$el, self.$el, self.Content);
+				if(typeof c !== 'undefined') self._content_set(c);
+				
+				self.$el
+					// strip the title off of the element to prevent the default tooltips from popping up
+					.removeAttr('title')
+					// to be able to find all instances on the page later (upon window events in particular)
+					.addClass('tooltipstered');
+
+				// detect if we're changing the tooltip origin to an icon
+				// note about this condition : if the device has touch capability and self.options.iconTouch is false, you'll have no icons event though you may consider your device as a desktop if it also has a mouse. Not sure why someone would have this use case though.
+				if ((!deviceHasTouchCapability && self.options.iconDesktop) || (deviceHasTouchCapability && self.options.iconTouch)) {
+					
+					// TODO : the tooltip should be automatically be given an absolute position to be near the origin. Otherwise, when the origin is floating or what, it's going to be nowhere near it and disturb the position flow of the page elements. It will imply that the icon also detects when its origin moves, to follow it : not trivial.
+					// Until it's done, the icon feature does not really make sense since the user still has most of the work to do by himself
+					
+					// if the icon provided is in the form of a string
+					if(typeof self.options.icon === 'string'){
+						// wrap it in a span with the icon class
+						self.$elProxy = $('<span class="'+ self.options.iconTheme +'"></span>');
+						self.$elProxy.text(self.options.icon);
+					}
+					// if it is an object (sensible choice)
+					else {
+						// (deep) clone the object if iconCloning == true, to make sure every instance has its own proxy. We use the icon without wrapping, no need to. We do not give it a class either, as the user will undoubtedly style the object on his own and since our css properties may conflict with his own
+						if (self.options.iconCloning) self.$elProxy = self.options.icon.clone(true);
+						else self.$elProxy = self.options.icon;
+					}
+					
+					self.$elProxy.insertAfter(self.$el);
+				}
+				else {
+					self.$elProxy = self.$el;
+				}
+				
+				// for 'click' and 'hover' triggers : bind on events to open the tooltip. Closing is now handled in _showNow() because of its bindings.
+				// Notes about touch events :
+					// - mouseenter, mouseleave and clicks happen even on pure touch devices because they are emulated. deviceIsPureTouch() is a simple attempt to detect them.
+					// - on hybrid devices, we do not prevent touch gesture from opening tooltips. It would be too complex to differentiate real mouse events from emulated ones.
+					// - we check deviceIsPureTouch() at each event rather than prior to binding because the situation may change during browsing
+				if (self.options.trigger == 'hover') {
+					
+					// these binding are for mouse interaction only
+					self.$elProxy
+						.on('mouseenter.'+ self.namespace, function() {
+							if (!deviceIsPureTouch() || self.options.touchDevices) {
+								self.mouseIsOverProxy = true;
+								self._show();
+							}
+						})
+						.on('mouseleave.'+ self.namespace, function() {
+							if (!deviceIsPureTouch() || self.options.touchDevices) {
+								self.mouseIsOverProxy = false;
+							}
+						});
+					
+					// for touch interaction only
+					if (deviceHasTouchCapability && self.options.touchDevices) {
+						
+						// for touch devices, we immediately display the tooltip because we cannot rely on mouseleave to handle the delay
+						self.$elProxy.on('touchstart.'+ self.namespace, function() {
+							self._showNow();
+						});
+					}
+				}
+				else if (self.options.trigger == 'click') {
+					
+					// note : for touch devices, we do not bind on touchstart, we only rely on the emulated clicks (triggered by taps)
+					self.$elProxy.on('click.'+ self.namespace, function() {
+						if (!deviceIsPureTouch() || self.options.touchDevices) {
+							self._show();
+						}
+					});
+				}
+			}
+		},
+		
+		// this function will schedule the opening of the tooltip after the delay, if there is one
+		_show: function() {
+			
+			var self = this;
+			
+			if (self.Status != 'shown' && self.Status != 'appearing') {
+				
+				if (self.options.delay) {
+					self.timerShow = setTimeout(function(){
+						
+						// for hover trigger, we check if the mouse is still over the proxy, otherwise we do not show anything
+						if (self.options.trigger == 'click' || (self.options.trigger == 'hover' && self.mouseIsOverProxy)) {
+							self._showNow();
+						}
+					}, self.options.delay);
+				}
+				else self._showNow();
+			}
+		},
+		
+		// this function will open the tooltip right away
+		_showNow: function(callback) {
+			
+			var self = this;
+			
+			// call our constructor custom function before continuing
+			self.options.functionBefore.call(self.$el, self.$el, function() {
+				
+				// continue only if the tooltip is enabled and has any content
+				if (self.enabled && self.Content !== null) {
+				
+					// save the method callback and cancel hide method callbacks
+					if (callback) self.callbacks.show.push(callback);
+					self.callbacks.hide = [];
+					
+					//get rid of any appearance timer
+					clearTimeout(self.timerShow);
+					self.timerShow = null;
+					clearTimeout(self.timerHide);
+					self.timerHide = null;
+					
+					// if we only want one tooltip open at a time, close all auto-closing tooltips currently open and not already disappearing
+					if (self.options.onlyOne) {
+						$('.tooltipstered').not(self.$el).each(function(i,el) {
+							
+							var $el = $(el),
+								nss = $el.data('tooltipster-ns');
+							
+							// iterate on all tooltips of the element
+							$.each(nss, function(i, ns){
+								var instance = $el.data(ns),
+									// we have to use the public methods here
+									s = instance.status(),
+									ac = instance.option('autoClose');
+								
+								if (s !== 'hidden' && s !== 'disappearing' && ac) {
+									instance.hide();
+								}
+							});
+						});
+					}
+					
+					var finish = function() {
+						self.Status = 'shown';
+						
+						// trigger any show method custom callbacks and reset them
+						$.each(self.callbacks.show, function(i,c) { c.call(self.$el); });
+						self.callbacks.show = [];
+					};
+					
+					// if this origin already has its tooltip open
+					if (self.Status !== 'hidden') {
+						
+						// the timer (if any) will start (or restart) right now
+						var extraTime = 0;
+						
+						// if it was disappearing, cancel that
+						if (self.Status === 'disappearing') {
+							
+							self.Status = 'appearing';
+							
+							if (supportsTransitions()) {
+								
+								self.$tooltip
+									.clearQueue()
+									.removeClass('tooltipster-dying')
+									.addClass('tooltipster-'+ self.options.animation +'-show');
+								
+								if (self.options.speed > 0) self.$tooltip.delay(self.options.speed);
+								
+								self.$tooltip.queue(finish);
+							}
+							else {
+								// in case the tooltip was currently fading out, bring it back to life
+								self.$tooltip
+									.stop()
+									.fadeIn(finish);
+							}
+						}
+						// if the tooltip is already open, we still need to trigger the method custom callback
+						else if(self.Status === 'shown') {
+							finish();
+						}
+					}
+					// if the tooltip isn't already open, open that sucker up!
+					else {
+						
+						self.Status = 'appearing';
+						
+						// the timer (if any) will start when the tooltip has fully appeared after its transition
+						var extraTime = self.options.speed;
+						
+						// disable horizontal scrollbar to keep overflowing tooltips from jacking with it and then restore it to its previous value
+						self.bodyOverflowX = $('body').css('overflow-x');
+						$('body').css('overflow-x', 'hidden');
+						
+						// get some other settings related to building the tooltip
+						var animation = 'tooltipster-' + self.options.animation,
+							animationSpeed = '-webkit-transition-duration: '+ self.options.speed +'ms; -webkit-animation-duration: '+ self.options.speed +'ms; -moz-transition-duration: '+ self.options.speed +'ms; -moz-animation-duration: '+ self.options.speed +'ms; -o-transition-duration: '+ self.options.speed +'ms; -o-animation-duration: '+ self.options.speed +'ms; -ms-transition-duration: '+ self.options.speed +'ms; -ms-animation-duration: '+ self.options.speed +'ms; transition-duration: '+ self.options.speed +'ms; animation-duration: '+ self.options.speed +'ms;',
+							minWidth = self.options.minWidth ? 'min-width:'+ Math.round(self.options.minWidth) +'px;' : '',
+							maxWidth = self.options.maxWidth ? 'max-width:'+ Math.round(self.options.maxWidth) +'px;' : '',
+							pointerEvents = self.options.interactive ? 'pointer-events: auto;' : '';
+						
+						// build the base of our tooltip
+						self.$tooltip = $('<div class="tooltipster-base '+ self.options.theme +'" style="'+ minWidth +' '+ maxWidth +' '+ pointerEvents +' '+ animationSpeed +'"><div class="tooltipster-content"></div></div>');
+						
+						// only add the animation class if the user has a browser that supports animations
+						if (supportsTransitions()) self.$tooltip.addClass(animation);
+						
+						// insert the content
+						self._content_insert();
+						
+						// attach
+						self.$tooltip.appendTo('body');
+						
+						// do all the crazy calculations and positioning
+						self.reposition();
+						
+						// call our custom callback since the content of the tooltip is now part of the DOM
+						self.options.functionReady.call(self.$el, self.$el, self.$tooltip);
+						
+						// animate in the tooltip
+						if (supportsTransitions()) {
+							
+							self.$tooltip.addClass(animation + '-show');
+							
+							if(self.options.speed > 0) self.$tooltip.delay(self.options.speed);
+							
+							self.$tooltip.queue(finish);
+						}
+						else {
+							self.$tooltip.css('display', 'none').fadeIn(self.options.speed, finish);
+						}
+						
+						// will check if our tooltip origin is removed while the tooltip is shown
+						self._interval_set();
+						
+						// reposition on scroll (otherwise position:fixed element's tooltips will move away form their origin) and on resize (in case position can/has to be changed)
+						$(window).on('scroll.'+ self.namespace +' resize.'+ self.namespace, function() {
+							self.reposition();
+						});
+						
+						// auto-close bindings
+						if (self.options.autoClose) {
+							
+							// in case a listener is already bound for autoclosing (mouse or touch, hover or click), unbind it first
+							$('body').off('.'+ self.namespace);
+							
+							// here we'll have to set different sets of bindings for both touch and mouse
+							if (self.options.trigger == 'hover') {
+								
+								// if the user touches the body, hide
+								if (deviceHasTouchCapability) {
+									// timeout 0 : explanation below in click section
+									setTimeout(function() {
+										// we don't want to bind on click here because the initial touchstart event has not yet triggered its click event, which is thus about to happen
+										$('body').on('touchstart.'+ self.namespace, function() {
+											self.hide();
+										});
+									}, 0);
+								}
+								
+								// if we have to allow interaction
+								if (self.options.interactive) {
+									
+									// touch events inside the tooltip must not close it
+									if (deviceHasTouchCapability) {
+										self.$tooltip.on('touchstart.'+ self.namespace, function(event) {
+											event.stopPropagation();
+										});
+									}
+									
+									// as for mouse interaction, we get rid of the tooltip only after the mouse has spent some time out of it
+									var tolerance = null;
+									
+									self.$elProxy.add(self.$tooltip)
+										// hide after some time out of the proxy and the tooltip
+										.on('mouseleave.'+ self.namespace + '-autoClose', function() {
+											clearTimeout(tolerance);
+											tolerance = setTimeout(function(){
+												self.hide();
+											}, self.options.interactiveTolerance);
+										})
+										// suspend timeout when the mouse is over the proxy or the tooltip
+										.on('mouseenter.'+ self.namespace + '-autoClose', function() {
+											clearTimeout(tolerance);
+										});
+								}
+								// if this is a non-interactive tooltip, get rid of it if the mouse leaves
+								else {
+									self.$elProxy.on('mouseleave.'+ self.namespace + '-autoClose', function() {
+										self.hide();
+									});
+								}
+								
+								// close the tooltip when the proxy gets a click (common behavior of native tooltips)
+								if (self.options.hideOnClick) {
+									
+									self.$elProxy.on('click.'+ self.namespace + '-autoClose', function() {
+										self.hide();
+									});
+								}
+							}
+							// here we'll set the same bindings for both clicks and touch on the body to hide the tooltip
+							else if(self.options.trigger == 'click'){
+								
+								// use a timeout to prevent immediate closing if the method was called on a click event and if options.delay == 0 (because of bubbling)
+								setTimeout(function() {
+									$('body').on('click.'+ self.namespace +' touchstart.'+ self.namespace, function() {
+										self.hide();
+									});
+								}, 0);
+								
+								// if interactive, we'll stop the events that were emitted from inside the tooltip to stop autoClosing
+								if (self.options.interactive) {
+									
+									// note : the touch events will just not be used if the plugin is not enabled on touch devices
+									self.$tooltip.on('click.'+ self.namespace +' touchstart.'+ self.namespace, function(event) {
+										event.stopPropagation();
+									});
+								}
+							}
+						}
+					}
+					
+					// if we have a timer set, let the countdown begin
+					if (self.options.timer > 0) {
+						
+						self.timerHide = setTimeout(function() {
+							self.timerHide = null;
+							self.hide();
+						}, self.options.timer + extraTime);
+					}
+				}
+			});
+		},
+		
+		_interval_set: function() {
+			
+			var self = this;
+			
+			self.checkInterval = setInterval(function() {
+				
+				// if the tooltip and/or its interval should be stopped
+				if (
+						// if the origin has been removed
+						$('body').find(self.$el).length === 0
+						// if the elProxy has been removed
+					||	$('body').find(self.$elProxy).length === 0
+						// if the tooltip has been closed
+					||	self.Status == 'hidden'
+						// if the tooltip has somehow been removed
+					||	$('body').find(self.$tooltip).length === 0
+				) {
+					// remove the tooltip if it's still here
+					if (self.Status == 'shown' || self.Status == 'appearing') self.hide();
+					
+					// clear this interval as it is no longer necessary
+					self._interval_cancel();
+				}
+				// if everything is alright
+				else {
+					// compare the former and current positions of the elProxy to reposition the tooltip if need be
+					if(self.options.positionTracker){
+						
+						var p = self._repositionInfo(self.$elProxy),
+							identical = false;
+						
+						// compare size first (a change requires repositioning too)
+						if(areEqual(p.dimension, self.elProxyPosition.dimension)){
+							
+							// for elements with a fixed position, we track the top and left properties (relative to window)
+							if(self.$elProxy.css('position') === 'fixed'){
+								if(areEqual(p.position, self.elProxyPosition.position)) identical = true;
+							}
+							// otherwise, track total offset (relative to document)
+							else {
+								if(areEqual(p.offset, self.elProxyPosition.offset)) identical = true;
+							}
+						}
+						
+						if(!identical){
+							self.reposition();
+							self.options.positionTrackerCallback.call(self, self.$el);
+						}
+					}
+				}
+			}, 200);
+		},
+		
+		_interval_cancel: function() {
+			clearInterval(this.checkInterval);
+			// clean delete
+			this.checkInterval = null;
+		},
+		
+		_content_set: function(content) {
+			// clone if asked. Cloning the object makes sure that each instance has its own version of the content (in case a same object were provided for several instances)
+			// reminder : typeof null === object
+			if (typeof content === 'object' && content !== null && this.options.contentCloning) {
+				content = content.clone(true);
+			}
+			this.Content = content;
+		},
+		
+		_content_insert: function() {
+			
+			var self = this,
+				$d = this.$tooltip.find('.tooltipster-content');
+			
+			if (typeof self.Content === 'string' && !self.options.contentAsHTML) {
+				$d.text(self.Content);
+			}
+			else {
+				$d
+					.empty()
+					.append(self.Content);
+			}
+		},
+		
+		_update: function(content) {
+			
+			var self = this;
+			
+			// change the content
+			self._content_set(content);
+			
+			if (self.Content !== null) {
+				
+				// update the tooltip if it is open
+				if (self.Status !== 'hidden') {
+					
+					// reset the content in the tooltip
+					self._content_insert();
+					
+					// reposition and resize the tooltip
+					self.reposition();
+					
+					// if we want to play a little animation showing the content changed
+					if (self.options.updateAnimation) {
+						
+						if (supportsTransitions()) {
+							
+							self.$tooltip.css({
+								'width': '',
+								'-webkit-transition': 'all ' + self.options.speed + 'ms, width 0ms, height 0ms, left 0ms, top 0ms',
+								'-moz-transition': 'all ' + self.options.speed + 'ms, width 0ms, height 0ms, left 0ms, top 0ms',
+								'-o-transition': 'all ' + self.options.speed + 'ms, width 0ms, height 0ms, left 0ms, top 0ms',
+								'-ms-transition': 'all ' + self.options.speed + 'ms, width 0ms, height 0ms, left 0ms, top 0ms',
+								'transition': 'all ' + self.options.speed + 'ms, width 0ms, height 0ms, left 0ms, top 0ms'
+							}).addClass('tooltipster-content-changing');
+							
+							// reset the CSS transitions and finish the change animation
+							setTimeout(function() {
+								
+								if(self.Status != 'hidden'){
+									
+									self.$tooltip.removeClass('tooltipster-content-changing');
+									
+									// after the changing animation has completed, reset the CSS transitions
+									setTimeout(function() {
+										
+										if(self.Status !== 'hidden'){
+											self.$tooltip.css({
+												'-webkit-transition': self.options.speed + 'ms',
+												'-moz-transition': self.options.speed + 'ms',
+												'-o-transition': self.options.speed + 'ms',
+												'-ms-transition': self.options.speed + 'ms',
+												'transition': self.options.speed + 'ms'
+											});
+										}
+									}, self.options.speed);
+								}
+							}, self.options.speed);
+						}
+						else {
+							self.$tooltip.fadeTo(self.options.speed, 0.5, function() {
+								if(self.Status != 'hidden'){
+									self.$tooltip.fadeTo(self.options.speed, 1);
+								}
+							});
+						}
+					}
+				}
+			}
+			else {
+				self.hide();
+			}
+		},
+		
+		_repositionInfo: function($el) {
+			return {
+				dimension: {
+					height: $el.outerHeight(false),
+					width: $el.outerWidth(false)
+				},
+				offset: $el.offset(),
+				position: {
+					left: parseInt($el.css('left')),
+					top: parseInt($el.css('top'))
+				}
+			};
+		},
+		
+		hide: function(callback) {
+			
+			var self = this;
+			
+			// save the method custom callback and cancel any show method custom callbacks
+			if (callback) self.callbacks.hide.push(callback);
+			self.callbacks.show = [];
+			
+			// get rid of any appearance timeout
+			clearTimeout(self.timerShow);
+			self.timerShow = null;
+			clearTimeout(self.timerHide);
+			self.timerHide = null;
+			
+			var finishCallbacks = function() {
+				// trigger any hide method custom callbacks and reset them
+				$.each(self.callbacks.hide, function(i,c) { c.call(self.$el); });
+				self.callbacks.hide = [];
+			};
+			
+			// hide
+			if (self.Status == 'shown' || self.Status == 'appearing') {
+				
+				self.Status = 'disappearing';
+				
+				var finish = function() {
+					
+					self.Status = 'hidden';
+					
+					// detach our content object first, so the next jQuery's remove() call does not unbind its event handlers
+					if (typeof self.Content == 'object' && self.Content !== null) {
+						self.Content.detach();
+					}
+					
+					self.$tooltip.remove();
+					self.$tooltip = null;
+					
+					// unbind orientationchange, scroll and resize listeners
+					$(window).off('.'+ self.namespace);
+					
+					$('body')
+						// unbind any auto-closing click/touch listeners
+						.off('.'+ self.namespace)
+						.css('overflow-x', self.bodyOverflowX);
+					
+					// unbind any auto-closing click/touch listeners
+					$('body').off('.'+ self.namespace);
+					
+					// unbind any auto-closing hover listeners
+					self.$elProxy.off('.'+ self.namespace + '-autoClose');
+					
+					// call our constructor custom callback function
+					self.options.functionAfter.call(self.$el, self.$el);
+					
+					// call our method custom callbacks functions
+					finishCallbacks();
+				};
+				
+				if (supportsTransitions()) {
+					
+					self.$tooltip
+						.clearQueue()
+						.removeClass('tooltipster-' + self.options.animation + '-show')
+						// for transitions only
+						.addClass('tooltipster-dying');
+					
+					if(self.options.speed > 0) self.$tooltip.delay(self.options.speed);
+					
+					self.$tooltip.queue(finish);
+				}
+				else {
+					self.$tooltip
+						.stop()
+						.fadeOut(self.options.speed, finish);
+				}
+			}
+			// if the tooltip is already hidden, we still need to trigger the method custom callback
+			else if(self.Status == 'hidden') {
+				finishCallbacks();
+			}
+			
+			return self;
+		},
+		
+		// the public show() method is actually an alias for the private showNow() method
+		show: function(callback) {
+			this._showNow(callback);
+			return this;
+		},
+		
+		// 'update' is deprecated in favor of 'content' but is kept for backward compatibility
+		update: function(c) {
+			return this.content(c);
+		},
+		content: function(c) {
+			// getter method
+			if(typeof c === 'undefined'){
+				return this.Content;
+			}
+			// setter method
+			else {
+				this._update(c);
+				return this;
+			}
+		},
+		
+		reposition: function() {
+			
+			var self = this;
+			
+			// in case the tooltip has been removed from DOM manually
+			if ($('body').find(self.$tooltip).length !== 0) {
+				
+				// reset width
+				self.$tooltip.css('width', '');
+				
+				// find variables to determine placement
+				self.elProxyPosition = self._repositionInfo(self.$elProxy);
+				var arrowReposition = null,
+					windowWidth = $(window).width(),
+					// shorthand
+					proxy = self.elProxyPosition,
+					tooltipWidth = self.$tooltip.outerWidth(false),
+					tooltipInnerWidth = self.$tooltip.innerWidth() + 1, // this +1 stops FireFox from sometimes forcing an additional text line
+					tooltipHeight = self.$tooltip.outerHeight(false);
+				
+				// if this is an <area> tag inside a <map>, all hell breaks loose. Recalculate all the measurements based on coordinates
+				if (self.$elProxy.is('area')) {
+					var areaShape = self.$elProxy.attr('shape'),
+						mapName = self.$elProxy.parent().attr('name'),
+						map = $('img[usemap="#'+ mapName +'"]'),
+						mapOffsetLeft = map.offset().left,
+						mapOffsetTop = map.offset().top,
+						areaMeasurements = self.$elProxy.attr('coords') !== undefined ? self.$elProxy.attr('coords').split(',') : undefined;
+					
+					if (areaShape == 'circle') {
+						var areaLeft = parseInt(areaMeasurements[0]),
+							areaTop = parseInt(areaMeasurements[1]),
+							areaWidth = parseInt(areaMeasurements[2]);
+						proxy.dimension.height = areaWidth * 2;
+						proxy.dimension.width = areaWidth * 2;
+						proxy.offset.top = mapOffsetTop + areaTop - areaWidth;
+						proxy.offset.left = mapOffsetLeft + areaLeft - areaWidth;
+					}
+					else if (areaShape == 'rect') {
+						var areaLeft = parseInt(areaMeasurements[0]),
+							areaTop = parseInt(areaMeasurements[1]),
+							areaRight = parseInt(areaMeasurements[2]),
+							areaBottom = parseInt(areaMeasurements[3]);
+						proxy.dimension.height = areaBottom - areaTop;
+						proxy.dimension.width = areaRight - areaLeft;
+						proxy.offset.top = mapOffsetTop + areaTop;
+						proxy.offset.left = mapOffsetLeft + areaLeft;
+					}
+					else if (areaShape == 'poly') {
+						var areaXs = [],
+							areaYs = [],
+							areaSmallestX = 0,
+							areaSmallestY = 0,
+							areaGreatestX = 0,
+							areaGreatestY = 0,
+							arrayAlternate = 'even';
+						
+						for (var i = 0; i < areaMeasurements.length; i++) {
+							var areaNumber = parseInt(areaMeasurements[i]);
+							
+							if (arrayAlternate == 'even') {
+								if (areaNumber > areaGreatestX) {
+									areaGreatestX = areaNumber;
+									if (i === 0) {
+										areaSmallestX = areaGreatestX;
+									}
+								}
+								
+								if (areaNumber < areaSmallestX) {
+									areaSmallestX = areaNumber;
+								}
+								
+								arrayAlternate = 'odd';
+							}
+							else {
+								if (areaNumber > areaGreatestY) {
+									areaGreatestY = areaNumber;
+									if (i == 1) {
+										areaSmallestY = areaGreatestY;
+									}
+								}
+								
+								if (areaNumber < areaSmallestY) {
+									areaSmallestY = areaNumber;
+								}
+								
+								arrayAlternate = 'even';
+							}
+						}
+					
+						proxy.dimension.height = areaGreatestY - areaSmallestY;
+						proxy.dimension.width = areaGreatestX - areaSmallestX;
+						proxy.offset.top = mapOffsetTop + areaSmallestY;
+						proxy.offset.left = mapOffsetLeft + areaSmallestX;
+					}
+					else {
+						proxy.dimension.height = map.outerHeight(false);
+						proxy.dimension.width = map.outerWidth(false);
+						proxy.offset.top = mapOffsetTop;
+						proxy.offset.left = mapOffsetLeft;
+					}
+				}
+				
+				// our function and global vars for positioning our tooltip
+				var myLeft = 0,
+					myLeftMirror = 0,
+					myTop = 0,
+					offsetY = parseInt(self.options.offsetY),
+					offsetX = parseInt(self.options.offsetX),
+					// this is the arrow position that will eventually be used. It may differ from the position option if the tooltip cannot be displayed in this position
+					practicalPosition = self.options.position;
+				
+				// a function to detect if the tooltip is going off the screen horizontally. If so, reposition the crap out of it!
+				function dontGoOffScreenX() {
+				
+					var windowLeft = $(window).scrollLeft();
+					
+					// if the tooltip goes off the left side of the screen, line it up with the left side of the window
+					if((myLeft - windowLeft) < 0) {
+						arrowReposition = myLeft - windowLeft;
+						myLeft = windowLeft;
+					}
+					
+					// if the tooltip goes off the right of the screen, line it up with the right side of the window
+					if (((myLeft + tooltipWidth) - windowLeft) > windowWidth) {
+						arrowReposition = myLeft - ((windowWidth + windowLeft) - tooltipWidth);
+						myLeft = (windowWidth + windowLeft) - tooltipWidth;
+					}
+				}
+				
+				// a function to detect if the tooltip is going off the screen vertically. If so, switch to the opposite!
+				function dontGoOffScreenY(switchTo, switchFrom) {
+					// if it goes off the top off the page
+					if(((proxy.offset.top - $(window).scrollTop() - tooltipHeight - offsetY - 12) < 0) && (switchFrom.indexOf('top') > -1)) {
+						practicalPosition = switchTo;
+					}
+					
+					// if it goes off the bottom of the page
+					if (((proxy.offset.top + proxy.dimension.height + tooltipHeight + 12 + offsetY) > ($(window).scrollTop() + $(window).height())) && (switchFrom.indexOf('bottom') > -1)) {
+						practicalPosition = switchTo;
+						myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+					}
+				}
+				
+				if(practicalPosition == 'top') {
+					var leftDifference = (proxy.offset.left + tooltipWidth) - (proxy.offset.left + proxy.dimension.width);
+					myLeft = (proxy.offset.left + offsetX) - (leftDifference / 2);
+					myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+					dontGoOffScreenX();
+					dontGoOffScreenY('bottom', 'top');
+				}
+				
+				if(practicalPosition == 'top-left') {
+					myLeft = proxy.offset.left + offsetX;
+					myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+					dontGoOffScreenX();
+					dontGoOffScreenY('bottom-left', 'top-left');
+				}
+				
+				if(practicalPosition == 'top-right') {
+					myLeft = (proxy.offset.left + proxy.dimension.width + offsetX) - tooltipWidth;
+					myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+					dontGoOffScreenX();
+					dontGoOffScreenY('bottom-right', 'top-right');
+				}
+				
+				if(practicalPosition == 'bottom') {
+					var leftDifference = (proxy.offset.left + tooltipWidth) - (proxy.offset.left + proxy.dimension.width);
+					myLeft = proxy.offset.left - (leftDifference / 2) + offsetX;
+					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + 12;
+					dontGoOffScreenX();
+					dontGoOffScreenY('top', 'bottom');
+				}
+				
+				if(practicalPosition == 'bottom-left') {
+					myLeft = proxy.offset.left + offsetX;
+					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + 12;
+					dontGoOffScreenX();
+					dontGoOffScreenY('top-left', 'bottom-left');
+				}
+				
+				if(practicalPosition == 'bottom-right') {
+					myLeft = (proxy.offset.left + proxy.dimension.width + offsetX) - tooltipWidth;
+					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + 12;
+					dontGoOffScreenX();
+					dontGoOffScreenY('top-right', 'bottom-right');
+				}
+				
+				if(practicalPosition == 'left') {
+					myLeft = proxy.offset.left - offsetX - tooltipWidth - 12;
+					myLeftMirror = proxy.offset.left + offsetX + proxy.dimension.width + 12;
+					var topDifference = (proxy.offset.top + tooltipHeight) - (proxy.offset.top + proxy.dimension.height);
+					myTop = proxy.offset.top - (topDifference / 2) - offsetY;
+					
+					// if the tooltip goes off boths sides of the page
+					if((myLeft < 0) && ((myLeftMirror + tooltipWidth) > windowWidth)) {
+						var borderWidth = parseFloat(self.$tooltip.css('border-width')) * 2,
+							newWidth = (tooltipWidth + myLeft) - borderWidth;
+						self.$tooltip.css('width', newWidth + 'px');
+						
+						tooltipHeight = self.$tooltip.outerHeight(false);
+						myLeft = proxy.offset.left - offsetX - newWidth - 12 - borderWidth;
+						topDifference = (proxy.offset.top + tooltipHeight) - (proxy.offset.top + proxy.dimension.height);
+						myTop = proxy.offset.top - (topDifference / 2) - offsetY;
+					}
+					
+					// if it only goes off one side, flip it to the other side
+					else if(myLeft < 0) {
+						myLeft = proxy.offset.left + offsetX + proxy.dimension.width + 12;
+						arrowReposition = 'left';
+					}
+				}
+				
+				if(practicalPosition == 'right') {
+					myLeft = proxy.offset.left + offsetX + proxy.dimension.width + 12;
+					myLeftMirror = proxy.offset.left - offsetX - tooltipWidth - 12;
+					var topDifference = (proxy.offset.top + tooltipHeight) - (proxy.offset.top + proxy.dimension.height);
+					myTop = proxy.offset.top - (topDifference / 2) - offsetY;
+					
+					// if the tooltip goes off boths sides of the page
+					if(((myLeft + tooltipWidth) > windowWidth) && (myLeftMirror < 0)) {
+						var borderWidth = parseFloat(self.$tooltip.css('border-width')) * 2,
+							newWidth = (windowWidth - myLeft) - borderWidth;
+						self.$tooltip.css('width', newWidth + 'px');
+						
+						tooltipHeight = self.$tooltip.outerHeight(false);
+						topDifference = (proxy.offset.top + tooltipHeight) - (proxy.offset.top + proxy.dimension.height);
+						myTop = proxy.offset.top - (topDifference / 2) - offsetY;
+					}
+						
+					// if it only goes off one side, flip it to the other side
+					else if((myLeft + tooltipWidth) > windowWidth) {
+						myLeft = proxy.offset.left - offsetX - tooltipWidth - 12;
+						arrowReposition = 'right';
+					}
+				}
+				
+				// if arrow is set true, style it and append it
+				if (self.options.arrow) {
+	
+					var arrowClass = 'tooltipster-arrow-' + practicalPosition;
+					
+					// set color of the arrow
+					if(self.options.arrowColor.length < 1) {
+						var arrowColor = self.$tooltip.css('background-color');
+					}
+					else {
+						var arrowColor = self.options.arrowColor;
+					}
+					
+					// if the tooltip was going off the page and had to re-adjust, we need to update the arrow's position
+					if (!arrowReposition) {
+						arrowReposition = '';
+					}
+					else if (arrowReposition == 'left') {
+						arrowClass = 'tooltipster-arrow-right';
+						arrowReposition = '';
+					}
+					else if (arrowReposition == 'right') {
+						arrowClass = 'tooltipster-arrow-left';
+						arrowReposition = '';
+					}
+					else {
+						arrowReposition = 'left:'+ Math.round(arrowReposition) +'px;';
+					}
+					
+					// building the logic to create the border around the arrow of the tooltip
+					if ((practicalPosition == 'top') || (practicalPosition == 'top-left') || (practicalPosition == 'top-right')) {
+						var tooltipBorderWidth = parseFloat(self.$tooltip.css('border-bottom-width')),
+							tooltipBorderColor = self.$tooltip.css('border-bottom-color');
+					}
+					else if ((practicalPosition == 'bottom') || (practicalPosition == 'bottom-left') || (practicalPosition == 'bottom-right')) {
+						var tooltipBorderWidth = parseFloat(self.$tooltip.css('border-top-width')),
+							tooltipBorderColor = self.$tooltip.css('border-top-color');
+					}
+					else if (practicalPosition == 'left') {
+						var tooltipBorderWidth = parseFloat(self.$tooltip.css('border-right-width')),
+							tooltipBorderColor = self.$tooltip.css('border-right-color');
+					}
+					else if (practicalPosition == 'right') {
+						var tooltipBorderWidth = parseFloat(self.$tooltip.css('border-left-width')),
+							tooltipBorderColor = self.$tooltip.css('border-left-color');
+					}
+					else {
+						var tooltipBorderWidth = parseFloat(self.$tooltip.css('border-bottom-width')),
+							tooltipBorderColor = self.$tooltip.css('border-bottom-color');
+					}
+					
+					if (tooltipBorderWidth > 1) {
+						tooltipBorderWidth++;
+					}
+					
+					var arrowBorder = '';
+					if (tooltipBorderWidth !== 0) {
+						var arrowBorderSize = '',
+							arrowBorderColor = 'border-color: '+ tooltipBorderColor +';';
+						if (arrowClass.indexOf('bottom') !== -1) {
+							arrowBorderSize = 'margin-top: -'+ Math.round(tooltipBorderWidth) +'px;';
+						}
+						else if (arrowClass.indexOf('top') !== -1) {
+							arrowBorderSize = 'margin-bottom: -'+ Math.round(tooltipBorderWidth) +'px;';
+						}
+						else if (arrowClass.indexOf('left') !== -1) {
+							arrowBorderSize = 'margin-right: -'+ Math.round(tooltipBorderWidth) +'px;';
+						}
+						else if (arrowClass.indexOf('right') !== -1) {
+							arrowBorderSize = 'margin-left: -'+ Math.round(tooltipBorderWidth) +'px;';
+						}
+						arrowBorder = '<span class="tooltipster-arrow-border" style="'+ arrowBorderSize +' '+ arrowBorderColor +';"></span>';
+					}
+					
+					// if the arrow already exists, remove and replace it
+					self.$tooltip.find('.tooltipster-arrow').remove();
+					
+					// build out the arrow and append it		
+					var arrowConstruct = '<div class="'+ arrowClass +' tooltipster-arrow" style="'+ arrowReposition +'">'+ arrowBorder +'<span style="border-color:'+ arrowColor +';"></span></div>';
+					self.$tooltip.append(arrowConstruct);
+				}
+				
+				// position the tooltip
+				self.$tooltip.css({'top': Math.round(myTop) + 'px', 'left': Math.round(myLeft) + 'px'});
+			}
+			
+			return self;
+		},
+		
+		enable: function() {
+			this.enabled = true;
+			return this;
+		},
+		
+		disable: function() {
+			// hide first, in case the tooltip would not disappear on its own (autoClose false)
+			this.hide();
+			this.enabled = false;
+			return this;
+		},
+		
+		destroy: function() {
+			
+			var self = this;
+			
+			self.hide();
+			
+			// remove the icon, if any
+			if (self.$el[0] !== self.$elProxy[0]) {
+				self.$elProxy.remove();
+			}
+			
+			self.$el
+				.removeData(self.namespace)
+				.off('.'+ self.namespace);
+			
+			var ns = self.$el.data('tooltipster-ns');
+			
+			// if there are no more tooltips on this element
+			if(ns.length === 1){
+				
+				// optional restoration of a title attribute
+				var title = null;
+				if (self.options.restoration === 'previous'){
+					title = self.$el.data('tooltipster-initialTitle');
+				}
+				else if(self.options.restoration === 'current'){
+					
+					// old school technique to stringify when outerHTML is not supported
+					title =
+						(typeof self.Content === 'string') ?
+						self.Content :
+						$('<div></div>').append(self.Content).html();
+				}
+				
+				if (title) {
+					self.$el.attr('title', title);
+				}
+				
+				// final cleaning
+				self.$el
+					.removeClass('tooltipstered')
+					.removeData('tooltipster-ns')
+					.removeData('tooltipster-initialTitle');
+			}
+			else {
+				// remove the instance namespace from the list of namespaces of tooltips present on the element
+				ns = $.grep(ns, function(el, i){
+					return el !== self.namespace;
+				});
+				self.$el.data('tooltipster-ns', ns);
+			}
+			
+			return self;
+		},
+		
+		elementIcon: function() {
+			return (this.$el[0] !== this.$elProxy[0]) ? this.$elProxy[0] : undefined;
+		},
+		
+		elementTooltip: function() {
+			return this.$tooltip ? this.$tooltip[0] : undefined;
+		},
+		
+		// public methods but for internal use only
+		// getter if val is ommitted, setter otherwise
+		option: function(o, val) {
+			if (typeof val == 'undefined') return this.options[o];
+			else {
+				this.options[o] = val;
+				return this;
+			}
+		},
+		status: function() {
+			return this.Status;
+		}
+	};
+	
+	$.fn[pluginName] = function () {
+		
+		// for using in closures
+		var args = arguments;
+		
+		// if we are not in the context of jQuery wrapped HTML element(s) :
+		// this happens when calling static methods in the form $.fn.tooltipster('methodName'), or when calling $(sel).tooltipster('methodName or options') where $(sel) does not match anything
+		if (this.length === 0) {
+			
+			// if the first argument is a method name
+			if (typeof args[0] === 'string') {
+				
+				var methodIsStatic = true;
+				
+				// list static methods here (usable by calling $.fn.tooltipster('methodName');)
+				switch (args[0]) {
+					
+					case 'setDefaults':
+						// change default options for all future instances
+						$.extend(defaults, args[1]);
+						break;
+					
+					default:
+						methodIsStatic = false;
+						break;
+				}
+				
+				// $.fn.tooltipster('methodName') calls will return true
+				if (methodIsStatic) return true;
+				// $(sel).tooltipster('methodName') calls will return the list of objects event though it's empty because chaining should work on empty lists
+				else return this;
+			}
+			// the first argument is undefined or an object of options : we are initalizing but there is no element matched by selector
+			else {
+				// still chainable : same as above
+				return this;
+			}
+		}
+		// this happens when calling $(sel).tooltipster('methodName or options') where $(sel) matches one or more elements
+		else {
+			
+			// method calls
+			if (typeof args[0] === 'string') {
+				
+				var v = '#*$~&';
+				
+				this.each(function() {
+					
+					// retrieve the namepaces of the tooltip(s) that exist on that element. We will interact with the first tooltip only.
+					var ns = $(this).data('tooltipster-ns'),
+						// self represents the instance of the first tooltipster plugin associated to the current HTML object of the loop
+						self = ns ? $(this).data(ns[0]) : null;
+					
+					// if the current element holds a tooltipster instance
+					if (self) {
+						
+						if (typeof self[args[0]] === 'function') {
+							// note : args[1] and args[2] may not be defined
+							var resp = self[args[0]](args[1], args[2]);
+						}
+						else {
+							throw new Error('Unknown method .tooltipster("' + args[0] + '")');
+						}
+						
+						// if the function returned anything other than the instance itself (which implies chaining)
+						if (resp !== self){
+							v = resp;
+							// return false to stop .each iteration on the first element matched by the selector
+							return false;
+						}
+					}
+					else {
+						throw new Error('You called Tooltipster\'s "' + args[0] + '" method on an uninitialized element');
+					}
+				});
+				
+				return (v !== '#*$~&') ? v : this;
+			}
+			// first argument is undefined or an object : the tooltip is initializing
+			else {
+				
+				var instances = [],
+					// is there a defined value for the multiple option in the options object ?
+					multipleIsSet = args[0] && typeof args[0].multiple !== 'undefined',
+					// if the multiple option is set to true, or if it's not defined but set to true in the defaults
+					multiple = (multipleIsSet && args[0].multiple) || (!multipleIsSet && defaults.multiple),
+					// same for debug
+					debugIsSet = args[0] && typeof args[0].debug !== 'undefined',
+					debug = (debugIsSet && args[0].debug) || (!debugIsSet && defaults.debug);
+				
+				// initialize a tooltipster instance for each element if it doesn't already have one or if the multiple option is set, and attach the object to it
+				this.each(function () {
+					
+					var go = false,
+						ns = $(this).data('tooltipster-ns'),
+						instance = null;
+					
+					if (!ns) {
+						go = true;
+					}
+					else if (multiple) {
+						go = true;
+					}
+					else if (debug) {
+						console.log('Tooltipster: one or more tooltips are already attached to this element: ignoring. Use the "multiple" option to attach more tooltips.');
+					}
+					
+					if (go) {
+						instance = new Plugin(this, args[0]);
+						
+						// save the reference of the new instance
+						if (!ns) ns = [];
+						ns.push(instance.namespace);
+						$(this).data('tooltipster-ns', ns)
+						
+						// save the instance itself
+						$(this).data(instance.namespace, instance);
+					}
+					
+					instances.push(instance);
+				});
+				
+				if (multiple) return instances;
+				else return this;
+			}
+		}
+	};
+	
+	// quick & dirty compare function (not bijective nor multidimensional)
+	function areEqual(a,b) {
+		var same = true;
+		$.each(a, function(i, el){
+			if(typeof b[i] === 'undefined' || a[i] !== b[i]){
+				same = false;
+				return false;
+			}
+		});
+		return same;
+	}
+	
+	// detect if this device can trigger touch events
+	var deviceHasTouchCapability = !!('ontouchstart' in window);
+	
+	// we'll assume the device has no mouse until we detect any mouse movement
+	var deviceHasMouse = false;
+	$('body').one('mousemove', function() {
+		deviceHasMouse = true;
+	});
+	
+	function deviceIsPureTouch() {
+		return (!deviceHasMouse && deviceHasTouchCapability);
+	}
+	
+	// detecting support for CSS transitions
+	function supportsTransitions() {
+		var b = document.body || document.documentElement,
+			s = b.style,
+			p = 'transition';
+		
+		if(typeof s[p] == 'string') {return true; }
+
+		v = ['Moz', 'Webkit', 'Khtml', 'O', 'ms'],
+		p = p.charAt(0).toUpperCase() + p.substr(1);
+		for(var i=0; i<v.length; i++) {
+			if(typeof s[v[i] + p] == 'string') { return true; }
+		}
+		return false;
+	}
+})( jQuery, window, document );

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -261,6 +261,49 @@ svg .axis .label {
 .selenium #search.error { border-color: red; }
 .selenium #search.loaded { border-color: green; }
 
+/* tooltips */
+
+.tooltip {
+  display: inline;
+  position: relative;
+}
+
+.tooltip::after {
+  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.8);
+  border-radius: 5px;
+  bottom: 26px;
+  color: #fff;
+  content: attr(title);
+  left: 20%;
+  opacity: 0;
+  padding: 5px 15px;
+  position: absolute;
+  transition: opacity 0.25s ease-in-out 0s;
+  width: 220px;
+  z-index: 98;
+}
+
+.tooltip:hover::after {
+  opacity: 1;
+}
+
+.tooltip:hover::before {
+  -moz-border-bottom-colors: none;
+  -moz-border-left-colors: none;
+  -moz-border-right-colors: none;
+  -moz-border-top-colors: none;
+  border-color: #333 transparent;
+  border-image: none;
+  border-style: solid;
+  border-width: 6px 6px 0;
+  bottom: 20px;
+  content: "";
+  left: 50%;
+  position: absolute;
+  z-index: 99;
+}
+
+
 /**
  * IE tweaks!
  *

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -274,12 +274,12 @@ svg .axis .label {
 
 /* tooltips */
 
-.tooltip {
+.xtooltip {
   display: inline;
   position: relative;
 }
 
-.tooltip:hover:before {
+.xtooltip:hover:before {
   border: solid;
   border-color: #333 transparent;
   border-width: 6px 6px 0 6px;
@@ -290,7 +290,7 @@ svg .axis .label {
   z-index: 99;
 }
 
-.tooltip:hover::after {
+.xtooltip:hover::after {
   background: none repeat scroll 0 0 rgba(0, 0, 0, 0.8);
   border-radius: 5px;
   bottom: 26px;
@@ -373,4 +373,278 @@ th:hover.tooltips span {
  */
 .ie #results-table thead th a {
   top: -20px;
+}
+
+/* This is the default Tooltipster theme (feel free to modify or duplicate and create multiple themes!): */
+.tooltipster-default {
+  border-radius: 5px; 
+  border: 2px solid #000;
+  background: #4c4c4c;
+  color: #fff;
+}
+
+/* Use this next selector to style things like font-size and line-height: */
+.tooltipster-default .tooltipster-content {
+  font-size: 14px;
+  line-height: 16px;
+  padding: 8px 10px;
+  overflow: hidden;
+}
+
+/* This next selector defines the color of the border on the outside of the arrow. This will automatically match the color and size of the border set on the main tooltip styles. Set display: none; if you would like a border around the tooltip but no border around the arrow */
+.tooltipster-default .tooltipster-arrow .tooltipster-arrow-border {
+  /* border-color: ... !important; */
+}
+
+
+/* If you're using the icon option, use this next selector to style them */
+.tooltipster-icon {
+  cursor: help;
+  margin-left: 4px;
+}
+
+
+
+
+
+
+
+
+/* This is the base styling required to make all Tooltipsters work */
+.tooltipster-base {
+  padding: 0;
+  font-size: 0;
+  line-height: 0;
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 9999999;
+  pointer-events: none;
+  width: auto;
+  overflow: visible;
+}
+.tooltipster-base .tooltipster-content {
+  overflow: hidden;
+}
+
+
+/* These next classes handle the styles for the little arrow attached to the tooltip. By default, the arrow will inherit the same colors and border as what is set on the main tooltip itself. */
+.tooltipster-arrow {
+  display: block;
+  text-align: center;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}
+.tooltipster-arrow span, .tooltipster-arrow-border {
+  display: block;
+  width: 0; 
+  height: 0;
+  position: absolute;
+}
+.tooltipster-arrow-top span, .tooltipster-arrow-top-right span, .tooltipster-arrow-top-left span {
+  border-left: 8px solid transparent !important;
+  border-right: 8px solid transparent !important;
+  border-top: 8px solid;
+  bottom: -7px;
+}
+.tooltipster-arrow-top .tooltipster-arrow-border, .tooltipster-arrow-top-right .tooltipster-arrow-border, .tooltipster-arrow-top-left .tooltipster-arrow-border {
+  border-left: 9px solid transparent !important;
+  border-right: 9px solid transparent !important;
+  border-top: 9px solid;
+  bottom: -7px;
+}
+
+.tooltipster-arrow-bottom span, .tooltipster-arrow-bottom-right span, .tooltipster-arrow-bottom-left span {
+  border-left: 8px solid transparent !important;
+  border-right: 8px solid transparent !important;
+  border-bottom: 8px solid;
+  top: -7px;
+}
+.tooltipster-arrow-bottom .tooltipster-arrow-border, .tooltipster-arrow-bottom-right .tooltipster-arrow-border, .tooltipster-arrow-bottom-left .tooltipster-arrow-border {
+  border-left: 9px solid transparent !important;
+  border-right: 9px solid transparent !important;
+  border-bottom: 9px solid;
+  top: -7px;
+}
+.tooltipster-arrow-top span, .tooltipster-arrow-top .tooltipster-arrow-border, .tooltipster-arrow-bottom span, .tooltipster-arrow-bottom .tooltipster-arrow-border {
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+}
+.tooltipster-arrow-top-left span, .tooltipster-arrow-bottom-left span {
+  left: 6px;
+}
+.tooltipster-arrow-top-left .tooltipster-arrow-border, .tooltipster-arrow-bottom-left .tooltipster-arrow-border {
+  left: 5px;
+}
+.tooltipster-arrow-top-right span,  .tooltipster-arrow-bottom-right span {
+  right: 6px;
+}
+.tooltipster-arrow-top-right .tooltipster-arrow-border, .tooltipster-arrow-bottom-right .tooltipster-arrow-border {
+  right: 5px;
+}
+.tooltipster-arrow-left span, .tooltipster-arrow-left .tooltipster-arrow-border {
+  border-top: 8px solid transparent !important;
+  border-bottom: 8px solid transparent !important; 
+  border-left: 8px solid;
+  top: 50%;
+  margin-top: -7px;
+  right: -7px;
+}
+.tooltipster-arrow-left .tooltipster-arrow-border {
+  border-top: 9px solid transparent !important;
+  border-bottom: 9px solid transparent !important; 
+  border-left: 9px solid;
+  margin-top: -8px;
+}
+.tooltipster-arrow-right span, .tooltipster-arrow-right .tooltipster-arrow-border {
+  border-top: 8px solid transparent !important;
+  border-bottom: 8px solid transparent !important; 
+  border-right: 8px solid;
+  top: 50%;
+  margin-top: -7px;
+  left: -7px;
+}
+.tooltipster-arrow-right .tooltipster-arrow-border {
+  border-top: 9px solid transparent !important;
+  border-bottom: 9px solid transparent !important; 
+  border-right: 9px solid;
+  margin-top: -8px;
+}
+
+
+/* Some CSS magic for the awesome animations - feel free to make your own custom animations and reference it in your Tooltipster settings! */
+
+.tooltipster-fade {
+  opacity: 0;
+  -webkit-transition-property: opacity;
+  -moz-transition-property: opacity;
+  -o-transition-property: opacity;
+  -ms-transition-property: opacity;
+  transition-property: opacity;
+}
+.tooltipster-fade-show {
+  opacity: 1;
+}
+
+.tooltipster-grow {
+  -webkit-transform: scale(0,0);
+  -moz-transform: scale(0,0);
+  -o-transform: scale(0,0);
+  -ms-transform: scale(0,0);
+  transform: scale(0,0);
+  -webkit-transition-property: -webkit-transform;
+  -moz-transition-property: -moz-transform;
+  -o-transition-property: -o-transform;
+  -ms-transition-property: -ms-transform;
+  transition-property: transform;
+  -webkit-backface-visibility: hidden;
+}
+.tooltipster-grow-show {
+  -webkit-transform: scale(1,1);
+  -moz-transform: scale(1,1);
+  -o-transform: scale(1,1);
+  -ms-transform: scale(1,1);
+  transform: scale(1,1);
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15);
+}
+
+.tooltipster-swing {
+  opacity: 0;
+  -webkit-transform: rotateZ(4deg);
+  -moz-transform: rotateZ(4deg);
+  -o-transform: rotateZ(4deg);
+  -ms-transform: rotateZ(4deg);
+  transform: rotateZ(4deg);
+  -webkit-transition-property: -webkit-transform, opacity;
+  -moz-transition-property: -moz-transform;
+  -o-transition-property: -o-transform;
+  -ms-transition-property: -ms-transform;
+  transition-property: transform;
+}
+.tooltipster-swing-show {
+  opacity: 1;
+  -webkit-transform: rotateZ(0deg);
+  -moz-transform: rotateZ(0deg);
+  -o-transform: rotateZ(0deg);
+  -ms-transform: rotateZ(0deg);
+  transform: rotateZ(0deg);
+  -webkit-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4); 
+  -moz-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4); 
+  -ms-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4); 
+  -o-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4); 
+  transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4);
+}
+
+.tooltipster-fall {
+  top: 0;
+  -webkit-transition-property: top;
+  -moz-transition-property: top;
+  -o-transition-property: top;
+  -ms-transition-property: top;
+  transition-property: top;
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+}
+.tooltipster-fall-show {
+}
+.tooltipster-fall.tooltipster-dying {
+  -webkit-transition-property: all;
+  -moz-transition-property: all;
+  -o-transition-property: all;
+  -ms-transition-property: all;
+  transition-property: all;
+  top: 0px !important;
+  opacity: 0;
+}
+
+.tooltipster-slide {
+  left: -40px;
+  -webkit-transition-property: left;
+  -moz-transition-property: left;
+  -o-transition-property: left;
+  -ms-transition-property: left;
+  transition-property: left;
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  -o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+  transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15);
+}
+.tooltipster-slide.tooltipster-slide-show {
+}
+.tooltipster-slide.tooltipster-dying {
+  -webkit-transition-property: all;
+  -moz-transition-property: all;
+  -o-transition-property: all;
+  -ms-transition-property: all;
+  transition-property: all;
+  left: 0px !important;
+  opacity: 0;
+}
+
+
+/* CSS transition for when contenting is changing in a tooltip that is still open. The only properties that will NOT transition are: width, height, top, and left */
+.tooltipster-content-changing {
+  opacity: 0.5;
+  -webkit-transform: scale(1.1, 1.1);
+  -moz-transform: scale(1.1, 1.1);
+  -o-transform: scale(1.1, 1.1);
+  -ms-transform: scale(1.1, 1.1);
+  transform: scale(1.1, 1.1);
 }

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -273,39 +273,29 @@ svg .axis .label {
   position: relative;
 }
 
-.tooltip::after {
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.8);
-  border-radius: 5px;
-  bottom: 26px;
-  color: #fff;
-  content: attr(title);
-  left: 20%;
-  opacity: 0;
-  padding: 5px 15px;
-  position: absolute;
-  transition: opacity 0.25s ease-in-out 0s;
-  width: 220px;
-  z-index: 98;
-}
-
-.tooltip:hover::after {
-  opacity: 1;
-}
-
-.tooltip:hover::before {
-  -moz-border-bottom-colors: none;
-  -moz-border-left-colors: none;
-  -moz-border-right-colors: none;
-  -moz-border-top-colors: none;
+.tooltip:hover:before {
+  border: solid;
   border-color: #333 transparent;
-  border-image: none;
-  border-style: solid;
-  border-width: 6px 6px 0;
+  border-width: 6px 6px 0 6px;
   bottom: 20px;
   content: "";
   left: 50%;
   position: absolute;
   z-index: 99;
+}
+
+.tooltip:hover:after {
+  background: #333;
+  background: rgba(0,0,0,.8);
+  border-radius: 5px;
+  bottom: 26px;
+  color: #fff;
+  content: attr(aria-label);
+  left: 20%;
+  padding: 5px 15px;
+  position: absolute;
+  z-index: 98;
+  width: 220px;
 }
 
 

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -290,20 +290,73 @@ svg .axis .label {
   z-index: 99;
 }
 
-.tooltip:hover:after {
-  background: #333;
-  background: rgba(0,0,0,.8);
+.tooltip:hover::after {
+  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.8);
   border-radius: 5px;
   bottom: 26px;
   color: #fff;
   content: attr(aria-label);
-  left: 20%;
-  padding: 5px 15px;
+  left: 0;
+  padding: 3px 15px;
   position: absolute;
+  text-align: center;
+  width: auto;
   z-index: 98;
-  width: 220px;
 }
 
+/* tooltips test 2 */
+
+.tooltips {
+  position: relative;
+  display: inline;
+}
+.tooltips span {
+  position: absolute;
+  width:140px;
+  color: #FFFFFF;
+  background: #000000;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
+  visibility: hidden;
+  border-radius: 6px;
+}
+.tooltips span:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -8px;
+  width: 0; height: 0;
+  border-top: 8px solid #000000;
+  border-right: 8px solid transparent;
+  border-left: 8px solid transparent;
+}
+th:hover.tooltips span {
+  visibility: visible;
+  opacity: 0.8;
+  bottom: 30px;
+  left: 50%;
+  margin-left: -76px;
+  z-index: 999;
+}
+
+/* tooltips test 3 */
+
+.drag-hint {
+  position:relative;
+}
+.drag-hint > span{
+  display:none;
+}
+.drag-hint:hover > span {
+  display: inline;
+  position:absolute;
+  top: -25px;
+  left: 0;
+  right: 0;
+  text-align: center;
+}
 
 /**
  * IE tweaks!

--- a/hourglass_site/static/hourglass_site/style/tooltipster.css
+++ b/hourglass_site/static/hourglass_site/style/tooltipster.css
@@ -1,0 +1,274 @@
+/* This is the default Tooltipster theme (feel free to modify or duplicate and create multiple themes!): */
+.tooltipster-default {
+	border-radius: 5px; 
+	border: 2px solid #000;
+	background: #4c4c4c;
+	color: #fff;
+}
+
+/* Use this next selector to style things like font-size and line-height: */
+.tooltipster-default .tooltipster-content {
+	font-family: Arial, sans-serif;
+	font-size: 14px;
+	line-height: 16px;
+	padding: 8px 10px;
+	overflow: hidden;
+}
+
+/* This next selector defines the color of the border on the outside of the arrow. This will automatically match the color and size of the border set on the main tooltip styles. Set display: none; if you would like a border around the tooltip but no border around the arrow */
+.tooltipster-default .tooltipster-arrow .tooltipster-arrow-border {
+	/* border-color: ... !important; */
+}
+
+
+/* If you're using the icon option, use this next selector to style them */
+.tooltipster-icon {
+	cursor: help;
+	margin-left: 4px;
+}
+
+
+
+
+
+
+
+
+/* This is the base styling required to make all Tooltipsters work */
+.tooltipster-base {
+	padding: 0;
+	font-size: 0;
+	line-height: 0;
+	position: absolute;
+	left: 0;
+	top: 0;
+	z-index: 9999999;
+	pointer-events: none;
+	width: auto;
+	overflow: visible;
+}
+.tooltipster-base .tooltipster-content {
+	overflow: hidden;
+}
+
+
+/* These next classes handle the styles for the little arrow attached to the tooltip. By default, the arrow will inherit the same colors and border as what is set on the main tooltip itself. */
+.tooltipster-arrow {
+	display: block;
+	text-align: center;
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: -1;
+}
+.tooltipster-arrow span, .tooltipster-arrow-border {
+	display: block;
+	width: 0; 
+	height: 0;
+	position: absolute;
+}
+.tooltipster-arrow-top span, .tooltipster-arrow-top-right span, .tooltipster-arrow-top-left span {
+	border-left: 8px solid transparent !important;
+	border-right: 8px solid transparent !important;
+	border-top: 8px solid;
+	bottom: -7px;
+}
+.tooltipster-arrow-top .tooltipster-arrow-border, .tooltipster-arrow-top-right .tooltipster-arrow-border, .tooltipster-arrow-top-left .tooltipster-arrow-border {
+	border-left: 9px solid transparent !important;
+	border-right: 9px solid transparent !important;
+	border-top: 9px solid;
+	bottom: -7px;
+}
+
+.tooltipster-arrow-bottom span, .tooltipster-arrow-bottom-right span, .tooltipster-arrow-bottom-left span {
+	border-left: 8px solid transparent !important;
+	border-right: 8px solid transparent !important;
+	border-bottom: 8px solid;
+	top: -7px;
+}
+.tooltipster-arrow-bottom .tooltipster-arrow-border, .tooltipster-arrow-bottom-right .tooltipster-arrow-border, .tooltipster-arrow-bottom-left .tooltipster-arrow-border {
+	border-left: 9px solid transparent !important;
+	border-right: 9px solid transparent !important;
+	border-bottom: 9px solid;
+	top: -7px;
+}
+.tooltipster-arrow-top span, .tooltipster-arrow-top .tooltipster-arrow-border, .tooltipster-arrow-bottom span, .tooltipster-arrow-bottom .tooltipster-arrow-border {
+	left: 0;
+	right: 0;
+	margin: 0 auto;
+}
+.tooltipster-arrow-top-left span, .tooltipster-arrow-bottom-left span {
+	left: 6px;
+}
+.tooltipster-arrow-top-left .tooltipster-arrow-border, .tooltipster-arrow-bottom-left .tooltipster-arrow-border {
+	left: 5px;
+}
+.tooltipster-arrow-top-right span,  .tooltipster-arrow-bottom-right span {
+	right: 6px;
+}
+.tooltipster-arrow-top-right .tooltipster-arrow-border, .tooltipster-arrow-bottom-right .tooltipster-arrow-border {
+	right: 5px;
+}
+.tooltipster-arrow-left span, .tooltipster-arrow-left .tooltipster-arrow-border {
+	border-top: 8px solid transparent !important;
+	border-bottom: 8px solid transparent !important; 
+	border-left: 8px solid;
+	top: 50%;
+	margin-top: -7px;
+	right: -7px;
+}
+.tooltipster-arrow-left .tooltipster-arrow-border {
+	border-top: 9px solid transparent !important;
+	border-bottom: 9px solid transparent !important; 
+	border-left: 9px solid;
+	margin-top: -8px;
+}
+.tooltipster-arrow-right span, .tooltipster-arrow-right .tooltipster-arrow-border {
+	border-top: 8px solid transparent !important;
+	border-bottom: 8px solid transparent !important; 
+	border-right: 8px solid;
+	top: 50%;
+	margin-top: -7px;
+	left: -7px;
+}
+.tooltipster-arrow-right .tooltipster-arrow-border {
+	border-top: 9px solid transparent !important;
+	border-bottom: 9px solid transparent !important; 
+	border-right: 9px solid;
+	margin-top: -8px;
+}
+
+
+/* Some CSS magic for the awesome animations - feel free to make your own custom animations and reference it in your Tooltipster settings! */
+
+.tooltipster-fade {
+	opacity: 0;
+	-webkit-transition-property: opacity;
+	-moz-transition-property: opacity;
+	-o-transition-property: opacity;
+	-ms-transition-property: opacity;
+	transition-property: opacity;
+}
+.tooltipster-fade-show {
+	opacity: 1;
+}
+
+.tooltipster-grow {
+	-webkit-transform: scale(0,0);
+	-moz-transform: scale(0,0);
+	-o-transform: scale(0,0);
+	-ms-transform: scale(0,0);
+	transform: scale(0,0);
+	-webkit-transition-property: -webkit-transform;
+	-moz-transition-property: -moz-transform;
+	-o-transition-property: -o-transform;
+	-ms-transition-property: -ms-transform;
+	transition-property: transform;
+	-webkit-backface-visibility: hidden;
+}
+.tooltipster-grow-show {
+	-webkit-transform: scale(1,1);
+	-moz-transform: scale(1,1);
+	-o-transform: scale(1,1);
+	-ms-transform: scale(1,1);
+	transform: scale(1,1);
+	-webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1);
+	-webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15);
+}
+
+.tooltipster-swing {
+	opacity: 0;
+	-webkit-transform: rotateZ(4deg);
+	-moz-transform: rotateZ(4deg);
+	-o-transform: rotateZ(4deg);
+	-ms-transform: rotateZ(4deg);
+	transform: rotateZ(4deg);
+	-webkit-transition-property: -webkit-transform, opacity;
+	-moz-transition-property: -moz-transform;
+	-o-transition-property: -o-transform;
+	-ms-transition-property: -ms-transform;
+	transition-property: transform;
+}
+.tooltipster-swing-show {
+	opacity: 1;
+	-webkit-transform: rotateZ(0deg);
+	-moz-transform: rotateZ(0deg);
+	-o-transform: rotateZ(0deg);
+	-ms-transform: rotateZ(0deg);
+	transform: rotateZ(0deg);
+	-webkit-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 1);
+	-webkit-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4); 
+	-moz-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4); 
+	-ms-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4); 
+	-o-transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4); 
+	transition-timing-function: cubic-bezier(0.230, 0.635, 0.495, 2.4);
+}
+
+.tooltipster-fall {
+	top: 0;
+	-webkit-transition-property: top;
+	-moz-transition-property: top;
+	-o-transition-property: top;
+	-ms-transition-property: top;
+	transition-property: top;
+	-webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1);
+	-webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+}
+.tooltipster-fall-show {
+}
+.tooltipster-fall.tooltipster-dying {
+	-webkit-transition-property: all;
+	-moz-transition-property: all;
+	-o-transition-property: all;
+	-ms-transition-property: all;
+	transition-property: all;
+	top: 0px !important;
+	opacity: 0;
+}
+
+.tooltipster-slide {
+	left: -40px;
+	-webkit-transition-property: left;
+	-moz-transition-property: left;
+	-o-transition-property: left;
+	-ms-transition-property: left;
+	transition-property: left;
+	-webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1);
+	-webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	-o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15); 
+	transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.15);
+}
+.tooltipster-slide.tooltipster-slide-show {
+}
+.tooltipster-slide.tooltipster-dying {
+	-webkit-transition-property: all;
+	-moz-transition-property: all;
+	-o-transition-property: all;
+	-ms-transition-property: all;
+	transition-property: all;
+	left: 0px !important;
+	opacity: 0;
+}
+
+
+/* CSS transition for when contenting is changing in a tooltip that is still open. The only properties that will NOT transition are: width, height, top, and left */
+.tooltipster-content-changing {
+	opacity: 0.5;
+	-webkit-transform: scale(1.1, 1.1);
+	-moz-transform: scale(1.1, 1.1);
+	-o-transform: scale(1.1, 1.1);
+	-ms-transform: scale(1.1, 1.1);
+	transform: scale(1.1, 1.1);
+}

--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -20,6 +20,7 @@
     <script src="{% static 'hourglass_site/js/vendor/jquery.xdomainrequest.min.js' %}"></script>
     <script src="{% static 'hourglass_site/js/vendor/formdb.min.js' %}"></script>
     <script src="{% static 'hourglass_site/js/hourglass.js' %}"></script>
+    <script src="{% static 'hourglass_site/js/vendor/jquery.tooltipster.js' %}"></script>
     <![endif]>
     <link href='https://fonts.googleapis.com/css?family=Lato:300,400,700,400italic,700italic' rel='stylesheet' type='text/css'>
     {% block head %}

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -173,7 +173,7 @@ form {
           <thead>
             <tr>
               <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params" href="?exclude="></a></th>
-              <th scope="col" class="sortable" data-key="labor_category">Labor Category</th>
+              <th scope="col" class="sortable" aria-label="Labor Category" data-key="labor_category">Labor Category</th>
               <th scope="col" class="sortable" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
               <th scope="col" class="sortable" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
               <th scope="col" class="sortable" data-key="current_price" data-format="$%,.02f">Price</th>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -172,7 +172,7 @@ form {
         <table id="results-table" class="results has-data">
           <thead>
             <tr>
-              <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params tooltip" href="?exclude="></a></th>
+              <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params" href="?exclude="></a></th>
               <th scope="col" class="sortable" data-key="labor_category">Labor Category</th>
               <th scope="col" class="sortable" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
               <th scope="col" class="sortable" data-key="min_years_experience" title="Minimum years of experience">Experience</th>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -173,13 +173,13 @@ form {
           <thead>
             <tr>
               <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params" href="?exclude="></a></th>
-              <th scope="col" class="sortable tooltips/" aria-label="Labor Category" data-key="labor_category">Labor Category</th>
+              <th scope="col" class="sortable tooltip" aria-label="Labor Category" data-key="labor_category">Labor Category</th>
               <th scope="col" class="sortable tooltip" aria-label="Min Edu"  data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
-              <th scope="col" class="sortable drag-hint" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
-              <th scope="col" class="sortable" data-key="current_price" data-format="$%,.02f">Price</th>
+              <th scope="col" class="sortable tooltip" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
+              <th scope="col" class="sortable tooltip" data-key="current_price" data-format="$%,.02f">Price</th>
               <th scope="col" data-key="idv_piid">Contract #</th>
-              <th scope="col" class="sortable" data-key="vendor_name">Vendor</th>
-              <th scope="col" class="sortable collapsible" data-key="schedule">Schedule</th>
+              <th scope="col" class="sortable tooltip" data-key="vendor_name">Vendor</th>
+              <th scope="col" class="sortable collapsible tooltip" data-key="schedule">Schedule</th>
             </tr>
           </thead>
           <tbody>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -173,8 +173,8 @@ form {
           <thead>
             <tr>
               <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params" href="?exclude="></a></th>
-              <th scope="col" class="sortable tooltip" aria-label="Labor Category" data-key="labor_category">Labor Category</th>
-              <th scope="col" class="sortable tooltip" aria-label="Min Edu"  data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
+              <th scope="col" class="sortable tooltip" data-key="labor_category">Labor Category</th>
+              <th scope="col" class="sortable tooltip" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
               <th scope="col" class="sortable tooltip" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
               <th scope="col" class="sortable tooltip" data-key="current_price" data-format="$%,.02f">Price</th>
               <th scope="col" data-key="idv_piid">Contract #</th>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -172,7 +172,7 @@ form {
         <table id="results-table" class="results has-data">
           <thead>
             <tr>
-              <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params" href="?exclude="></a></th>
+              <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params tooltip" href="?exclude="></a></th>
               <th scope="col" class="sortable" data-key="labor_category">Labor Category</th>
               <th scope="col" class="sortable" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
               <th scope="col" class="sortable" data-key="min_years_experience" title="Minimum years of experience">Experience</th>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -173,9 +173,9 @@ form {
           <thead>
             <tr>
               <th scope="col" class="exclude" data-key="exclude" data-format=""><a id="restore-excluded" class="restore merge-params" href="?exclude="></a></th>
-              <th scope="col" class="sortable" aria-label="Labor Category" data-key="labor_category">Labor Category</th>
-              <th scope="col" class="sortable" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
-              <th scope="col" class="sortable" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
+              <th scope="col" class="sortable tooltips/" aria-label="Labor Category" data-key="labor_category">Labor Category</th>
+              <th scope="col" class="sortable tooltip" aria-label="Min Edu"  data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
+              <th scope="col" class="sortable drag-hint" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
               <th scope="col" class="sortable" data-key="current_price" data-format="$%,.02f">Price</th>
               <th scope="col" data-key="idv_piid">Contract #</th>
               <th scope="col" class="sortable" data-key="vendor_name">Vendor</th>

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -344,7 +344,8 @@ class FunctionalTests(LiveServerTestCase):
 
         self.assertFalse(has_class(col_header, 'collapsed'))
 
-    def test_hide_schedule_column(self):
+    # functionality temporarily deactivated
+    def xtest_hide_schedule_column(self):
         get_contract_recipe().make(_quantity=5)
         driver = self.load()
         col_header = find_column_header(driver, 'schedule')


### PR DESCRIPTION
WIP :warning: :construction: 

This uses [tooltipster.js](http://iamceege.github.io/tooltipster/) to display tooltips on table headers and exclude rows. This displays the dynamic content on `aria-label` (was previously `title`) for greater accessibility.

Thanks to @theresaanna and @shawnbot!

Table headers:
![screen shot 2015-05-20 at 3 15 25 pm](https://cloud.githubusercontent.com/assets/5249443/7737910/f6abbb40-ff03-11e4-995f-692a46d6ae95.png)

Exclude results:
![screen shot 2015-05-20 at 3 15 52 pm](https://cloud.githubusercontent.com/assets/5249443/7737911/f9beacb6-ff03-11e4-8080-0f886b413308.png)

## Bug :bug: 
There is a bug where bc the “Hide Schedule” button is structured inside a table header, the tooltip is firing on hover, even though it is visually outside of it. One idea is to move the hide button outside of the table header.

![screen shot 2015-05-20 at 3 45 50 pm](https://cloud.githubusercontent.com/assets/5249443/7738398/a63d04e8-ff08-11e4-9499-858e0d02e0ce.png)
