### PR TITLE
Add upload widget

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ const paths = {
       'vendor/query.xdomainrequest.min.js',
       'vendor/formdb.min.js',
       'common/hourglass.js',
+      'common/upload.js',
       'vendor/jquery.tooltipster.js',
       'vendor/jquery.nouislider.all.min.js',
     ],

--- a/hourglass_site/static/hourglass_site/js/upload_tests.js
+++ b/hourglass_site/static/hourglass_site/js/upload_tests.js
@@ -37,4 +37,19 @@
 
     upload.remove();
   });
+
+  advancedTest("'changefile' event triggered on drop", function(assert) {
+    var upload = $(UPLOAD_HTML).appendTo(document.body);
+    var input = upload.uploadify().find('input');
+    var fakeFile = {name: "boop"};
+    var evt = jQuery.Event('drop', {
+      originalEvent: { dataTransfer: { files: [fakeFile] } }
+    });
+
+    upload.on('changefile', function(e, file) {
+      assert.strictEqual(file, fakeFile);
+    });
+    upload.trigger(evt);
+    upload.remove();
+  });
 })(QUnit, jQuery);

--- a/hourglass_site/static/hourglass_site/js/upload_tests.js
+++ b/hourglass_site/static/hourglass_site/js/upload_tests.js
@@ -1,0 +1,40 @@
+(function(QUnit, $) {
+  QUnit.module("upload");
+
+  var UPLOAD_HTML = (
+    '<div class="upload">' +
+    '<input type="file" name="file" id="file">' +
+    '<div class="upload-chooser">' +
+    '<label for="file">Choose file or drag and drop here</label>' +
+    '</div>' +
+    '</div>'
+  );
+
+  var advancedTest = $.support.advancedUpload ? QUnit.test : QUnit.skip;
+
+  test("degraded upload sets 'upload', data", function(assert) {
+    var upload = $(UPLOAD_HTML)
+      .attr('data-force-degradation', 'yup')
+      .appendTo(document.body);
+
+    var input = upload.uploadify().find('input');
+
+    assert.strictEqual(input.data('upload').isDegraded, true);
+    assert.strictEqual(input.data('upload').input, input[0]);
+    assert.strictEqual(input.data('upload').file, null);
+
+    upload.remove();
+  });
+
+  advancedTest("advanced upload sets 'upload' data", function(assert) {
+    var upload = $(UPLOAD_HTML).appendTo(document.body);
+
+    var input = upload.uploadify().find('input');
+
+    assert.strictEqual(input.data('upload').isDegraded, false);
+    assert.strictEqual(input.data('upload').input, input[0]);
+    assert.strictEqual(input.data('upload').file, null);
+
+    upload.remove();
+  });
+})(QUnit, jQuery);

--- a/hourglass_site/static/hourglass_site/js/upload_tests.js
+++ b/hourglass_site/static/hourglass_site/js/upload_tests.js
@@ -1,6 +1,4 @@
 (function(QUnit, $) {
-  QUnit.module("upload");
-
   var UPLOAD_HTML = (
     '<div class="upload">' +
     '<input type="file" name="file" id="file">' +
@@ -10,37 +8,51 @@
     '</div>'
   );
 
-  var advancedTest = $.support.advancedUpload ? QUnit.test : QUnit.skip;
+  var upload, input;
+
+  function advancedTest(name, cb) {
+    if (!$.support.advancedUpload) {
+      return QUnit.skip(name, cb);
+    }
+    return QUnit.test(name, function(assert) {
+      upload = $(UPLOAD_HTML).appendTo(document.body);
+      input = upload.uploadify().find('input');
+      return cb(assert);
+    });
+  }
+
+  QUnit.module("upload", {
+    afterEach: function() {
+      if (upload) {
+        upload.remove();
+      }
+      upload = null;
+      input = null;
+    }
+  });
+
+  test("$.support.advancedUpload is a boolean", function(assert) {
+    assert.equal(typeof($.support.advancedUpload), "boolean");
+  });
 
   test("degraded upload sets 'upload', data", function(assert) {
-    var upload = $(UPLOAD_HTML)
+    upload = $(UPLOAD_HTML)
       .attr('data-force-degradation', 'yup')
       .appendTo(document.body);
-
-    var input = upload.uploadify().find('input');
+    input = upload.uploadify().find('input');
 
     assert.strictEqual(input.data('upload').isDegraded, true);
     assert.strictEqual(input.data('upload').input, input[0]);
     assert.strictEqual(input.data('upload').file, null);
-
-    upload.remove();
   });
 
   advancedTest("advanced upload sets 'upload' data", function(assert) {
-    var upload = $(UPLOAD_HTML).appendTo(document.body);
-
-    var input = upload.uploadify().find('input');
-
     assert.strictEqual(input.data('upload').isDegraded, false);
     assert.strictEqual(input.data('upload').input, input[0]);
     assert.strictEqual(input.data('upload').file, null);
-
-    upload.remove();
   });
 
   advancedTest("'changefile' event triggered on drop", function(assert) {
-    var upload = $(UPLOAD_HTML).appendTo(document.body);
-    var input = upload.uploadify().find('input');
     var fakeFile = {name: "boop"};
     var evt = jQuery.Event('drop', {
       originalEvent: { dataTransfer: { files: [fakeFile] } }
@@ -50,6 +62,5 @@
       assert.strictEqual(file, fakeFile);
     });
     upload.trigger(evt);
-    upload.remove();
   });
 })(QUnit, jQuery);

