### PR TITLE
Fixes stretching and missing label in downloadable graph

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -466,8 +466,7 @@
 
       var ppText = pp.append("text")
         .attr("text-anchor", "middle")
-        .attr("dy", ppOffset - 6);
-      ppText.append("tspan")
+        .attr("dy", ppOffset - 6)
         .attr("class", "value proposed");
       pp.append("line");
     }
@@ -513,8 +512,7 @@
 
       var avgText = avg.append("text")
         .attr("text-anchor", "middle")
-        .attr("dy", avgOffset - 7);
-      avgText.append("tspan")
+        .attr("dy", avgOffset - 7)
         .attr("class", "value average");
       avg.append("line");
     }

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -1132,7 +1132,7 @@
     svg = serializer.serializeToString(svg);
 
     // convert svg into canvas
-    canvg(canvas, svg, {ignoreMouse: true, scaleWidth: 640, scaleHeight: 200});
+    canvg(canvas, svg, {ignoreMouse: true, scaleWidth: 720, scaleHeight: 300});
 
     if (typeof Blob !== 'undefined') {
       canvas.toBlob(function(blob) {


### PR DESCRIPTION
- Removes tspans for both the average and proposed price labels. This makes the average price label show up. For some reason, canvg has problems with tspans. 
- Adjusted the dimensions of the generated canvas so that the final image will be the correct size. This fixes the stretching.