### PR TITLE
Add icon attribution

### DIFF
--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -94,6 +94,8 @@
                 <li><a href="https://github.com/18F/calc"><img alt="GitHub Logo" src="https://mirage-gsa-gov.s3.amazonaws.com:443/mirage_site/images/github_icon.png"> View our code on GitHub</a></li>
                 <!-- <li><a href="/docs/">Read the API documentation</a></li> -->
               </ul>
+
+              <p>Icons by Paulo Sá Ferreira, Luis Prado, John Testa, Andrew Forrester from <a href="https://thenounproject.com/">The Noun Project</a>.</p>
             </div><!-- /.footer_nav -->
           </div>
 


### PR DESCRIPTION
This adds attribution for the icons used in the header area. Attribution is added in the footer.

This is what it looks like: 

![screen shot 2015-06-23 at 9 12 47 am](https://cloud.githubusercontent.com/assets/5249443/8311032/69140612-1988-11e5-9687-04915b1891ad.png)
