### PR TITLE
Run Django migrations and load_data script when pushing to Cloud Foundry

### DIFF
--- a/cf.sh
+++ b/cf.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "------ Starting APP ------"
+if [ $CF_INSTANCE_INDEX = "0" ]; then
+    echo "----- Migrating Database -----"
+    python manage.py migrate --noinput
+    echo "----- Loading Labor Category Data -----"
+    python manage.py load_data
+fi
+newrelic-admin run-program waitress-serve --port=$VCAP_APP_PORT hourglass.wsgi:application

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,7 @@ applications:
   host: calc-dev
   buildpack: https://github.com/cloudfoundry/python-buildpack.git
   memory: 256M
+  command: bash cf.sh
 
 - name: calc-prod
 # commenting these out so an accidental straight deploy to calc.gsa.gov doesn't happen

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ whitenoise==1.0.6
 dj-database-url==0.3.0
 Django==1.7.6
 djangorestframework==3.0.2
--e git+https://github.com/theresaanna/djorm-ext-pgfulltext.git#egg=djorm_ext_pgfulltext-master
+-e git+https://github.com/djangonauts/djorm-ext-pgfulltext.git@0.9.3#egg=djorm_ext_pgfulltext-master
 psycopg2==2.5.4
 selenium
 model_mommy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ whitenoise==1.0.6
 dj-database-url==0.3.0
 Django==1.7.6
 djangorestframework==3.0.2
--e git+https://github.com/djangonauts/djorm-ext-pgfulltext.git#egg=djorm_ext_pgfulltext-master
+-e git+https://github.com/theresaanna/djorm-ext-pgfulltext.git#egg=djorm_ext_pgfulltext-master
 psycopg2==2.5.4
 selenium
 model_mommy


### PR DESCRIPTION
Also locks us to a known working version of pgfulltext as there are issues with the newest version. First, the issue described here: https://github.com/linuxlewis/djorm-ext-pgfulltext/pull/59 and, per Ozzy, it sounds like theres some encoding change between 0.9.3 and 0.9.4 that he ran into while helping me with the migration + Cloud Foundry work.