### PR TITLE
Add support for cloudfoundry CUPS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ pip-selfcheck.json
 /src
 .ruby-version
 .sass-cache/
+credentials.json

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ From there, you're just a hop, skip and a jump away from your own dev server:
 ./manage.py runserver
 ```
 
-If you are managing https://calc.gsa.gov, see https://github.com/18F/calc/blob/master/deploy.md.
+If you are managing https://calc.gsa.gov or any other cloud.gov-based
+deployment, see [`deploy.md`][].
 
 ## Testing
 
@@ -268,3 +269,4 @@ for other than small business.
 [Docker goes native]: https://blog.docker.com/2016/03/docker-for-mac-windows-beta/
 [`SECRET_KEY`]: https://docs.djangoproject.com/en/1.9/ref/settings/#secret-key
 [SASS]: http://sass-lang.com/
+[`deploy.md`]: https://github.com/18F/calc/blob/master/deploy.md

--- a/deploy.md
+++ b/deploy.md
@@ -23,6 +23,41 @@ To start, target the org and space you want to work with. For example, if you wa
 
 You can edit the app attributes in the `manifest.yml` file, including what domains the site deploys to, how many instances are running, and how much memory they have. 
 
+#### Environment Variables
+
+For cloud.gov deployments, this project makes use of a
+[Custom User Provided Service (CUPS)][CUPS] to get its configuration
+variables, instead of using the local environment. You will need to create a
+CUPS called `calc-env`, provide 'credentials' to it, and link it to the
+application instance.
+
+First, create a file called `credentials.json` with all the configuration
+values specified as per the "Environment Variables" section of
+[`README.md`][]:
+
+```json
+{
+  "SECRET_KEY": "my secret key",
+  "...": "other environment variables"
+}
+```
+
+Then enter the following commands (assuming you already have an application
+instance named `calc`):
+
+```sh
+cf cups calc-env -p credentials.json
+cf bind-service calc calc-env
+cf restage calc
+```
+
+You can update the user provided service with the following commands:
+
+```sh
+cf uups calc-env -p credentials.json
+cf restage calc
+```
+
 #### Dev Server
 The development server updates automatically when changes are merged into the master branch. Check out `.travis.yml` for details.
 
@@ -59,6 +94,5 @@ Then unmap calc.gsa.gov from the original app, using:
 
 Your changes are now launched! How easy was that?
 
-
-
-
+[CUPS]: https://docs.cloudfoundry.org/devguide/services/user-provided.html
+[`README.md`]: https://github.com/18F/calc#readme

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -14,7 +14,10 @@ import sys
 import dj_database_url
 
 from docker_django_management import IS_RUNNING_IN_DOCKER
+from .settings_utils import load_cups_from_vcap_services
 
+
+load_cups_from_vcap_services('calc-env')
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 

--- a/hourglass/settings_utils.py
+++ b/hourglass/settings_utils.py
@@ -1,0 +1,23 @@
+import os
+import json
+
+def load_cups_from_vcap_services(name, env=os.environ):
+    '''
+    Detects if VCAP_SERVICES exists in the environment; if so, parses
+    it and imports all the credentials from the given custom
+    user-provided service (CUPS) as strings into the environment.
+
+    For more details on CUPS, see:
+
+    https://docs.cloudfoundry.org/devguide/services/user-provided.html
+    '''
+
+    if 'VCAP_SERVICES' not in env:
+        return
+
+    vcap = json.loads(env['VCAP_SERVICES'])
+
+    for entry in vcap.get('user-provided', []):
+        if entry['name'] == name:
+            for key, value in entry['credentials'].items():
+                env[key] = value

--- a/hourglass/settings_utils.py
+++ b/hourglass/settings_utils.py
@@ -1,6 +1,7 @@
 import os
 import json
 
+
 def load_cups_from_vcap_services(name, env=os.environ):
     '''
     Detects if VCAP_SERVICES exists in the environment; if so, parses

--- a/hourglass/tests.py
+++ b/hourglass/tests.py
@@ -1,0 +1,55 @@
+import unittest
+import json
+
+from .settings_utils import load_cups_from_vcap_services
+
+
+class CupsTests(unittest.TestCase):
+    @staticmethod
+    def make_vcap_services_env(vcap_services):
+        return {
+            'VCAP_SERVICES': json.dumps(vcap_services)
+        }
+
+    def test_noop_if_vcap_services_not_in_env(self):
+        env = {}
+        load_cups_from_vcap_services('blah', env=env)
+        self.assertEqual(env, {})
+
+    def test_irrelevant_cups_are_ignored(self):
+        env = self.make_vcap_services_env({
+          "user-provided": [
+            {
+              "label": "user-provided", 
+              "name": "NOT-boop-env",
+              "syslog_drain_url": "", 
+              "credentials": {
+                "boop": "jones"
+              },
+              "tags": []
+            }
+          ]
+        })
+
+        load_cups_from_vcap_services('boop-env', env=env)
+
+        self.assertFalse('boop' in env)
+
+    def test_credentials_are_loaded(self):
+        env = self.make_vcap_services_env({
+          "user-provided": [
+            {
+              "label": "user-provided",
+              "name": "boop-env",
+              "syslog_drain_url": "",
+              "credentials": {
+                "boop": "jones"
+              },
+              "tags": []
+            }
+          ]
+        })
+
+        load_cups_from_vcap_services('boop-env', env=env)
+
+        self.assertEqual(env['boop'], 'jones')

--- a/hourglass/tests.py
+++ b/hourglass/tests.py
@@ -20,9 +20,9 @@ class CupsTests(unittest.TestCase):
         env = self.make_vcap_services_env({
           "user-provided": [
             {
-              "label": "user-provided", 
+              "label": "user-provided",
               "name": "NOT-boop-env",
-              "syslog_drain_url": "", 
+              "syslog_drain_url": "",
               "credentials": {
                 "boop": "jones"
               },

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ django-secure==1.0.1
 djangorestframework==3.3.3
 djorm-ext-pgfulltext==0.9.3
 model-mommy==1.2.6
+flake8==2.6.0
 newrelic==2.66.0.49
 nose==1.3.7
 numpy==1.9.3


### PR DESCRIPTION
This fixes #306.

The `load_cups_from_vcap_services()` function was largely inspired by [python-dotenv](https://github.com/theskumar/python-dotenv#readme).

The documentation is largely cribbed from [team-api-server](https://github.com/18F/team-api-server/blob/master/README.md#on-cloudgov)'s.
