### PR TITLE
Fix numpy warning.

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -6,7 +6,6 @@ from contracts.mommy_recipes import get_contract_recipe
 from api.views import convert_to_tsquery
 
 from itertools import cycle
-import math
 
 
 RATES_API_PATH = '/api/rates/'
@@ -64,7 +63,7 @@ class ContractsTest(TestCase):
         resp = self.c.get(self.path, {'q': 'nsfr87y3487h3rufbf'})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data['results'], [])
-        self.assertTrue(math.isnan(resp.data['first_standard_deviation']))
+        self.assertEqual(resp.data['first_standard_deviation'], None)
 
     def test_search_results(self):
         self.make_test_set()

--- a/api/tests.py
+++ b/api/tests.py
@@ -6,6 +6,7 @@ from contracts.mommy_recipes import get_contract_recipe
 from api.views import convert_to_tsquery
 
 from itertools import cycle
+import math
 
 
 RATES_API_PATH = '/api/rates/'
@@ -63,6 +64,7 @@ class ContractsTest(TestCase):
         resp = self.c.get(self.path, {'q': 'nsfr87y3487h3rufbf'})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data['results'], [])
+        self.assertTrue(math.isnan(resp.data['first_standard_deviation']))
 
     def test_search_results(self):
         self.make_test_set()

--- a/api/views.py
+++ b/api/views.py
@@ -195,7 +195,7 @@ class GetRates(APIView):
         if current_rates:
             std_dev = np.std(current_rates)
         else:
-            std_dev = float('nan')
+            std_dev = None
 
         page_stats['first_standard_deviation'] = std_dev
 

--- a/api/views.py
+++ b/api/views.py
@@ -191,7 +191,13 @@ class GetRates(APIView):
             # its common for the wage_field to have an empty value
             if rate.get(wage_field):
                 current_rates.append(rate[wage_field])
-        page_stats['first_standard_deviation'] = np.std(current_rates)
+
+        if current_rates:
+            std_dev = np.std(current_rates)
+        else:
+            std_dev = float('nan')
+
+        page_stats['first_standard_deviation'] = std_dev
 
         if bins and bins.isnumeric():
             # numpy wants these to be floats, not Decimals


### PR DESCRIPTION
This fixes #250.

Note that it ~~preserves~~ changes the current behavior of the API, which *seems* to be non-standard, as `first_standard_deviation` is set to `NaN` when there are empty results--yet [the JSON specification claims `NaN` should be specified as `null`](http://stackoverflow.com/q/1423081).

But indeed, querying an empty result set from the API yields a `"first_standard_deviation": NaN`, and piping the response through `python -m json.tool` works fine, which makes me wonder if maybe it was added to the standard at some point... yet in JS, `JSON.parse('{"boop": NaN}')` raises a syntax error, so perhaps we're actually outputting illegal JSON in our API!
