### PR TITLE
Upgrade to Django 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==0.3.0
-Django==1.7.11
+Django==1.8.13
 django-cors-headers==1.1.0
 django-nose==1.4.3
 django-secure==1.0.1


### PR DESCRIPTION
This fixes #279.

However, as mentioned in that issue, there are some `RemovedInDjango19Warning` messages that are logged, which unfortunately aren't very easy to fix because they come from third-party libraries that are either not well-maintained, or whose upgrade paths involve non-trivial changes to our code:

* Our version 3.0.5 of `rest_framework` is using `django.utils.importlib`, which is removed in 1.9. Unfortunately, upgrading it requires dealing with the fact that [`PaginationSerializer` was deprecated in 3.1](http://stackoverflow.com/questions/31500192/django-rest-framework-error-cannot-import-name-paginationserializer/31500287#31500287), which will require refactoring our code.

* During `manage.py load_data`, our version of `djorm_pgfulltext` is using `django.db.models.get_app` and  `django.db.models.get_model`, which are removed in 1.9. Fixing this will require an upstream change to that package (or alternatively, using a different package, or waiting until Django 1.10 is out and switching to its built-in full-text indexing for postgres).

Aside from that, though, the test suite passes and the site still seems to work fine with Django 1.8.  So I recommend just upgrading and filing the above points as separate issues.
