### PR TITLE
Increase phantomJS timeout to 15s on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ script:
 - cp hourglass/local_settings{.travis,}.py
 - phantomjs --version
 - make test
+env:
+- PHANTOMJS_TIMEOUT=15
 notifications:
   email: false
 deploy:

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -36,7 +36,7 @@ TESTING_KEY = 'REMOTE_TESTING'
 REMOTE_TESTING = hasattr(settings, TESTING_KEY) and getattr(settings, TESTING_KEY) or {}
 TESTING_URL = os.environ.get('LOCAL_TUNNEL_URL', REMOTE_TESTING.get('url'))
 
-PHANTOMJS_TIMEOUT = 3
+PHANTOMJS_TIMEOUT = int(os.environ.get('PHANTOMJS_TIMEOUT', '3'))
 WEBDRIVER_TIMEOUT_LOAD_ATTEMPTS = 10
 
 def _get_testing_config(key, default=None):


### PR DESCRIPTION
A number of travis builds were failing earlier today due to hitting the 3-second timeout so many times (see #267) during the selenium tests.  I re-ran one of them just now and it worked fine, though, so my guess is that Travis was just under a lot of load and taking a really long time to run our tests. So this PR changes the timeout to 15s on Travis while keeping it at a brisk 3s for local development.