### PR TITLE
Updated docker docs in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ be rebuilt for you.
 
 A Docker setup potentially makes development and deployment easier.
 
-To use it, install [Docker][] and [Docker Compose][]. (If you're on OS X or
-Windows, you'll also have to explicitly start the Docker Quickstart Terminal,
-at least until [Docker goes native][].)
+To use it, install [Docker][] and [Docker Compose][] and read the
+[18F Docker guide][] if you haven't already.
 
 Then run:
 
@@ -98,11 +97,8 @@ docker-compose up
 ```
 
 This will start up all required servers in containers and output their
-log information to stdout. If you're on Linux, you should be able
-to visit http://localhost:8000/ directly to access the site. If you're on
-OS X or Windows, you'll likely have to visit port 8000 on the IP
-address given to you by `docker-machine ip default`. (Note that this
-hassle will go away once [Docker goes native][] for OS X/Windows.)
+log information to stdout. You should be able to visit http://localhost:8000/
+directly to access the site.
 
 ### Accessing the app container
 
@@ -121,6 +117,12 @@ Note that if you don't have Django installed on your host system, you
 can just run `python manage.py` directly from outside the container--the
 `manage.py` script has been modified to run itself in a Docker container
 if it detects that Django isn't installed.
+
+### Updating the containers
+
+All the project's dependencies, such as those mentioned in `requirements.txt`,
+are contained in Docker container images.  Whenever these dependencies change,
+you'll want to re-run `docker-compose build` to rebuild the containers.
 
 ## Environment Variables
 
@@ -264,9 +266,9 @@ And the `small_business` parameter can be either `s` for small business, or `o`
 for other than small business.
 
 [Django]: https://www.djangoproject.com/
+[18F Docker guide]: https://pages.18f.gov/dev-environment-standardization/virtualization/docker/
 [Docker]: https://www.docker.com/
 [Docker Compose]: https://docs.docker.com/compose/
-[Docker goes native]: https://blog.docker.com/2016/03/docker-for-mac-windows-beta/
 [`SECRET_KEY`]: https://docs.djangoproject.com/en/1.9/ref/settings/#secret-key
 [SASS]: http://sass-lang.com/
 [`deploy.md`]: https://github.com/18F/calc/blob/master/deploy.md


### PR DESCRIPTION
This removes references to docker-machine, since Docker has gone native for OS X / Windows (although it is still in beta).  It also links to the 18F docker guide and documents updating the container.