### PR TITLE
Upgrade to Django REST Framework 3.1

### DIFF
--- a/api/pagination.py
+++ b/api/pagination.py
@@ -5,11 +5,10 @@ from django.conf import settings
 
 
 class ContractPagination(pagination.PageNumberPagination):
-    page_size = settings.PAGINATION
-
     def __init__(self, context):
         super().__init__()
         self.context = context
+        self.page_size = settings.PAGINATION
 
     def get_paginated_response(self, data):
         return Response(OrderedDict([

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -1,0 +1,40 @@
+from collections import OrderedDict
+from rest_framework import pagination
+from rest_framework.response import Response
+from django.conf import settings
+
+
+class ContractPagination(pagination.PageNumberPagination):
+    page_size = settings.PAGINATION
+
+    def __init__(self, context):
+        super().__init__()
+        self.context = context
+
+    def get_paginated_response(self, data):
+        return Response(OrderedDict([
+            ('count', self.page.paginator.count),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('average', self.get_average()),
+            ('minimum', self.get_minimum()),
+            ('maximum', self.get_maximum()),
+            ('wage_histogram', self.get_wage_histogram()),
+            ('first_standard_deviation', self.get_first_standard_deviation()),
+            ('results', data)
+        ]))
+
+    def get_average(self):
+        return self.context.get('average', 0)
+
+    def get_minimum(self):
+        return self.context.get('minimum', 0)
+
+    def get_maximum(self):
+        return self.context.get('maximum', 0)
+
+    def get_wage_histogram(self):
+        return self.context.get('wage_histogram', [])
+
+    def get_first_standard_deviation(self):
+        return self.context.get('first_standard_deviation', 0)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,5 +1,6 @@
 from contracts.models import Contract
-from rest_framework import serializers, pagination
+from rest_framework import serializers
+
 
 class ContractSerializer(serializers.ModelSerializer):
 
@@ -8,29 +9,3 @@ class ContractSerializer(serializers.ModelSerializer):
     class Meta:
         model = Contract
         fields = ('id', 'idv_piid', 'vendor_name', 'labor_category', 'education_level', 'min_years_experience', 'hourly_rate_year1', 'current_price', 'next_year_price', 'second_year_price', 'schedule', 'contractor_site', 'business_size')
-
-class PaginatedContractSerializer(pagination.PaginationSerializer):
-
-    average = serializers.SerializerMethodField()
-    minimum = serializers.SerializerMethodField()
-    maximum = serializers.SerializerMethodField()
-    wage_histogram = serializers.SerializerMethodField()
-    first_standard_deviation = serializers.SerializerMethodField()
-
-    class Meta:
-        object_serializer_class = ContractSerializer
-
-    def get_average(self, obj):
-        return self.context.get('average', 0)
-
-    def get_minimum(self, obj):
-        return self.context.get('minimum', 0)
-
-    def get_maximum(self, obj):
-        return self.context.get('maximum', 0)
-
-    def get_wage_histogram(self, obj):
-        return self.context.get('wage_histogram', [])
-
-    def get_first_standard_deviation(self, obj):
-        return self.context.get('first_standard_deviation', 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Django==1.8.13
 django-cors-headers==1.1.0
 django-nose==1.4.3
 django-secure==1.0.1
-djangorestframework==3.0.5
+djangorestframework==3.1.3
 djorm-ext-pgfulltext==0.9.3
 model-mommy==1.2.6
 newrelic==2.66.0.49


### PR DESCRIPTION
This fixes #290 by upgrading us to Django REST Framework 3.1.

Note that the latest version of DRF is 3.3, and I doubt we should run into any major barriers upgrading it all the way there, but I'd rather save it for a separate PR.

As mentioned in #290, upgrading to DRF 3.1 was non-trivial because of its architectural overhaul of pagination.

I believe this PR has feature parity with the existing API, with the following changes:

* On the existing API, submitting an API request for a non-integer page, e.g. `page=blarg`, results in a 500 internal server error.  This PR fixes the bug by delegating all pagination to DRF's `PageNumberPagination`, which returns the following response:

  ```http
HTTP 404 Not Found
Vary: Accept
Content-Type: application/json
Allow: GET, HEAD, OPTIONS

{
    "detail": "Invalid page \"u\": That page number is not an integer."
}
```

* On the existing API, the `next` and `previous` keys in the response are relative URLs, e.g. `?page=2`. In this PR, they are now absolute URLs.

