### PR TITLE
[DO NOT MERGE] Non-functional selenium server integration.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,34 @@
-app:
-  build: .
-  volumes:
-    - .:/calc
-  links:
-    - db
-  working_dir: /calc
-  entrypoint: python /calc/docker_django_management.py
-  environment:
-    - DDM_HOST_USER=calc_user
-    - DDM_IS_RUNNING_IN_DOCKER=yup
-    - PYTHONUNBUFFERED=yup
-    - DATABASE_URL=postgres://calc_user@db/calc
-  command: python manage.py runserver 0.0.0.0:8000
-  ports:
-    - "8000:8000"
-db:
-  image: postgres:9.4
-  environment:
-    - POSTGRES_DB=calc
-    - POSTGRES_USER=calc_user
+version: '2'
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/calc
+    links:
+      - db
+      - selenium
+    working_dir: /calc
+    entrypoint: python /calc/docker_django_management.py
+    environment:
+      - DDM_HOST_USER=calc_user
+      - DDM_IS_RUNNING_IN_DOCKER=yup
+      - PYTHONUNBUFFERED=yup
+      - DATABASE_URL=postgres://calc_user@db/calc
+      - DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:9999
+    command: python manage.py runserver 0.0.0.0:8000
+    ports:
+      - "8000:8000"
+      - "9999:9999"
+  db:
+    image: postgres:9.4
+    environment:
+      - POSTGRES_DB=calc
+      - POSTGRES_USER=calc_user
+  selenium:
+    image: selenium/standalone-chrome
+#    environment:
+#      - DISPLAY=:99.0
+#      - DBUS_SESSION_BUS_ADDRESS=/dev/null
+    ports:
+      - "4444:4444"

--- a/hourglass/docker_settings.py
+++ b/hourglass/docker_settings.py
@@ -1,3 +1,16 @@
 DEBUG=True
 
 SECURE_SSL_REDIRECT = False
+
+REMOTE_TESTING = {
+    'enabled': True,
+    'hub_url': 'http://selenium:4444/wd/hub',
+    'username': '',
+    'access_key': '',
+    'capabilities': {
+        'browser': 'chrome'
+        # 'browser': 'internet explorer',
+        # 'version': '9.0',
+        # 'platform': 'Windows 7'
+    }
+}

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -123,7 +123,8 @@ class FunctionalTests(LiveServerTestCase):
         super(FunctionalTests, self).fail(*args, **kwargs)
 
     def setUp(self):
-        self.base_url = self.live_server_url.replace('0.0.0.0', 'app')
+        my_ip = socket.gethostbyaddr(socket.gethostname())[2][0]
+        self.base_url = self.live_server_url.replace('0.0.0.0', my_ip)
         #if TESTING_URL:
         #    self.base_url = TESTING_URL
         self.driver.set_window_size(*self.window_size)


### PR DESCRIPTION
Basically I was trying to see if I could work-around our problems with PhantomJS selenium integration (see #266, #267, etc) by using [Docker images for standalone Selenium](https://github.com/SeleniumHQ/docker-selenium). What I've got right now works *in theory*--the app container is able to connect to the selenium server and pass it its IP address, and the selenium server is able to connect back--but there are lots of problems, e.g.:

* The user has to run `docker-compose up selenium` in a separate terminal window, which is inconvenient.
* Sometimes `docker-compose up selenium` [randomly fails](https://github.com/18F/calc/pull/305#issuecomment-227479583).
* The docker-selenium container image is large and takes a very long time to download even on a fast internet connection, for some reason (that could've just been something weird going on with my internet connection, I suppose).

Aside from that, there's lots of [issues in docker-selenium's GitHub](https://github.com/SeleniumHQ/docker-selenium/issues) that seem to indicate lots of possibilities for the same kinds of problems we're running into with PhantomJS, so I'm closing this PR unmerged.
