### PR TITLE
Clarify price

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -423,7 +423,7 @@
       .attr('class', 'label')
       .attr('transform', 'translate(' + [left + (right - left) / 2, 45] + ')')
       .attr('text-anchor', 'middle')
-      .text('Price (hourly rate)')
+      .text('Ceiling price (hourly rate)')
 
     var yd = d3.extent(heightScale.domain());
     var ya = d3.svg.axis()

--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -51,7 +51,7 @@
 
       <div class="row">
         <div class="twelve columns">
-          <h1 class="description-main">Search awarded hourly rates for labor categories</h1>
+          <h1 class="description-main">Search awarded ceiling rates for labor categories</h1>
           <h2 class="description-secondary">CALC lets you conduct market research on professional service labor categories more quickly and easily. It also takes the guesswork out of cost estimations — all results shown are <i>actual</i> awarded hourly rates from GSA service schedules — helping you make more informed decisions. </h2>
         </div>
       </div>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -218,7 +218,7 @@
               <th scope="col" class="sortable tooltip" data-key="labor_category">Labor Category</th>
               <th scope="col" class="sortable tooltip" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
               <th scope="col" class="sortable tooltip" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
-              <th scope="col" class="sortable tooltip" data-key="current_price" data-format="$%,.02f">Price</th>
+              <th scope="col" class="sortable tooltip" data-key="current_price" title="Ceiling price" data-format="$%,.02f">Price</th>
               <th scope="col" data-key="idv_piid">Contract #</th>
               <th scope="col" class="sortable tooltip" data-key="vendor_name">Vendor</th>
               <th scope="col" class="sortable collapsible tooltip" data-key="schedule">Schedule</th>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -218,7 +218,7 @@
               <th scope="col" class="sortable tooltip" data-key="labor_category">Labor Category</th>
               <th scope="col" class="sortable tooltip" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
               <th scope="col" class="sortable tooltip" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
-              <th scope="col" class="sortable tooltip" data-key="current_price" data-format="$%,.02f">Price</th>
+              <th scope="col" class="sortable tooltip" data-key="current_price" data-format="$%,.02f">Ceiling Price</th>
               <th scope="col" data-key="idv_piid">Contract #</th>
               <th scope="col" class="sortable tooltip" data-key="vendor_name">Vendor</th>
               <th scope="col" class="sortable collapsible tooltip" data-key="schedule">Schedule</th>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -218,7 +218,7 @@
               <th scope="col" class="sortable tooltip" data-key="labor_category">Labor Category</th>
               <th scope="col" class="sortable tooltip" data-key="education_level" title="Minimum years of education">Min&nbsp;Edu.</th>
               <th scope="col" class="sortable tooltip" data-key="min_years_experience" title="Minimum years of experience">Experience</th>
-              <th scope="col" class="sortable tooltip" data-key="current_price" data-format="$%,.02f">Ceiling Price</th>
+              <th scope="col" class="sortable tooltip" data-key="current_price" data-format="$%,.02f">Price</th>
               <th scope="col" data-key="idv_piid">Contract #</th>
               <th scope="col" class="sortable tooltip" data-key="vendor_name">Vendor</th>
               <th scope="col" class="sortable collapsible tooltip" data-key="schedule">Schedule</th>


### PR DESCRIPTION
This adds "ceiling" before "price" in the text in the **main header**, **histogram x-axis**, and **results table**. This accomplishes the first two tasks in trello: https://trello.com/c/pHF7rMN0/134-further-clarify-that-the-prices-in-calc-are-ceiling-level-prof-services-schedule-only-worldwide

This is what it looks like:

**main header**:
![ceiling 1](https://cloud.githubusercontent.com/assets/5249443/8050697/9a5d0d12-0e26-11e5-9755-8409de6bab50.png)

**histogram x-axis**:
![ceiling 2](https://cloud.githubusercontent.com/assets/5249443/8050698/9a610354-0e26-11e5-96df-0831c7b8ee7a.png)

**results table**:
![ceiling 3](https://cloud.githubusercontent.com/assets/5249443/8050699/9a62953e-0e26-11e5-84e5-7f5cab3ec983.png)

Note: we'll need to resize columns so that we can fit "ceiling price" on a single line. Otherwise it jumps to two lines.