### PR TITLE
[WIP] Add standard deviation callout

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -15,6 +15,7 @@ class PaginatedContractSerializer(pagination.PaginationSerializer):
     minimum = serializers.SerializerMethodField()
     maximum = serializers.SerializerMethodField()
     wage_histogram = serializers.SerializerMethodField()
+    first_standard_deviation = serializers.SerializerMethodField()
 
     class Meta:
         object_serializer_class = ContractSerializer
@@ -30,3 +31,6 @@ class PaginatedContractSerializer(pagination.PaginationSerializer):
 
     def get_wage_histogram(self, obj):
         return self.context.get('wage_histogram', [])
+
+    def get_first_standard_deviation(self, obj):
+        return self.context.get('first_standard_deviation', 0)

--- a/api/tests.py
+++ b/api/tests.py
@@ -650,6 +650,12 @@ class ContractsTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data['average'], (16.0 + 18.0 + 50.0) / 3)
 
+    def test_first_std_deviation_no_args(self):
+        self.make_test_set()
+        resp = self.c.get(self.path, {})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(int(resp.data['first_standard_deviation']), 15)
+
     def test_histogram_length(self):
         self.make_test_set()
         resp = self.c.get(self.path, {'histogram': 5})

--- a/api/views.py
+++ b/api/views.py
@@ -165,15 +165,15 @@ class GetRates(APIView):
         contracts = paginator.page(page)
         
         page_stats = {}
-        current_prices = []
+        current_rates = []
 
         page_stats['minimum'] = contracts_all.aggregate(Min(wage_field))[wage_field + '__min']
         page_stats['maximum'] = contracts_all.aggregate(Max(wage_field))[wage_field + '__max']
         page_stats['average'] = quantize(contracts_all.aggregate(Avg(wage_field))[wage_field + '__avg'])
-        for v in contracts_all.values(wage_field):
-            current_prices.append(v[wage_field])
-        page_stats['first_standard_deviation'] = np.std(current_prices)
-        print(page_stats['first_standard_deviation'])
+
+        for rate in contracts_all.values(wage_field):
+            current_rates.append(rate[wage_field])
+        page_stats['first_standard_deviation'] = np.std(current_rates)
 
         #use paginator count method
         if paginator.count > 0:

--- a/api/views.py
+++ b/api/views.py
@@ -165,10 +165,15 @@ class GetRates(APIView):
         contracts = paginator.page(page)
         
         page_stats = {}
+        current_prices = []
 
         page_stats['minimum'] = contracts_all.aggregate(Min(wage_field))[wage_field + '__min']
         page_stats['maximum'] = contracts_all.aggregate(Max(wage_field))[wage_field + '__max']
         page_stats['average'] = quantize(contracts_all.aggregate(Avg(wage_field))[wage_field + '__avg'])
+        for v in contracts_all.values(wage_field):
+            current_prices.append(v[wage_field])
+        page_stats['first_standard_deviation'] = np.std(current_prices)
+        print(page_stats['first_standard_deviation'])
 
         #use paginator count method
         if paginator.count > 0:

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -299,9 +299,12 @@
 
     d3.select("#avg-price-highlight")
       .text(formatDollars(data.average));
-console.log(data.first_standard_deviation);
-    d3.select("#standard-deviation-highlight")
-      .text(formatDollars(data.first_standard_deviation));
+
+    d3.select("#standard-deviation-minus-highlight")
+      .text(formatDollars(data.average - data.first_standard_deviation));
+
+    d3.select("#standard-deviation-plus-highlight")
+      .text(formatDollars(data.average + data.first_standard_deviation));
 
     var xAxis = svg.select(".axis.x");
     if (xAxis.empty()) {

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -299,6 +299,9 @@
 
     d3.select("#avg-price-highlight")
       .text(formatDollars(data.average));
+console.log(data.first_standard_deviation);
+    d3.select("#standard-deviation-highlight")
+      .text(formatDollars(data.first_standard_deviation));
 
     var xAxis = svg.select(".axis.x");
     if (xAxis.empty()) {

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -119,7 +119,8 @@ span.dollars {
   text-align: center;
 }
 
-.avg-price-block {
+.avg-price-block,
+.standard-deviation-block {
   background: #f3f3f3;
   border-radius: 4px;
   display: inline-block;
@@ -128,7 +129,8 @@ span.dollars {
   text-align: center;
 }
 
-#avg-price-highlight {
+#avg-price-highlight,
+.sd-highlight {
   color: #17779f;
   font-weight: 400;
 }

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -199,6 +199,11 @@
               <h5 class="avg-price-title">Average Price</h5>
               <h5 id="avg-price-highlight"></h5>
             </div> 
+            <div class="standard-deviation-block four columns">
+              <h5 class="standard-deviation-title">Standard Deviation</h5>
+              <h5 id="standard-deviation-highlight"></h5>
+            </div> 
+
             <div class="four columns">
               <a id="download-histogram" class="button button-primary" href="#">⬇ Download graph</a>
             </div>

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -192,16 +192,18 @@
           </div>
 
           <div class="highlights-container row">
-            <div class="four columns">
-              <p>&nbsp</p>
+            <div class="standard-deviation-block three columns">
+              <h5 class="standard-deviation-title">Std Deviation -1</h5>
+              <h5 id="standard-deviation-minus-highlight" class="sd-highlight"></h5>
+
             </div>            
-            <div class="avg-price-block four columns">
+            <div class="avg-price-block three columns">
               <h5 class="avg-price-title">Average Price</h5>
               <h5 id="avg-price-highlight"></h5>
             </div> 
-            <div class="standard-deviation-block four columns">
-              <h5 class="standard-deviation-title">Standard Deviation</h5>
-              <h5 id="standard-deviation-highlight"></h5>
+            <div class="standard-deviation-block three columns">
+              <h5 class="standard-deviation-title">Std Deviation +1</h5>
+              <h5 id="standard-deviation-plus-highlight" class="sd-highlight"></h5>
             </div> 
 
             <div class="four columns">


### PR DESCRIPTION
This adds a standard deviation callout below the graph. It also moves the two download buttons together below the callout. This does work around: https://github.com/18F/calc/issues/176.

Here is what it looks like:
![screen shot 2015-06-17 at 10 52 32 pm](https://cloud.githubusercontent.com/assets/5249443/8224985/f2fd7294-1543-11e5-93d1-78faf13983ed.png)

Great work on the functionality by @theresaanna!