### PR TITLE
Rework the method by which raw queries are formatted

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -75,6 +75,7 @@ class ContractsTest(TestCase):
         self.make_test_set()
         resp = self.c.get(self.path, {'q': 'category (ABC)"^$#@!&*'})
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['results'], [])
 
     def test_search_results_with_extra_spaces(self):
         # the search should insert the correct number of ampersands in the right locations

--- a/api/tests.py
+++ b/api/tests.py
@@ -3,6 +3,8 @@ from model_mommy import mommy
 from model_mommy.recipe import seq
 from contracts.models import Contract
 from contracts.mommy_recipes import get_contract_recipe
+from api.views import convert_to_tsquery
+
 from itertools import cycle
 
 class ContractsTest(TestCase):
@@ -16,6 +18,11 @@ class ContractsTest(TestCase):
 
         self.c = Client()
         self.path = '/api/rates/'
+
+    def test_convert_to_tsquery(self):
+        self.assertEqual(convert_to_tsquery('staff  consultant'), 'staff:* & consultant:*')
+        self.assertEqual(convert_to_tsquery('senior typist (st)'), 'senior:* & typist:* & st:*')
+        self.assertEqual(convert_to_tsquery('@$(#)%&**#'), '')
 
     def test_empty_results(self):
         self.make_test_set()
@@ -68,7 +75,12 @@ class ContractsTest(TestCase):
         self.make_test_set()
         resp = self.c.get(self.path, {'q': 'category (ABC)"^$#@!&*'})
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.data['results'], [])
+
+    def test_search_results_with_extra_spaces(self):
+        # the search should insert the correct number of ampersands in the right locations
+        self.make_test_set()
+        resp = self.c.get(self.path, {'q': 'legal  advice '})
+        self.assertEqual(resp.status_code, 200)
 
     def test_filter_by_price__exact(self):
         self.make_test_set()

--- a/api/views.py
+++ b/api/views.py
@@ -22,7 +22,7 @@ def convert_to_tsquery(query):
     # remove all non-alphanumeric or whitespace chars
     pattern = re.compile('[^a-zA-Z\s]')
     query = pattern.sub('', query)
-    query_parts = query.split(' ')
+    query_parts = query.split()
     # remove empty strings and add :* to use prefix matching on each chunk
     query_parts = ["%s:*" % s for s in query_parts if s]
     tsquery = ' & '.join(query_parts)

--- a/api/views.py
+++ b/api/views.py
@@ -21,8 +21,10 @@ def convert_to_tsquery(query):
     """ converts multi-word phrases into AND boolean queries for postgresql """
     pattern = re.compile('[^a-zA-Z\s]')
     query = pattern.sub('', query)
-    tsquery = query.strip() + ':*'
-    tsquery = tsquery.replace(' ', ' & ')
+    query_parts = query.split(' ')
+    # remove empty strings and add :* to use prefix matching on each chunk
+    query_parts = ["%s:*" % s for s in query_parts if s]
+    tsquery = ' & '.join(query_parts)
 
     return tsquery
 

--- a/api/views.py
+++ b/api/views.py
@@ -19,6 +19,7 @@ import csv
 
 def convert_to_tsquery(query):
     """ converts multi-word phrases into AND boolean queries for postgresql """
+    # remove all non-alphanumeric or whitespace chars
     pattern = re.compile('[^a-zA-Z\s]')
     query = pattern.sub('', query)
     query_parts = query.split(' ')


### PR DESCRIPTION
Looking at the errors users encountered that have been logged in New Relic, I noticed that they all had double spaces in the search term, which caused `convert_to_tsquery` to format queries like `senior & & engineer:*`, which causes errors as it is invalid syntax.

I rewrote `convert_to_tsquery` to address this. I also added prefix matching to each chunk of the query. So, for example, if someone searches "staffing consultant" with default search settings, they now get results for categories like "staff consultant". Previously, only the last term would have prefix matching applied.