### PR TITLE
[WIP] Add search help text

### DIFF
--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -305,7 +305,7 @@ input[type="checkbox"]:checked ~ label {
 }
 
 
-.rates-help-text {
+.help-text {
   color: #757575;
   clear: both;
 }

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -308,6 +308,7 @@ input[type="checkbox"]:checked ~ label {
 .help-text {
   color: #757575;
   clear: both;
+  margin-bottom: 1em;
 }
 
 .filter select {

--- a/hourglass_site/static/hourglass_site/style/index.css
+++ b/hourglass_site/static/hourglass_site/style/index.css
@@ -306,8 +306,8 @@ input[type="checkbox"]:checked ~ label {
 
 
 .help-text {
+  clear: both;  
   color: #757575;
-  clear: both;
   margin-bottom: 1em;
 }
 

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -25,7 +25,7 @@
 
   <section class="search">
     <div class="container">
-      <p class="help-text">Separate multiple search terms with a comma.</p>      
+      <p class="help-text">Use a comma between words to search multiple terms. (For example: Engineer, Consultant)</p>      
       <div class="row">
         <div class="six columns">
           <input id="labor_category" name="q" placeholder="Type a labor category" class="search u-full-width" type="text">

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -25,7 +25,7 @@
 
   <section class="search">
     <div class="container">
-      <p class="help-text">Search can include multiple terms. Terms must be separated by a comma.</p>      
+      <p class="help-text">Separate multiple search terms with a comma.</p>      
       <div class="row">
         <div class="six columns">
           <input id="labor_category" name="q" placeholder="Type a labor category" class="search u-full-width" type="text">

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -25,6 +25,7 @@
 
   <section class="search">
     <div class="container">
+      <p>Search can include multiple terms. Terms must be separated by a comma.</p>      
       <div class="row">
         <div class="six columns">
           <input id="labor_category" name="q" placeholder="Type a labor category" class="search u-full-width" type="text">

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -25,7 +25,7 @@
 
   <section class="search">
     <div class="container">
-      <p>Search can include multiple terms. Terms must be separated by a comma.</p>      
+      <p class="help-text">Search can include multiple terms. Terms must be separated by a comma.</p>      
       <div class="row">
         <div class="six columns">
           <input id="labor_category" name="q" placeholder="Type a labor category" class="search u-full-width" type="text">

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -416,7 +416,7 @@
               title="Click to export your search results to an Excel file (CSV)" href="{{ API_HOST }}rates/csv/">⬇ Export Data (CSV)</a>
           </div>
 
-          <p class="rates-help-text">The rates shown here are fully burdened, applicable worldwide, and representative of the current fiscal year. This data represents rates awarded at the master contract level.</p>
+          <p class="help-text">The rates shown here are fully burdened, applicable worldwide, and representative of the current fiscal year. This data represents rates awarded at the master contract level.</p>
 
         </div><!-- /.div -->
 


### PR DESCRIPTION
This adds help text around the search field which lets users know they can enter multiple terms and how to do it: 

Use a comma between words to search multiple terms. (For example: Engineer, Consultant)

This addresses:
https://trello.com/c/en3kpl5i/170-make-it-obvious-that-user-can-search-multiple-terms

This is what it looks like:
![screen shot 2015-07-29 at 1 32 51 pm](https://cloud.githubusercontent.com/assets/5249443/8969117/4049746c-35f6-11e5-9188-73152b349d81.png)

