### PR TITLE
Run QUnit tests in phantomjs

### DIFF
--- a/qunit_tests/tests.py
+++ b/qunit_tests/tests.py
@@ -1,8 +1,10 @@
 import os
 import subprocess
 
-from django.core import management
 from django.test import LiveServerTestCase
+
+from selenium_tests.utils import build_static_assets
+
 
 # This file was taken from https://github.com/jonkemp/qunit-phantomjs-runner.
 RUNNER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -17,6 +19,5 @@ class QunitTests(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        management.call_command('collectstatic', '--noinput', '--link',
-                                verbosity=0)
+        build_static_assets()
         super(QunitTests, cls).setUpClass()

--- a/qunit_tests/tests.py
+++ b/qunit_tests/tests.py
@@ -6,7 +6,6 @@ from django.test import LiveServerTestCase
 from selenium_tests.utils import build_static_assets
 
 
-# This file was taken from https://github.com/jonkemp/qunit-phantomjs-runner.
 RUNNER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                            'vendor', 'runner.js')
 

--- a/qunit_tests/tests.py
+++ b/qunit_tests/tests.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+
+from django.core import management
+from django.test import LiveServerTestCase
+
+# This file was taken from https://github.com/jonkemp/qunit-phantomjs-runner.
+RUNNER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           'vendor', 'runner.js')
+
+
+class QunitTests(LiveServerTestCase):
+    def test_qunit(self):
+        subprocess.check_call([
+            'phantomjs', RUNNER_PATH, self.live_server_url + '/tests/'
+        ])
+
+    @classmethod
+    def setUpClass(cls):
+        management.call_command('collectstatic', '--noinput', '--link',
+                                verbosity=0)
+        super(QunitTests, cls).setUpClass()

--- a/qunit_tests/vendor/LICENSE
+++ b/qunit_tests/vendor/LICENSE
@@ -1,0 +1,24 @@
+The MIT License
+
+Copyright (c) 2014, Jonathan Kemp
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/qunit_tests/vendor/README.md
+++ b/qunit_tests/vendor/README.md
@@ -1,0 +1,12 @@
+This directory contains a copy of the runner.js file from
+qunit-phantomjs-runner:
+
+    https://github.com/jonkemp/qunit-phantomjs-runner
+
+We decided to simply copy the file instead of using `npm install` because
+locating the `node_modules` directory was made non-trivial by the following PR:
+
+    https://github.com/18F/calc/pull/373
+
+Combined with the fact that qunit-phantomjs-runner is small and doesn't change
+often, we figured it'd be OK to include it in the repository.

--- a/qunit_tests/vendor/runner.js
+++ b/qunit_tests/vendor/runner.js
@@ -1,0 +1,167 @@
+/*global phantom:false, require:false, console:false, window:false, QUnit:false */
+
+(function () {
+    'use strict';
+
+    var url, page, timeout,
+        args = require('system').args;
+
+    // arg[0]: scriptName, args[1...]: arguments
+    if (args.length < 2) {
+        console.error('Usage:\n  phantomjs [phantom arguments] runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds] [page-properties]');
+        exit(1);
+    }
+
+    url = args[1];
+
+    if (args[2] !== undefined) {
+        timeout = parseInt(args[2], 10);
+    }
+
+    page = require('webpage').create();
+
+    if (args[3] !== undefined) {
+        try {
+            var pageProperties = JSON.parse(args[3]);
+
+            if (pageProperties) {
+                for (var prop in pageProperties) {
+                    if (pageProperties.hasOwnProperty(prop)) {
+                        page[prop] = pageProperties[prop];
+                    }
+                }
+            }
+        } catch(e) {
+            console.error('Error parsing "' + args[3] + '": ' + e);
+        }
+    }
+
+    // Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
+    page.onConsoleMessage = function (msg) {
+        console.log(msg);
+    };
+
+    page.onInitialized = function () {
+        page.evaluate(addLogging);
+    };
+
+    page.onCallback = function (message) {
+        var result,
+            failed;
+
+        if (message) {
+            if (message.name === 'QUnit.done') {
+                result = message.data;
+                failed = !result || !result.total || result.failed;
+
+                if (!result.total) {
+                    console.error('No tests were executed. Are you loading tests asynchronously?');
+                }
+
+                exit(failed ? 1 : 0);
+            }
+        }
+    };
+
+    page.open(url, function (status) {
+        if (status !== 'success') {
+            console.error('Unable to access network: ' + status);
+            exit(1);
+        } else {
+            // Cannot do this verification with the 'DOMContentLoaded' handler because it
+            // will be too late to attach it if a page does not have any script tags.
+            var qunitMissing = page.evaluate(function () {
+                return (typeof QUnit === 'undefined' || !QUnit);
+            });
+            if (qunitMissing) {
+                console.error('The `QUnit` object is not present on this page.');
+                exit(1);
+            }
+
+            // Set a default timeout value if the user does not provide one
+            if (typeof timeout === 'undefined') {
+                timeout = 5;
+            }
+
+            // Set a timeout on the test running, otherwise tests with async problems will hang forever
+            setTimeout(function () {
+                console.error('The specified timeout of ' + timeout + ' seconds has expired. Aborting...');
+                exit(1);
+            }, timeout * 1000);
+
+            // Do nothing... the callback mechanism will handle everything!
+        }
+    });
+
+    function addLogging() {
+        window.document.addEventListener('DOMContentLoaded', function () {
+            var currentTestAssertions = [];
+
+            QUnit.log(function (details) {
+                var response;
+
+                // Ignore passing assertions
+                if (details.result) {
+                    return;
+                }
+
+                response = details.message || '';
+
+                if (typeof details.expected !== 'undefined') {
+                    if (response) {
+                        response += ', ';
+                    }
+
+                    response += 'expected: ' + details.expected + ', but was: ' + details.actual;
+                }
+
+                if (details.source) {
+                    response += '\n' + details.source;
+                }
+
+                currentTestAssertions.push('Failed assertion: ' + response);
+            });
+
+            QUnit.testDone(function (result) {
+                var i,
+                    len,
+                    name = '';
+
+                if (result.module) {
+                    name += result.module + ': ';
+                }
+                name += result.name;
+
+                if (result.failed) {
+                    console.log('\n' + 'Test failed: ' + name);
+
+                    for (i = 0, len = currentTestAssertions.length; i < len; i++) {
+                        console.log('    ' + currentTestAssertions[i]);
+                    }
+                }
+
+                currentTestAssertions.length = 0;
+            });
+
+            QUnit.done(function (result) {
+                console.log('\n' + 'Took ' + result.runtime + 'ms to run ' + result.total + ' tests. ' + result.passed + ' passed, ' + result.failed + ' failed.');
+
+                if (typeof window.callPhantom === 'function') {
+                    window.callPhantom({
+                        'name': 'QUnit.done',
+                        'data': result
+                    });
+                }
+            });
+        }, false);
+    }
+
+    function exit(code) {
+        if (page) {
+            page.close();
+        }
+        setTimeout(function () {
+            phantom.exit(code);
+        }, 0);
+    }
+})();

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -34,12 +34,16 @@ import socket
 import subprocess
 from datetime import datetime
 
