### PR TITLE
create manifests/ folder; target specific manifest for auto-deploy;

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -23,4 +23,4 @@ pip-selfcheck.json
 .ruby-version
 .sass-cache/
 *credentials*.json
-*manifest*.yml
+/manifests

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ pip-selfcheck.json
 .ruby-version
 .sass-cache/
 *credentials*.json
-*manifest*.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ deploy:
   api: https://api.cloud.gov
   organization: oasis
   space: calc-dev
+  manifest: manifests/manifest-staging.yml
   on:
     branch: develop
 sudo: required

--- a/manifests/manifest-sandbox.yml
+++ b/manifests/manifest-sandbox.yml
@@ -1,0 +1,15 @@
+---
+services:
+- db-calc-sandbox
+- calc-env
+applications:
+- name: calc-sandbox
+  instances: 1
+  memory: 256M
+  disk_quota: 1024M
+  host: calc-sandbox
+  domain: apps.cloud.gov
+  buildpack: python_buildpack
+  command: bash cf.sh
+  stack: cflinuxfs2
+  timeout: 180

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -1,0 +1,15 @@
+---
+services:
+- db-calc-dev
+- calc-env
+applications:
+- name: calc-dev
+  instances: 1
+  memory: 256M
+  disk_quota: 1024M
+  host: calc-dev
+  domain: apps.cloud.gov
+  buildpack: python_buildpack
+  command: bash cf.sh
+  stack: cflinuxfs2
+  timeout: 180


### PR DESCRIPTION
Attempt at getting our deployment under a little better control. This will likely change in the future, especially once we start pushing to a prod instance, but for now I think this should work well.

`manifest.yml` files are no longer gitignore'd. Rather, there is a `manifests/` folder where we will store manifest files WITHOUT sensitive information. Environment configs should be done instead via User Provided Services.

The `.travis.yml` deploy step has been updated to use the `manifest-staging.yml` manifest to deploy to the `calc-dev` space on pushes to the `develop` branch.