### PR TITLE
Take SECRET_KEY from environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ can just run `python manage.py` directly from outside the container--the
 `manage.py` script has been modified to run itself in a Docker container
 if it detects that Django isn't installed.
 
+## Environment Variables
+
+* `SECRET_KEY` is a large random value corresponding to Django's
+  [`SECRET_KEY`][] setting. It is automatically set to a known, insecure
+  value when `DEBUG` is true.
+
 ## API
 
 If you're interested in the underlying data, please see https://github.com/18F/calc/blob/master/updating_data.md
@@ -239,3 +245,4 @@ for other than small business.
 [Docker]: https://www.docker.com/
 [Docker Compose]: https://docs.docker.com/compose/
 [Docker goes native]: https://blog.docker.com/2016/03/docker-for-mac-windows-beta/
+[`SECRET_KEY`]: https://docs.djangoproject.com/en/1.9/ref/settings/#secret-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ app:
     - DDM_IS_RUNNING_IN_DOCKER=yup
     - PYTHONUNBUFFERED=yup
     - DATABASE_URL=postgres://calc_user@db/calc
+    - SECRET_KEY="I am an insecure secret key intended ONLY for dev/testing."
   command: python manage.py runserver 0.0.0.0:8000
   ports:
     - "8000:8000"

--- a/hourglass/local_settings.example.py
+++ b/hourglass/local_settings.example.py
@@ -9,6 +9,6 @@ DATABASES = {
     }
 }
 
-SECRET_KEY = ''
+SECRET_KEY = 'I am an insecure secret key intended ONLY for dev/testing.'
 
 SECURE_SSL_REDIRECT = False

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -24,9 +24,6 @@ API_HOST = os.environ.get('API_HOST', '/api/')
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'i=-6!=jo-qh3sh!z=uo_2)5wf*_@ogw9eam3e0_53hp4)cp53!'
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
@@ -187,3 +184,6 @@ else:
         from hourglass.local_settings import *
     except ImportError:
         pass
+
+if 'SECRET_KEY' not in globals():
+    SECRET_KEY = os.environ['SECRET_KEY']


### PR DESCRIPTION
This fixes #280.

Note that in production, this will require configuring the cloud.gov environment to set a `SECRET_KEY` environment variable. According to the [documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#env-block) I think this can probably be done with something like:

```
cf set-env SECRET_KEY boop
```

However, depending on how we deploy the app, we might need to somehow ensure that this environment variable is still defined whenever we re-deploy... This could potentially get complicated with a zero-downtime tool like [autopilot](https://github.com/concourse/autopilot), I'm not sure though.