+from .utils import build_static_assets
+
+
 TESTING_KEY = 'REMOTE_TESTING'
 REMOTE_TESTING = hasattr(settings, TESTING_KEY) and getattr(settings, TESTING_KEY) or {}
 TESTING_URL = os.environ.get('LOCAL_TUNNEL_URL', REMOTE_TESTING.get('url'))
 
 PHANTOMJS_TIMEOUT = int(os.environ.get('PHANTOMJS_TIMEOUT', '3'))
 WEBDRIVER_TIMEOUT_LOAD_ATTEMPTS = 10
+
 
 def _get_testing_config(key, default=None):
     return REMOTE_TESTING.get(key, os.environ.get('%s_%s' % (TESTING_KEY, key.upper()), default))
@@ -99,9 +103,7 @@ class FunctionalTests(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        subprocess.check_call(['npm', 'run', 'gulp', '--', 'build'])
-        management.call_command('collectstatic', '--noinput', '--link',
-                                verbosity=0)
+        build_static_assets()
         cls.driver = cls.get_driver()
         cls.longMessage = True
         cls.maxDiff = None

--- a/selenium_tests/utils.py
+++ b/selenium_tests/utils.py
@@ -6,6 +6,7 @@ import subprocess
 
 _static_assets_built = False
 
+
 def build_static_assets():
     '''
     Sometimes we need static assets to be available before browser-based

--- a/selenium_tests/utils.py
+++ b/selenium_tests/utils.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.core import management
+
+import subprocess
+
+
+_static_assets_built = False
+
+def build_static_assets():
+    '''
+    Sometimes we need static assets to be available before browser-based
+    tests run. We want to be able to have multiple browser-based test suites,
+    but we also don't want to needlessly regenerate the static assets
+    for each one, so we'll use this function, which ensures that the assets
+    are only built once per test run.
+    '''
+
+    global _static_assets_built
+
+    if not _static_assets_built:
+        subprocess.check_call(['rm', '-rf', settings.STATIC_ROOT])
+        subprocess.check_call(['npm', 'run', 'gulp', '--', 'build'])
+        management.call_command('collectstatic', '--noinput', '--link',
+                                verbosity=0)
+        _static_assets_built = True


### PR DESCRIPTION
This should have been really easy but it took me a while because `whitenoise` is confusing.

I copied `runner.js` from [qunit-phantomjs-runner](https://github.com/jonkemp/qunit-phantomjs-runner) because:

1. Finding the file when it's installed via `npm` is actually non-trivial due to #373.
2. It's just one dinky file that doesn't change often.

If we really want, though, I can install it via `npm` and add code to locate the `node_modules` directory it's located in.