### PR TITLE
Update to accessible grays

### DIFF
--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -306,7 +306,7 @@ input[type="checkbox"]:checked ~ label {
 
 
 .rates-help-text {
-  color: #999;
+  color: #757575;
   clear: both;
 }
 
@@ -378,7 +378,7 @@ td.column-min_years_experience i {
 
 td.column-min_years_experience .years {
   font-style: italic;
-  color: #bbb;
+  color: #757575;
 }
 
 .document-icon {

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -316,3 +316,19 @@ footer {
   width: 85px;
   height: 85px;
 }
+
+::-webkit-input-placeholder {
+   color: #757575;
+}
+
+:-moz-placeholder { /* Firefox 18- */
+   color: #757575;  
+}
+
+::-moz-placeholder {  /* Firefox 19+ */
+   color: #757575;  
+}
+
+:-ms-input-placeholder {  
+   color: #757575;  
+}

--- a/hourglass_site/static/hourglass_site/style/tables.css
+++ b/hourglass_site/static/hourglass_site/style/tables.css
@@ -27,7 +27,7 @@ table caption {
 thead th,
 thead th:first-child {
   vertical-align: bottom;
-  color: #595959;
+  color: #757575;
   border-bottom: 1px solid;
 }
 

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -305,22 +305,22 @@
                 }
 
                 .range-rule {
-                  stroke: #595959;
+                  stroke: #757575;
                   fill: none;
                   stroke-dasharray: 5,5;
                   stroke-width: 1;
                 }
 
                 .label-rule {
-                  stroke: #595959;
+                  stroke: #757575;
                 }
 
                 .stddev-text {
-                  fill: #595959;
+                  fill: #757575;
                 }
 
                 .axis .label {
-                  fill: #595959;
+                  fill: #757575;
                   font-style: italic;
                 }
 
@@ -338,7 +338,7 @@
 
                 .stddev-text-label {
                   font-size: 12px;
-                  fill: #595959;
+                  fill: #757575;
                 }
 
                 .avg .value, .pp .value,


### PR DESCRIPTION
This updates placeholder text and other additional text to a darker gray. This also lightens some gray text used as labels for the histogram and table headers. This follows WCAG AA guidelines.