### PR TITLE
Only use whitenoise CompressedManifestStaticFilesStorage in production.

### DIFF
--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -123,7 +123,8 @@ STATICFILES_DIRS = (
 )
 
 if not DEBUG:
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    STATICFILES_STORAGE = ('whitenoise.storage.'
+                           'CompressedManifestStaticFilesStorage')
 
 PAGINATION = 200
 REST_FRAMEWORK = {

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -121,7 +121,9 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATICFILES_DIRS = (
     # os.path.join(BASE_DIR, 'static'),
 )
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+if not DEBUG:
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 PAGINATION = 200
 REST_FRAMEWORK = {


### PR DESCRIPTION
This fixes #213.

I've had an extremely frustrating time using whitenoise in development due to errors like #213 that intermittently come up during development and [testing](https://travis-ci.org/18F/calc/builds/140849798).

The only way I can think of to remedy this is by disabling whitenoise's `CompressedManifestStaticFilesStorage` entirely during development. It's not great for dev/prod parity but I also can't really imagine it having negative effects, unless we forget to use the `static` template tag and hardcode a URL to a static asset, but we should be able to easily catch that during code review.

I originally tried to remove our `collectstatic` call before running selenium tests, but they bizarrely fail without them, which I suppose is par for the course when it comes to selenium at this point. 😣 