### PR TITLE
Fix empty price histogram

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -350,6 +350,7 @@
         maximum: .001,
         average: 0,
         count: 0,
+        proposedPrice: 0,
         results: [],
         wage_histogram: [
           {count: 0, min: 0, max: 0}
@@ -390,6 +391,9 @@
 
     var stdDevMin = data.average - data.first_standard_deviation,
         stdDevMax = data.average + data.first_standard_deviation;
+
+    if (isNaN(stdDevMin)) stdDevMin = 0;
+    if (isNaN(stdDevMax)) stdDevMax = 0;
 
     d3.select("#standard-deviation-minus-highlight")
       .text(formatDollars(stdDevMin));


### PR DESCRIPTION
This fixes #244 and #289.

I'm not really sure what I'm doing here, though, as I'm totally unfamiliar with the front-end code. I basically just added the minimum amount of code to ensure that the browser doesn't throw an exception or log any SVG attribute errors.

From an end-user perspective, though, this solution seems nice because one can now enter queries that return no results, and the graph is updated (it previously would remain unchanged due to the JS exception being thrown).  That said, the graph isn't updated to anything *particularly* user-friendly:

![empty-price-histogram](https://cloud.githubusercontent.com/assets/124687/16150432/23a05182-3465-11e6-9bd2-b065336befa4.png)

But hey, it's still better than the graph not updating *at all*, right? :grin: 
