### PR TITLE
Reverse sort arrows

### DIFF
--- a/hourglass_site/static/hourglass_site/style/tables.css
+++ b/hourglass_site/static/hourglass_site/style/tables.css
@@ -87,12 +87,12 @@ th.sortable {
   }
 
   th.sorted:after {
-    content: "▼";
+    content: "▲";
     font-size: 1em;
   }
 
   th.sorted.descending:after {
-    content: "▲";
+    content: "▼";
   }
 
 th.collapsible {


### PR DESCRIPTION
Looks like the sort arrows are reserved. This sets them so that pointing down is descending and pointing up is ascending.

**Old**
![screen shot 2015-05-29 at 12 10 37 pm](https://cloud.githubusercontent.com/assets/170641/7886990/d8c709b4-05fb-11e5-89f2-d3ec141fa37c.png)

**New**
![screen shot 2015-05-29 at 12 11 08 pm](https://cloud.githubusercontent.com/assets/170641/7886996/e490e63e-05fb-11e5-9973-3aa1f2a6920f.png)
