### PR TITLE
add code coverage reporting via code climate

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,15 @@
 [run]
 branch = True
-source = hourglass
+source = .
+omit =
+  fake_uaa_provider/*
+  */migrations/*
+  */mommy_recipes.py
+  docker_django_management.py
+  manage.py
+  */tests.py
+  */tests/*
+  hourglass/wsgi.py
 [report]
 exclude_lines =
     pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
 - phantomjs --version
 - echo "For details on why we're ignoring selenium tests, see https://github.com/18F/calc/issues/330"
-- py.test --ignore=selenium_tests --cov=codeclimate_test_reporter
+- py.test --ignore=selenium_tests --cov
 env:
   global:
     - PHANTOMJS_TIMEOUT=15

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ addons:
 matrix:
   fast_finish: true
 before_install:
-  - pip install codecov
+  - pip install codeclimate-test-reporter
 after_success:
-  - codecov
+  - codeclimate-test-reporter
 install:
 - pip install -r requirements.txt
 script:
 - phantomjs --version
 - echo "For details on why we're ignoring selenium tests, see https://github.com/18F/calc/issues/330"
-- py.test --ignore=selenium_tests
+- py.test --ignore=selenium_tests --cov=codeclimate_test_reporter
 env:
   global:
     - PHANTOMJS_TIMEOUT=15

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Build Status](https://travis-ci.org/18F/calc.svg?branch=develop)](https://travis-ci.org/18F/calc)
 [![Code Climate](https://codeclimate.com/github/18F/calc/badges/gpa.svg)](https://codeclimate.com/github/18F/calc)
+[![Test Coverage](https://codeclimate.com/github/18F/calc/badges/coverage.svg)](https://codeclimate.com/github/18F/calc/coverage)
 
-CALC (formerly known as "Hourglass"), which stands for Contracts Awarded Labor Category, is a tool to help contracting personnel estimate their per-hour labor costs for a contract, based on historical pricing information. The tool is live at [https://calc.gsa.gov](https://calc.gsa.gov). You can track our progress on our [trello board](https://trello.com/b/LjXJaVbZ/prices) or file an issue on this repo. 
+CALC (formerly known as "Hourglass"), which stands for Contracts Awarded Labor Category, is a tool to help contracting personnel estimate their per-hour labor costs for a contract, based on historical pricing information. The tool is live at [https://calc.gsa.gov](https://calc.gsa.gov). You can track our progress on our [trello board](https://trello.com/b/LjXJaVbZ/prices) or file an issue on this repo.
 
 ## Setup
 
@@ -189,7 +190,7 @@ http://localhost:8000/api/rates/?&min_experience=5&max_experience=10&q=technical
 ```
 
 Or, you can filter with a single, comma-separated range.
-For example, if you wanted results with more than five years and less 
+For example, if you wanted results with more than five years and less
 than ten years of experience:
 
 ```
@@ -265,7 +266,7 @@ http://localhost:8000/api/rates/?schedule=mobis&site=customer&business_size=s
 
 For schedules, there are 8 different values that will return results (case
 insensitive):
- 
+
  - Environmental
  - AIMS
  - Logistics

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ newrelic==2.66.0.49
 nose==1.3.7
 numpy==1.9.3
 psycopg2==2.5.5
+pytest-cov==2.2.1
 pytest-django==2.9.1
 selenium==2.53.5
 six==1.10.0


### PR DESCRIPTION
This PR modifies the Travis build to report coverage information to CodeClimate.

One step not shown here in code is that I had to set the `CODECLIMATE_REPO_TOKEN` in Travis (as a private env variable).