### PR TITLE
use apt package for numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ addons:
   postgresql: 9.3
 matrix:
   fast_finish: true
+virtualenv:
+  system_site_packages: true
 before_install:
+  - sudo apt-get install -qq python-numpy
   - pip install codeclimate-test-reporter
 after_success:
   - codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ addons:
   postgresql: 9.3
 matrix:
   fast_finish: true
-virtualenv:
-  system_site_packages: true
 before_install:
   - sudo apt-get install -qq python-numpy
   - pip install codeclimate-test-reporter


### PR DESCRIPTION
Testing to see if we can use a system installed (via `apt`) numpy package, but it looks like that is not going to work.