### PR TITLE
New Relic documentation and config

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -57,6 +57,23 @@ cf uups calc-env -p credentials-staging.json
 cf restage calc-dev
 ```
 
+##### New Relic Environment Variables
+
+To enable integrated New Relic monitoring, cloud.gov-deployed versions of the
+the application are launched with `newrelic-admin` (see [`cf.sh`](/cf.sh)).
+Basic New Relic configuration is done in [`newrelic.ini`](/newrelic.ini), but
+additional settings need to be provided as "real" environment variables, i.e.,
+not through the user provided service. This is because UPS parsing is done in
+the application, but `newrelic-admin` runs outside of the application.
+
+Non-secret environment variables are specified in each deployment's
+associated `manifest-<ENV>.yml` file (see [`manifest-staging.yml`](/manifests/manifest-staging.yml) as an example).
+
+The only secret New Relic environment variable that you will need to manually
+set for each deployment is `NEW_RELIC_LICENSE_KEY`:
+
+`cf set-env <APP_NAME> NEW_RELIC_LICENSE_KEY <LICENSE_KEY>`
+
 #### Staging Server
 
 The staging server updates automatically when changes are merged into the

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -13,3 +13,8 @@ applications:
   command: bash cf.sh
   stack: cflinuxfs2
   timeout: 180
+  env:
+    NEW_RELIC_APP_NAME: "CALC (staging)"
+    NEW_RELIC_CONFIG_FILE: "newrelic.ini"
+    NEW_RELIC_ENV: "staging"
+    NEW_RELIC_LOG: "stdout"

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -5,7 +5,7 @@
 # account in the New Relic service.
 # license_key = foo
 
-# The appplication name. Set this to be the name of your
+# The application name. Set this to be the name of your
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
 # entry on your home dashboard page.

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -9,7 +9,7 @@
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
 # entry on your home dashboard page.
-app_name = CALC (production)
+# app_name = CALC (production)
 
 # When "true", the agent collects performance data about your
 # application and reports this data to the New Relic UI at


### PR DESCRIPTION
- Documented New Relic stuff in `deploy.md`.
- Updated `manifest-staging.yml` to include non-secret New Relic env vars
- Manually deployed to cloud.gov and verified that "CALC (staging)" is showing up in our New Relic console.