--- a/hourglass_site/static/hourglass_site/js/upload_tests.js
+++ b/hourglass_site/static/hourglass_site/js/upload_tests.js
@@ -41,9 +41,21 @@
       .appendTo(document.body);
     input = upload.uploadify().find('input');
 
+    assert.ok(upload.hasClass('degraded'));
+    assert.ok(!upload[0].hasAttribute('aria-live'));
     assert.strictEqual(input.data('upload').isDegraded, true);
     assert.strictEqual(input.data('upload').input, input[0]);
     assert.strictEqual(input.data('upload').file, null);
+  });
+
+  advancedTest("extra calls to uploadify() do nothing", function(assert) {
+    var data = input.data('upload');
+    upload.uploadify();
+    assert.strictEqual(input.data('upload'), data);
+  });
+
+  advancedTest("advanced upload sets aria-live", function(assert) {
+    assert.equal(upload.attr("aria-live"), "polite");
   });
 
   advancedTest("advanced upload sets 'upload' data", function(assert) {
@@ -62,5 +74,37 @@
       assert.strictEqual(file, fakeFile);
     });
     upload.trigger(evt);
+  });
+
+  advancedTest("input 'change' evt w/o files does nothing", function(assert) {
+    input.trigger('change');
+    assert.strictEqual(input.data('upload').file, null);
+  });
+
+  advancedTest("'changefile' sets current file", function(assert) {
+    var fakeFile = {name: "foo.txt"};
+    input.trigger('changefile', fakeFile);
+
+    assert.strictEqual(input.data('upload').file, fakeFile);
+    assert.equal(upload.find('.upload-filename').text(), 'foo.txt');
+  });
+
+  advancedTest("dragenter/dragleave affect .dragged-over", function(assert) {
+    var i;
+
+    assert.ok(!upload.hasClass('dragged-over'));
+
+    for (i = 0; i < 3; i++) {
+      upload.trigger('dragenter');
+      assert.ok(upload.hasClass('dragged-over'));
+    }
+
+    for (i = 0; i < 2; i++) {
+      upload.trigger('dragleave');
+      assert.ok(upload.hasClass('dragged-over'));
+    }
+
+    upload.trigger('dragleave');
+    assert.ok(!upload.hasClass('dragged-over'));
   });
 })(QUnit, jQuery);

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -51,7 +51,7 @@ $(document).ready(function () {
       $el.append(current);
     }
 
-    $el.data('upload', self);
+    $input.data('upload', self);
 
     if (!browserSupportsAdvancedUpload() ||
         this.hasAttribute('data-force-degradation')) {

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -32,6 +32,7 @@ $(document).ready(function () {
     var $el = $(this);
     var $input = $('input', $el);
     var self = {
+      input: $input[0],
       isDegraded: false,
       file: null
     };
@@ -70,7 +71,7 @@ $(document).ready(function () {
       var files = dt.files;
 
       if (files.length > 0) {
-        $el.trigger('changefile', files[0]);
+        $input.trigger('changefile', files[0]);
       }
     });
 
@@ -78,11 +79,11 @@ $(document).ready(function () {
       var selectedFile = this.files[0];
 
       if (selectedFile) {
-        $el.trigger('changefile', selectedFile);
+        $input.trigger('changefile', selectedFile);
       }
     });
 
-    $el.on('changefile', function (e, file) {
+    $input.on('changefile', function (e, file) {
       self.file = file;
       $input.val('');
       setCurrentFilename(file.name);

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -53,6 +53,12 @@
       $el.append(current);
     }
 
+    function setFile(file) {
+      if (file) {
+        $input.trigger('changefile', file);
+      }
+    }
+
     if ($input.data('upload')) {
       // We've already been uploadified!
       return;
@@ -88,20 +94,11 @@
       stopAndPrevent(e);
       $el.removeClass('dragged-over');
 
-      var dt = e.originalEvent.dataTransfer;
-      var files = dt.files;
-
-      if (files.length > 0) {
-        $input.trigger('changefile', files[0]);
-      }
+      setFile(e.originalEvent.dataTransfer.files[0]);
     });
 
     $input.on('change', function () {
-      var selectedFile = this.files[0];
-
-      if (selectedFile) {
-        $input.trigger('changefile', selectedFile);
-      }
+      setFile(this.files[0]);
     });
 
     $input.on('changefile', function (e, file) {

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -30,6 +30,22 @@ $(document).ready(function () {
   $('.upload').each(function () {
     var self = $(this);
 
+    function setCurrentFilename(filename) {
+      $('input', self).nextAll().remove();
+
+      var id = $('input', self).attr('id');
+      var current = $(
+        '<div class="upload-current">' +
+        '<div class="upload-filename"></div>' +
+        '<div class="upload-changer">Not right? ' +
+        '<label>Choose a different file</label> or drag and drop here.' +
+        '</div></div>'
+      );
+      $('label', current).attr('for', id);
+      $('.upload-filename', current).text(filename);
+      self.append(current);
+    }
+
     if (!browserSupportsAdvancedUpload()) {
       self.addClass('degraded');
       return;
@@ -55,9 +71,5 @@ $(document).ready(function () {
         self.trigger('changefile', selectedFile);
       }
     });
-  });
-
-  $('.upload').on('changefile', function(e, file) {
-    console.log("FILE CHANGED", file.name);
   });
 });

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -1,0 +1,63 @@
+/* global $ */
+/* eslint-disable prefer-arrow-callback, func-names */
+
+$(document).ready(function () {
+  // https://css-tricks.com/drag-and-drop-file-uploading/
+  function browserSupportsDragAndDrop() {
+    var div = document.createElement('div');
+    return ('draggable' in div) || ('ondragstart' in div && 'ondrop' in div);
+  }
+
+  function browserSupportsFormData() {
+    return 'FormData' in window;
+  }
+
+  function browserSupportsDataTransfer() {
+    // Browsers that support FileReader support DataTransfer too.
+    return 'FileReader' in window;
+  }
+
+  function browserSupportsAdvancedUpload() {
+    return browserSupportsDragAndDrop() && browserSupportsFormData() &&
+           browserSupportsDataTransfer();
+  }
+
+  function stopAndPrevent(event) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+  $('.upload').each(function () {
+    var self = $(this);
+
+    if (!browserSupportsAdvancedUpload()) {
+      self.addClass('degraded');
+      return;
+    }
+
+    self.on('dragenter', stopAndPrevent);
+    self.on('dragover', stopAndPrevent);
+    self.on('drop', function (e) {
+      stopAndPrevent(e);
+
+      var dt = e.originalEvent.dataTransfer;
+      var files = dt.files;
+
+      if (files.length > 0) {
+        self.trigger('changefile', files[0]);
+      }
+    });
+
+    $('input').on('change', function () {
+      var selectedFile = this.files[0];
+
+      if (selectedFile) {
+        self.trigger('changefile', selectedFile);
+      }
+    });
+  });
+
+  $('.upload').on('changefile', function(e, file) {
+    console.log("FILE CHANGED", file.name);
+  });
+});

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -1,7 +1,7 @@
 /* global $ */
 /* eslint-disable prefer-arrow-callback, func-names */
 
-$(document).ready(function () {
+(function ($) {
   // The following feature detectors are ultimately pulled from Modernizr.
 
   function browserSupportsDragAndDrop() {
@@ -28,8 +28,7 @@ $(document).ready(function () {
     event.preventDefault();
   }
 
-  $('.upload').each(function () {
-    var $el = $(this);
+  function activateUploadWidget($el) {
     var $input = $('input', $el);
     var dragCounter = 0;
     var self = {
@@ -54,10 +53,15 @@ $(document).ready(function () {
       $el.append(current);
     }
 
+    if ($input.data('upload')) {
+      // We've already been uploadified!
+      return;
+    }
+
     $input.data('upload', self);
 
     if (!browserSupportsAdvancedUpload() ||
-        this.hasAttribute('data-force-degradation')) {
+        $el[0].hasAttribute('data-force-degradation')) {
       $el.addClass('degraded');
       self.isDegraded = true;
       return;
@@ -101,5 +105,15 @@ $(document).ready(function () {
       $input.val('');
       setCurrentFilename(file.name);
     });
+  }
+
+  $.fn.uploadify = function() {
+    this.each(function() {
+      activateUploadWidget($(this));
+    });
+  };
+
+  $(document).ready(function() {
+    $('.upload').uploadify();
   });
-});
+})(jQuery);

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -47,7 +47,8 @@ $(document).ready(function () {
       $el.append(current);
     }
 
-    if (!browserSupportsAdvancedUpload()) {
+    if (!browserSupportsAdvancedUpload() ||
+        this.hasAttribute('data-force-degradation')) {
       $el.addClass('degraded');
       return;
     }

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -28,12 +28,13 @@ $(document).ready(function () {
   }
 
   $('.upload').each(function () {
-    var self = $(this);
+    var $el = $(this);
+    var $input = $('input', $el);
 
     function setCurrentFilename(filename) {
-      $('input', self).nextAll().remove();
+      $('input', $el).nextAll().remove();
 
-      var id = $('input', self).attr('id');
+      var id = $('input', $el).attr('id');
       var current = $(
         '<div class="upload-current">' +
         '<div class="upload-filename"></div>' +
@@ -43,33 +44,38 @@ $(document).ready(function () {
       );
       $('label', current).attr('for', id);
       $('.upload-filename', current).text(filename);
-      self.append(current);
+      $el.append(current);
     }
 
     if (!browserSupportsAdvancedUpload()) {
-      self.addClass('degraded');
+      $el.addClass('degraded');
       return;
     }
 
-    self.on('dragenter', stopAndPrevent);
-    self.on('dragover', stopAndPrevent);
-    self.on('drop', function (e) {
+    $el.on('dragenter', stopAndPrevent);
+    $el.on('dragover', stopAndPrevent);
+    $el.on('drop', function (e) {
       stopAndPrevent(e);
 
       var dt = e.originalEvent.dataTransfer;
       var files = dt.files;
 
       if (files.length > 0) {
-        self.trigger('changefile', files[0]);
+        $el.trigger('changefile', files[0]);
       }
     });
 
-    $('input').on('change', function () {
+    $input.on('change', function () {
       var selectedFile = this.files[0];
 
       if (selectedFile) {
-        self.trigger('changefile', selectedFile);
+        $el.trigger('changefile', selectedFile);
       }
+    });
+
+    $el.on('changefile', function (e, file) {
+      $input.val('');
+      setCurrentFilename(file.name);
     });
   });
 });

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -30,6 +30,10 @@ $(document).ready(function () {
   $('.upload').each(function () {
     var $el = $(this);
     var $input = $('input', $el);
+    var self = {
+      isDegraded: false,
+      file: null
+    };
 
     function setCurrentFilename(filename) {
       $('input', $el).nextAll().remove();
@@ -47,9 +51,12 @@ $(document).ready(function () {
       $el.append(current);
     }
 
+    $el.data('upload', self);
+
     if (!browserSupportsAdvancedUpload() ||
         this.hasAttribute('data-force-degradation')) {
       $el.addClass('degraded');
+      self.isDegraded = true;
       return;
     }
 
@@ -75,6 +82,7 @@ $(document).ready(function () {
     });
 
     $el.on('changefile', function (e, file) {
+      self.file = file;
       $input.val('');
       setCurrentFilename(file.name);
     });

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -111,9 +111,12 @@
     this.each(function() {
       activateUploadWidget($(this));
     });
+    return this;
   };
 
   $(document).ready(function() {
     $('.upload').uploadify();
   });
+
+  $.support.advancedUpload = browserSupportsAdvancedUpload();
 })(jQuery);

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -67,6 +67,10 @@
       return;
     }
 
+    // The content of the upload widget will change when the user chooses
+    // a file, so let's make sure screen readers let users know about it.
+    $el.attr('aria-live', 'polite');
+
     $el.on('dragenter', function (e) {
       stopAndPrevent(e);
 

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -2,7 +2,8 @@
 /* eslint-disable prefer-arrow-callback, func-names */
 
 $(document).ready(function () {
-  // https://css-tricks.com/drag-and-drop-file-uploading/
+  // The following feature detectors are ultimately pulled from Modernizr.
+
   function browserSupportsDragAndDrop() {
     var div = document.createElement('div');
     return ('draggable' in div) || ('ondragstart' in div && 'ondrop' in div);

--- a/hourglass_site/static_source/js/common/upload.js
+++ b/hourglass_site/static_source/js/common/upload.js
@@ -31,6 +31,7 @@ $(document).ready(function () {
   $('.upload').each(function () {
     var $el = $(this);
     var $input = $('input', $el);
+    var dragCounter = 0;
     var self = {
       input: $input[0],
       isDegraded: false,
@@ -62,10 +63,22 @@ $(document).ready(function () {
       return;
     }
 
-    $el.on('dragenter', stopAndPrevent);
+    $el.on('dragenter', function (e) {
+      stopAndPrevent(e);
+
+      dragCounter++;
+      $el.addClass('dragged-over');
+    });
+    $el.on('dragleave', function (e) {
+      // http://stackoverflow.com/a/21002544/2422398
+      if (--dragCounter === 0) {
+        $el.removeClass('dragged-over');
+      }
+    });
     $el.on('dragover', stopAndPrevent);
     $el.on('drop', function (e) {
       stopAndPrevent(e);
+      $el.removeClass('dragged-over');
 
       var dt = e.originalEvent.dataTransfer;
       var files = dt.files;

--- a/hourglass_site/static_source/style/main.scss
+++ b/hourglass_site/static_source/style/main.scss
@@ -3,6 +3,7 @@
 @import 'skeleton/normalize';
 @import 'skeleton/skeleton';
 @import 'widgets/steps';
+@import 'widgets/upload';
 
 body {
   font-family: Lato, Helvetica, Arial, sans-serif;
@@ -342,4 +343,8 @@ footer {
 
 fieldset {
   margin: 0;
+}
+
+.no-js .js-only {
+  display: none;
 }

--- a/hourglass_site/static_source/style/widgets/_upload.scss
+++ b/hourglass_site/static_source/style/widgets/_upload.scss
@@ -1,4 +1,5 @@
 .upload {
+  position: relative;
   background: $off-white;
 
   // TODO: We don't have a name for #AEB0B5 in _variables.scss--should we?
@@ -8,7 +9,7 @@
   font-size: 2rem;
   padding: 3em;
 
-  input + label {
+  label {
     // TODO: We don't have a name for #0872B9 in _variables.scss--should we?
     color: #0872B9;
     font-weight: bold;
@@ -16,9 +17,16 @@
     cursor: pointer;
   }
 
-  input:focus + label,
-  input + label:hover {
+  input:focus + div.upload-chooser label,
+  input:focus + div.upload-current label,
+  label:hover {
     text-decoration: underline;
+  }
+
+  .upload-changer {
+    position: absolute;
+    font-size: 1.25rem;
+    bottom: 0.5rem;
   }
 }
 

--- a/hourglass_site/static_source/style/widgets/_upload.scss
+++ b/hourglass_site/static_source/style/widgets/_upload.scss
@@ -4,7 +4,8 @@
   position: relative;
   align-items: center;
   padding: 0 3em;
-  background: $off-white;
+  background-color: $off-white;
+  transition: background-color 0.5s;
 
   // TODO: We don't have a name for #AEB0B5 in _variables.scss--should we?
 
@@ -30,6 +31,10 @@
     position: absolute;
     font-size: 1.25rem;
     bottom: 0.5rem;
+  }
+
+  &.dragged-over {
+    background-color: $white;
   }
 }
 

--- a/hourglass_site/static_source/style/widgets/_upload.scss
+++ b/hourglass_site/static_source/style/widgets/_upload.scss
@@ -1,0 +1,47 @@
+.upload {
+  background: $off-white;
+
+  // TODO: We don't have a name for #AEB0B5 in _variables.scss--should we?
+
+  border: 2px dashed #AEB0B5;
+  color: #AEB0B5;
+  font-size: 2rem;
+  padding: 3em;
+
+  input + label {
+    // TODO: We don't have a name for #0872B9 in _variables.scss--should we?
+    color: #0872B9;
+    font-weight: bold;
+    display: inline;
+    cursor: pointer;
+  }
+
+  input:focus + label,
+  input + label:hover {
+    text-decoration: underline;
+  }
+}
+
+.js .upload:not(.degraded) {
+  input {
+    width: 0.1px;
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+  }
+}
+
+.js .upload.degraded .js-only {
+  display: none;
+}
+
+.no-js .upload, .js .upload.degraded {
+  font-size: 1.5rem;
+  text-align: center;
+
+  label {
+    display: none;
+  }
+}

--- a/hourglass_site/static_source/style/widgets/_upload.scss
+++ b/hourglass_site/static_source/style/widgets/_upload.scss
@@ -18,10 +18,14 @@
     cursor: pointer;
   }
 
-  input:focus + div.upload-chooser label,
-  input:focus + div.upload-current label,
   label:hover {
     text-decoration: underline;
+  }
+
+  input:focus + div.upload-chooser label,
+  input:focus + div.upload-current label {
+    outline: 1px dotted #000;
+    outline: -webkit-focus-ring-color auto 5px;
   }
 
   .upload-changer {

--- a/hourglass_site/static_source/style/widgets/_upload.scss
+++ b/hourglass_site/static_source/style/widgets/_upload.scss
@@ -1,5 +1,9 @@
 .upload {
+  display: flex;
+  height: 6em;
   position: relative;
+  align-items: center;
+  padding: 0 3em;
   background: $off-white;
 
   // TODO: We don't have a name for #AEB0B5 in _variables.scss--should we?
@@ -7,7 +11,6 @@
   border: 2px dashed #AEB0B5;
   color: #AEB0B5;
   font-size: 2rem;
-  padding: 3em;
 
   label {
     // TODO: We don't have a name for #0872B9 in _variables.scss--should we?
@@ -51,6 +54,12 @@
 
   .upload-chooser {
     display: inline;
+  }
+
+  input {
+    // TODO: This is just clearing out the margin-bottom from our standard
+    // CSS, which feels like a hack.
+    margin-bottom: 0;
   }
 
   label {

--- a/hourglass_site/static_source/style/widgets/_upload.scss
+++ b/hourglass_site/static_source/style/widgets/_upload.scss
@@ -7,15 +7,12 @@
   background-color: $off-white;
   transition: background-color 0.5s;
 
-  // TODO: We don't have a name for #AEB0B5 in _variables.scss--should we?
-
-  border: 2px dashed #AEB0B5;
-  color: #AEB0B5;
+  border: 2px dashed $dark-gray;
+  color: $dark-gray;
   font-size: 2rem;
 
   label {
-    // TODO: We don't have a name for #0872B9 in _variables.scss--should we?
-    color: #0872B9;
+    color: $blue;
     font-weight: bold;
     display: inline;
     cursor: pointer;

--- a/hourglass_site/static_source/style/widgets/_upload.scss
+++ b/hourglass_site/static_source/style/widgets/_upload.scss
@@ -49,6 +49,10 @@
   font-size: 1.5rem;
   text-align: center;
 
+  .upload-chooser {
+    display: inline;
+  }
+
   label {
     display: none;
   }

--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-js">
   <head>
     <title>CALC / {% block title %}Home{% endblock %}</title>
     <meta charset="utf-8">
@@ -10,6 +10,7 @@
     <script src="{% static 'hourglass_site/js/vendor/aight.v2.min.js' %}"></script>
     <script src="{% static 'hourglass_site/js/vendor/history.min.js' %}"></script>
     <![endif]-->
+    <script>(function(e,t,n){var r=e.querySelectorAll("html")[0];r.className=r.className.replace(/(^|\s)no-js(\s|$)/,"$1js$2")})(document,window,0);</script>
     <link rel="stylesheet" href="{% static 'hourglass_site/style/built/main.min.css' %}"/>
 
     <![if gt IE 8]>

--- a/hourglass_site/templates/tests.html
+++ b/hourglass_site/templates/tests.html
@@ -20,5 +20,6 @@
     <div id="qunit-fixture"></div>
     <script src="{% static 'hourglass_site/tests/qunit-1.16.0.js' %}"></script>
     <script src="{% static 'hourglass_site/js/tests.js' %}"></script>
+    <script src="{% static 'hourglass_site/js/upload_tests.js' %}"></script>
   </body>
 </html>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -40,7 +40,7 @@
       <input type="file" name="file" id="file">
       <div class="upload-chooser">
         <label for="file">Choose file</label>
-        <span class="js-only">or drag and drop here.</span>
+        <span class="js-only" aria-hidden="true">or drag and drop here.</span>
         XLS, XLSX, or CSV format, please.
       </div>
     </div>
@@ -73,7 +73,7 @@
           <input type="file" name="file2" id="file2">
           <div class="upload-chooser">
             <label for="file2">Choose file</label>
-            <span class="js-only">or drag and drop here.</span>
+            <span class="js-only" aria-hidden="true">or drag and drop here.</span>
             XLS, XLSX, or CSV format, please.
           </div>
         </div>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -43,6 +43,24 @@
   </div>
   {% endexample %}
 
+  <p>
+    Note that the upload widget gracefully degrades to a standard HTML
+    file input if either JS is disabled or any required HTML5 features
+    are unavailable. This behavior can also be forced via the
+    <code>data-force-degradation</code> attribute:
+  </p>
+
+  {% example %}
+  <div class="upload" data-force-degradation>
+    <input type="file" name="file" id="file">
+    <div class="upload-chooser">
+      <label for="file">Choose file</label>
+      <span class="js-only">or drag and drop here.</span>
+      XLS, XLSX, or CSV format, please.
+    </div>
+  </div>
+  {% endexample %}
+
   <h2 id="primary-buttons">Primary Buttons</h2>
 
   <p>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -43,6 +43,8 @@
   </div>
   {% endexample %}
 
+  <h3>Graceful Degradation</h3>
+
   <p>
     Note that the upload widget gracefully degrades to a standard HTML
     file input if either JS is disabled or any required HTML5 features
@@ -67,11 +69,11 @@
   </p>
 
   <div class="styleguide-example">
-  <pre><code class="language-js">var upload = $('.upload:first').data('upload');
+  <pre><code class="language-js">var upload = $('#file').data('upload');
 
 if (upload.isDegraded) {
-  // The upload widget is degraded; we should just let the user submit
-  // the form manually.
+  // The upload widget is degraded; we should assume the browser has
+  // minimal HTML5 support and just let the user submit the form manually.
 } else {
   if (upload.file) {
     // `file` is a HTML5 File object. Upload it via an XMLHttpRequest with

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -52,9 +52,9 @@
 
   {% example %}
   <div class="upload" data-force-degradation>
-    <input type="file" name="file" id="file">
+    <input type="file" name="file2" id="file2">
     <div class="upload-chooser">
-      <label for="file">Choose file</label>
+      <label for="file2">Choose file</label>
       <span class="js-only">or drag and drop here.</span>
       XLS, XLSX, or CSV format, please.
     </div>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -35,7 +35,7 @@
   </p>
 
   {% example %}
-  <form>
+  <form enctype="multipart/form-data">
     <div class="upload">
       <input type="file" name="file" id="file">
       <div class="upload-chooser">

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -23,7 +23,9 @@
 
   <p>
     Our upload widget is implemented using the techniques outlined in
-    <a href="http://tympanus.net/codrops/2015/09/15/styling-customizing-file-inputs-smart-way/">Styling &amp; Customizing File Inputs the Smart Way</a> by Osvaldas Valutis.
+    <a href="http://tympanus.net/codrops/2015/09/15/styling-customizing-file-inputs-smart-way/">Styling &amp; Customizing File Inputs the Smart Way</a> and
+    <a href="https://css-tricks.com/drag-and-drop-file-uploading/">Drag
+    and Drop File Uploading</a> by Osvaldas Valutis.
   </p>
 
   <p>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -47,6 +47,17 @@
   </form>
   {% endexample %}
 
+  <p>
+    When the page is first loaded, all <code>.upload</code> elements are
+    automatically activated. However, if you dynamically inject content
+    into the page via Ajax, you'll want to manually activate them via
+    code like this:
+  </p>
+
+  <div class="styleguide-example">
+    <pre><code class="language-js">$('.my-new-content .upload').uploadify();</code></pre>
+  </div>
+
   <h3>Graceful Degradation</h3>
 
   <p>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -76,7 +76,7 @@
     <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/File">File</a></code>
     object from the upload widget, attach it to
     <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/FormData">FormData</a></code>,
-    and send the form via AJAX.
+    and send the form via Ajax.
   </p>
 
   <p>
@@ -95,7 +95,7 @@ if (upload.isDegraded) {
     data.delete('file');
     data.append('file', upload.file);
 
-    // Now we can send the data via ajax.
+    // Now we can send the data via Ajax.
   } else {
     alert("You need to choose a file!");
   }

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -103,6 +103,12 @@ if (upload.isDegraded) {
 </code></pre>
   </div>
 
+  <p>
+    Furthermore, due to the aforementioned technical limitations, you
+    should not add any HTML5 validation attributes like <code>required</code>
+    to the <code>&lt;input&gt;</code> element either.
+  </p>
+
   <h2 id="primary-buttons">Primary Buttons</h2>
 
   <p>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -61,6 +61,28 @@
   </div>
   {% endexample %}
 
+  <p>
+    You will also need to use the following code to detect whether a file has
+    been chosen:
+  </p>
+
+  <div class="styleguide-example">
+  <pre><code class="language-js">var upload = $('.upload:first').data('upload');
+
+if (upload.isDegraded) {
+  // The upload widget is degraded; we should just let the user submit
+  // the form manually.
+} else {
+  if (upload.file) {
+    // `file` is a HTML5 File object. Upload it via an XMLHttpRequest with
+    // FormData attached.
+  } else {
+    alert("You need to choose a file!");
+  }
+}
+</code></pre>
+  </div>
+
   <h2 id="primary-buttons">Primary Buttons</h2>
 
   <p>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -52,20 +52,22 @@
   <p>
     Note that the upload widget gracefully degrades to a standard HTML
     file input if either JS is disabled or any required HTML5 features
-    are unavailable. This behavior can also be forced via the
-    <code>data-force-degradation</code> attribute:
+    are unavailable:
   </p>
 
-  {% example %}
-  <div class="upload" data-force-degradation>
-    <input type="file" name="file2" id="file2">
-    <div class="upload-chooser">
-      <label for="file2">Choose file</label>
-      <span class="js-only">or drag and drop here.</span>
-      XLS, XLSX, or CSV format, please.
+  <div class="styleguide-example">
+    <div class="rendering">
+      <h3 class="example-heading">Example (no JavaScript)</h3>
+        <div class="upload" data-force-degradation>
+          <input type="file" name="file2" id="file2">
+          <div class="upload-chooser">
+            <label for="file2">Choose file</label>
+            <span class="js-only">or drag and drop here.</span>
+            XLS, XLSX, or CSV format, please.
+          </div>
+        </div>
     </div>
   </div>
-  {% endexample %}
 
   <h3>Form Submission</h3>
 

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -35,14 +35,16 @@
   </p>
 
   {% example %}
-  <div class="upload">
-    <input type="file" name="file" id="file">
-    <div class="upload-chooser">
-      <label for="file">Choose file</label>
-      <span class="js-only">or drag and drop here.</span>
-      XLS, XLSX, or CSV format, please.
+  <form>
+    <div class="upload">
+      <input type="file" name="file" id="file">
+      <div class="upload-chooser">
+        <label for="file">Choose file</label>
+        <span class="js-only">or drag and drop here.</span>
+        XLS, XLSX, or CSV format, please.
+      </div>
     </div>
-  </div>
+  </form>
   {% endexample %}
 
   <h3>Graceful Degradation</h3>
@@ -65,21 +67,35 @@
   </div>
   {% endexample %}
 
+  <h3>Form Submission</h3>
+
   <p>
-    You will also need to use the following code to detect whether a file has
-    been chosen:
+    Due to the technical limitations of HTML5, when the upload widget isn't
+    degraded, you can't rely on the <code>&lt;input&gt;</code> element to
+    contain the user's file; you need to obtain a
+    <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/File">File</a></code>
+    object from the upload widget, attach it to
+    <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/FormData">FormData</a></code>,
+    and send the form via AJAX.
+  </p>
+
+  <p>
+    The following code can be used to accomplish this:
   </p>
 
   <div class="styleguide-example">
-  <pre><code class="language-js">var upload = $('#file').data('upload');
+  <pre><code class="language-js">var data, upload = $('#file').data('upload');
 
 if (upload.isDegraded) {
   // The upload widget is degraded; we should assume the browser has
   // minimal HTML5 support and just let the user submit the form manually.
 } else {
   if (upload.file) {
-    // `file` is a HTML5 File object. Upload it via an XMLHttpRequest with
-    // FormData attached.
+    data = new FormData(upload.input.form);
+    data.delete('file');
+    data.append('file', upload.file);
+
+    // Now we can send the data via ajax.
   } else {
     alert("You need to choose a file!");
   }

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -19,6 +19,28 @@
     <a href="https://standards.usa.gov/">U.S. Web Design Standards (USWDS)</a>.
   </p>
 
+  <h2 id="upload">Upload</h2>
+
+  <p>
+    Our upload widget is implemented using the techniques outlined in
+    <a href="http://tympanus.net/codrops/2015/09/15/styling-customizing-file-inputs-smart-way/">Styling &amp; Customizing File Inputs the Smart Way</a> by Osvaldas Valutis.
+  </p>
+
+  <p>
+    The upload widget's <code>&lt;input&gt;</code> element does not currently
+    support the <code>multiple</code> attribute, however&mdash;it is intended
+    for single-file uploads only.
+  </p>
+
+  {% example %}
+  <div class="upload">
+    <input type="file" name="file" id="file">
+    <label for="file">Choose file</label>
+    <span class="js-only">or drag and drop here.</span>
+    XLS, XLSX, or CSV format, please.
+  </div>
+  {% endexample %}
+
   <h2 id="primary-buttons">Primary Buttons</h2>
 
   <p>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -35,9 +35,11 @@
   {% example %}
   <div class="upload">
     <input type="file" name="file" id="file">
-    <label for="file">Choose file</label>
-    <span class="js-only">or drag and drop here.</span>
-    XLS, XLSX, or CSV format, please.
+    <div class="upload-chooser">
+      <label for="file">Choose file</label>
+      <span class="js-only">or drag and drop here.</span>
+      XLS, XLSX, or CSV format, please.
+    </div>
   </div>
   {% endexample %}
 


### PR DESCRIPTION
**[The current work-in-progress can temporarily be viewed here.](http://54.87.247.188/styleguide/#upload)**

## To Do

- [x] Add unit tests. Maybe take inspiration from [bootstrap's test suite](https://github.com/twbs/bootstrap/tree/master/js/tests#readme)?
- [x] ~~Consider integrating [dragula](https://github.com/bevacqua/dragula).~~ Looks like it'll take some time to understand dragula and integrate it, so I'd rather do that in a separate PR.
- [x] ~~Consider filing a separate PR that fixes #389, and filing this on top of that.~~ Nah, we decided it's fine to rebase #391 atop this.
- [x] Maybe add `aria-hidden="true"` to `<span class="js-only">or drag and drop here.</span>` since it's not really relevant to non-sighted users (I think?).

## Notes

* One frustrating thing about using HTML5 Drag-and-Drop is that once you opt-in to it, you also have to do any file uploads via Ajax, because `<input type="file">` is read-only.  So we'll have to support that out-of-the-box too.
* This widget provides visual feedback when the user is dragging a file over it, it's just currently very subtle (switches background from off-white to white).  We can make it more obvious easily, though.
* The widget works without degradation in IE11 and the latest versions of Chrome, Firefox, Edge, and Safari.
* The widget reads fine on NVDA and VoiceOver. We dynamically add `aria-live="polite"` to the upload widget so that its changes are narrated to the user.
