### PR TITLE
Use branch=develop for travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CALC
 
-[![Build Status](https://travis-ci.org/18F/calc.svg)](https://travis-ci.org/18F/calc)
+[![Build Status](https://travis-ci.org/18F/calc.svg?branch=develop)](https://travis-ci.org/18F/calc)
 [![Code Climate](https://codeclimate.com/github/18F/calc/badges/gpa.svg)](https://codeclimate.com/github/18F/calc)
 
 CALC (formerly known as "Hourglass"), which stands for Contracts Awarded Labor Category, is a tool to help contracting personnel estimate their per-hour labor costs for a contract, based on historical pricing information. The tool is live at [https://calc.gsa.gov](https://calc.gsa.gov). You can track our progress on our [trello board](https://trello.com/b/LjXJaVbZ/prices) or file an issue on this repo. 


### PR DESCRIPTION
It seems as though https://travis-ci.org/18F/calc.svg just shows the build status of the most recent build, even if it's e.g. a WIP PR that's currently broken.  If we explicitly add `?branch=develop` to the URL then we'll get the status of the current `develop` branch.