### PR TITLE
reenable default travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ env:
   - PHANTOMJS_TIMEOUT=15
   - DEBUG=yup
   - DATABASE_URL=postgres://postgres@localhost/hourglass
-notifications:
-  email: false
 deploy:
   edge: true
   provider: cloudfoundry


### PR DESCRIPTION
Remove the explicit disabling of email notifications, which should revert travis back to its default email notification behavior of emailing the committer who broke the build.