### PR TITLE
[DO NOT MERGE] Support running Selenium tests in Docker w/ a real browser.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ app:
     - .:/calc
   links:
     - db
+    - sshd
   working_dir: /calc
   entrypoint: python /calc/docker_django_management.py
   environment:
@@ -27,3 +28,7 @@ sass:
   working_dir: /calc/hourglass_site/static/hourglass_site
   entrypoint: python /calc/docker_django_management.py
   command: make watch-style
+sshd:
+  build: ./sshd
+  ports:
+    - "8022:22"

--- a/selenium.md
+++ b/selenium.md
@@ -1,0 +1,38 @@
+# Running Selenium tests against a WebDriver server on a Docker host
+
+## Terminal A: Set up a WebDriver server on your host
+
+1. Get ChromeDriver:
+
+   https://sites.google.com/a/chromium.org/chromedriver/downloads
+
+2. Run it:
+
+   ```
+   ./chromedriver
+   ```
+
+## Terminal B: Start up Docker Compose
+
+```
+docker-compose up
+```
+
+## Terminal C: Make your WebDriver server available to Docker
+
+```
+ssh -R 9515:localhost:9515 root@calc.docker -p 8022 -N
+```
+
+The password is `screencast`.
+
+## Terminal D: Run the Selenium tests
+
+```
+docker-compose run \
+  -p 8001:8001 \
+  -e LOCAL_TUNNEL_URL=http://calc.docker:8001 \
+  -e DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8001 \
+  -e WEBDRIVER_URL=http://sshd:9515 \
+  app py.test selenium_tests
+```

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -61,6 +61,17 @@ class FunctionalTests(LiveServerTestCase):
 
     @classmethod
     def get_driver(cls):
+        desired_cap = webdriver.DesiredCapabilities.CHROME
+
+        driver = webdriver.Remote(
+            desired_capabilities=desired_cap,
+            command_executor=os.environ['WEBDRIVER_URL']
+        )
+
+        return driver
+
+        # TODO: Make the following code still reachable.
+
         if not REMOTE_TESTING or not TESTING_URL:
             driver = _get_webdriver(os.environ.get('TESTING_BROWSER',
                                                    'phantomjs'))

--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -1,0 +1,25 @@
+# https://docs.docker.com/engine/examples/running_ssh_service/
+#
+# sshd
+#
+# VERSION               0.0.2
+
+FROM ubuntu:14.04
+MAINTAINER Sven Dowideit <SvenDowideit@docker.com>
+
+RUN apt-get update && apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+RUN echo 'root:screencast' | chpasswd
+RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+
+EXPOSE 22
+EXPOSE 9000
+CMD ["/usr/sbin/sshd", "-D"]
+
+RUN sed -i '$ a\GatewayPorts yes' /etc/ssh/sshd_config


### PR DESCRIPTION
Ok, this kind of makes me hate Docker a little, because there's not really an easy way to expose a port running on one's host machine to a Docker container. Especially when Docker is running on a Docker Machine VM.

So this spike hacks things by running a `sshd` container that you use to create a tunnel between a WebDriver server running on your local machine and the internal network that Docker uses.

Also see #305.
