### PR TITLE
Strip non-alpha numeric or whitespace chars out of search query

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -63,6 +63,13 @@ class ContractsTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data['results'], [])
 
+    def test_search_results_with_nonalphanumeric(self):
+        # the search should be able to handle queries with non-alphanumeric chars without erroring
+        self.make_test_set()
+        resp = self.c.get(self.path, {'q': 'category (ABC)"^$#@!&*'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['results'], [])
+
     def test_filter_by_price__exact(self):
         self.make_test_set()
         resp = self.c.get(self.path, {'price': 18})

--- a/api/views.py
+++ b/api/views.py
@@ -13,11 +13,14 @@ from contracts.models import Contract, EDUCATION_CHOICES
 
 import numpy as np
 import sys
+import re
 
 import csv
 
 def convert_to_tsquery(query):
     """ converts multi-word phrases into AND boolean queries for postgresql """
+    pattern = re.compile('[^a-zA-Z\s]')
+    query = pattern.sub('', query)
     tsquery = query.strip() + ':*'
     tsquery = tsquery.replace(' ', ' & ')
 


### PR DESCRIPTION
This morning, in production, we had an issue where requests were timing out. After consulting New Relic, it looks like the app errored when a user submitted a couple search terms that included parentheses. 

This pull requests makes it so that, when users search using the default setting, "Contains words", non-query-friendly characters are stripped out of the query, leaving just alphanumeric characters and whitespaces.