### PR TITLE
Add steps widget to styleguide

### DIFF
--- a/hourglass_site/static_source/style/main.scss
+++ b/hourglass_site/static_source/style/main.scss
@@ -2,6 +2,7 @@
 @import 'partials/variables';
 @import 'skeleton/normalize';
 @import 'skeleton/skeleton';
+@import 'widgets/steps';
 
 body {
   font-family: Lato, Helvetica, Arial, sans-serif;

--- a/hourglass_site/static_source/style/widgets/_steps.scss
+++ b/hourglass_site/static_source/style/widgets/_steps.scss
@@ -1,0 +1,48 @@
+ol.steps {
+  font-weight: 300;
+  padding: 0;
+  list-style-type: none;
+  list-style-position: inside;
+  display: flex;
+}
+
+ol.steps li {
+  border-top: 3px solid #0872B9;
+  padding-top: 30px;
+  flex-grow: 1;
+  position: relative;
+}
+
+ol.steps li:last-child {
+  border-color: transparent;
+}
+
+ol.steps svg {
+  width: 30px;
+  height: 30px;
+  position: absolute;
+  top: -15px;
+  left: 0px;
+}
+
+ol.steps li.steps-done svg circle {
+  fill: #0872B9;
+}
+
+ol.steps li.steps-done svg text {
+  fill: white;
+}
+
+ol.steps svg circle {
+  fill: white;
+  stroke-width: 3px;
+  stroke: #0872B9;
+}
+
+ol.steps svg text {
+  font-weight: 700;
+  font-family: 'Lato';
+  font-size: 80%;
+  fill: #0872B9;
+  stroke: none;
+}

--- a/hourglass_site/static_source/style/widgets/_steps.scss
+++ b/hourglass_site/static_source/style/widgets/_steps.scss
@@ -43,6 +43,7 @@ ol.steps svg text {
   font-weight: 700;
   font-family: 'Lato';
   font-size: 80%;
+  text-anchor: middle;
   fill: #0872B9;
   stroke: none;
 }

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -34,6 +34,47 @@
   <input class="button-primary" type="submit" value="Submit">
   {% endexample %}
 
+  <h2 id="steps">Steps</h2>
+
+  <p>
+    The steps widget can be used to visualize the user's progress through a
+    multi-step process.
+  </p>
+
+  <p>
+    The widget extends to the full width of its container, with each
+    step consuming an equal amount of horizontal space.
+  </p>
+
+  <p>
+    Use <code>li.steps-done</code> to identify a step as being completed.
+  </p>
+
+  {% example %}
+  <ol class="steps">
+    <li class="steps-done">
+      <svg viewBox="0 0 30 30">
+        <circle cx="15" cy="15" r="13.5"/>
+        <text x="15" y="20" text-anchor="middle">1</text>
+      </svg>
+      Upload price list
+    </li>
+    <li class="steps-done">
+      <svg viewBox="0 0 30 30">
+        <circle cx="15" cy="15" r="13.5"/>
+        <text x="15" y="20" text-anchor="middle">2</text>
+      </svg>
+      Validate data
+    </li>
+    <li>
+      <svg viewBox="0 0 30 30">
+        <circle cx="15" cy="15" r="13.5"/>
+        <text x="15" y="20" text-anchor="middle">3</text>
+      </svg>
+      Submit data
+    </li>
+  </ol>
+  {% endexample %}
 </div>
 <script src="{% static 'styleguide/vendor/prism.js' %}"></script>
 {% endblock %}

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -54,22 +54,19 @@
   <ol class="steps">
     <li class="steps-done">
       <svg viewBox="0 0 30 30">
-        <circle cx="15" cy="15" r="13.5"/>
-        <text x="15" y="20" text-anchor="middle">1</text>
+        <circle cx="15" cy="15" r="13.5"/><text x="15" y="20">1</text>
       </svg>
       Upload price list
     </li>
     <li class="steps-done">
       <svg viewBox="0 0 30 30">
-        <circle cx="15" cy="15" r="13.5"/>
-        <text x="15" y="20" text-anchor="middle">2</text>
+        <circle cx="15" cy="15" r="13.5"/><text x="15" y="20">2</text>
       </svg>
       Validate data
     </li>
     <li>
       <svg viewBox="0 0 30 30">
-        <circle cx="15" cy="15" r="13.5"/>
-        <text x="15" y="20" text-anchor="middle">3</text>
+        <circle cx="15" cy="15" r="13.5"/><text x="15" y="20">3</text>
       </svg>
       Submit data
     </li>


### PR DESCRIPTION
This PR has been superseded by #381. Please look there instead!

<!--
This adds a steps widget to the styleguide:

> <img width="733" alt="screen shot 2016-07-13 at 10 00 29 am" src="https://cloud.githubusercontent.com/assets/124687/16806214/996776ee-48e1-11e6-8e31-cae53e4f50d3.png">

### SVGs

We should be fine to use SVGs in general, as the only browser that doesn't support them is IE8, and Kelly confirmed that we don't need to be concerned with that browser.

However, I am not a huge fan of how verbose the `<svg>`s are in particular.  Alternatives:

* Use pure CSS, although that could get kind of gnarly, especially when it comes to the stroked circles in the unfinished steps.
* Create individual SVG sprites for every number and link to those. I'm not a big fan of this because SVG sprites would still involve an `<svg>` tag with a `<use>` tag in it, so we're not saving much on verbosity, while also introducing a new level of indirection and complexity.
* Make a [custom Django inclusion tag](https://docs.djangoproject.com/en/1.8/howto/custom-template-tags/#inclusion-tags), e.g. `{% step 1 "Update Price List" done=True %}`, that adds the markup for us.
* Create the `<svg>` on the client-side via JS but it seems better to use JS only when absolutely necessary, which it clearly isn't here.

Aside from that, there's an unfortunate issue with SVG strokes whereby [it's not possible to specify whether a stroke is on the inside or outside of an element](http://stackoverflow.com/questions/7241393/can-you-control-how-an-svgs-stroke-width-is-drawn), and it's also not explicitly specified in the spec, so as a result different browsers render it in different ways.  This means that the widget will look slightly different on different browsers.  The SVG coordinates have also been "fudged" a bit to account for this.

### Flexbox

Also, this widget uses Flexbox, which has been [supported for a while on all major browsers except IE](http://caniuse.com/#search=flexbox), though we should probably use some kind of autoprefixer to support the slightly older ones.  ~~It might not look downright *horrible* on IE though, I will have to check on my Windows machine.~~ The widget looks fine on both MS Edge and IE 11.

### Mobile

I have **not** yet tried looking at this widget on mobile, though. I think this might require some up-front design work on exactly *how* we want the widget to look on mobile, though, as the current mock-ups are for desktop and it's unclear how they'd translate to mobile.

### Accessibility

I tried the widget out using NVDA and VoiceOver, and both treat the widget as a standard ordered list. They ignore the SVG content, but because they still treat the content as an ordered list, they audibly say the step numbers out loud, which is good.

The one thing that the screen readers *don't* convey is some kind of audible information about which steps the user has completed, or which one they're currently on.  We could alleviate this through the use of [invisible content just for screen reader users](http://webaim.org/techniques/css/invisiblecontent/) (this is `.sr-only` in Bootstrap, I'm not sure if we already have such a class in CALC). For example, `<aside class="sr-only">You are currently on this step</aside>` inside a list item would make it obvious to screen reader users the step they're currently on.

That said, such content would add even more verbosity to the widget, which would make the custom `{% step %}` tag described above even more useful.

### Future Considerations

In the future, I think it could be a nice micro-interaction to have the widget animate as users move  from one step to the next.  I think this could be accomplished with the current CSS, though we could do even better if we convert the lines between the circles into SVG too (this would enable the line to "grow" to the next step as the user completed tasks).

### Other Notes

I wanted to make this adhere to Marco's [CSS Architecture talk](https://www.youtube.com/watch?v=vO3KtQYrEUA) but I'm having problems viewing it for some reason.

Any advice on anything is appreciated!  I'm a bit of a noob when it comes to CSS best practices in particular.
-->