### PR TITLE
Updates DAP location, tightens GA settings

### DIFF
--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -122,12 +122,20 @@
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
+        // anonymize user IPs (chops off the last IP triplet)
+        ga('set', 'anonymizeIp', true);
+        
+        // forces SSL even if the page were somehow loaded over http://
+        ga('set', 'forceSSL', true);
+  
         ga('create', 'UA-48605964-21', 'auto');
         ga('send', 'pageview');
     </script>
-    <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
+
+    <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->    
+    <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
 
     <![if gt IE 8]>
     <script>


### PR DESCRIPTION
This changes our DAP embed code to:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
```

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.

This PR also tightens up the GA settings to match [18F's standard settings](https://github.com/18F/analytics-standards#18f-snippet-standards-for-website-analytics).