### PR TITLE
Add table of contents to style guide

### DIFF
--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -1,3 +1,34 @@
+.styleguide-toc {
+  background-color: #f0f0f0;
+  padding: 1em;
+}
+
+.styleguide-toc li:last-child {
+  margin-bottom: 0;
+}
+
+h3.styleguide-section {
+  border-bottom: 1px solid lightgray;
+}
+
+.styleguide-section a {
+  color: lightgray;
+  text-decoration: none;
+  margin-left: -32px;
+  padding-right: 2px;
+  display: inline-block;
+  opacity: 0;
+  transition: opacity 0.25s;
+}
+
+.styleguide-section:hover a {
+  opacity: 1;
+}
+
+.styleguide-section a:before {
+  content: '#';
+}
+
 .styleguide-example {
   border: 1px solid lightgray;
   margin-bottom: 2.5rem;

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -13,13 +13,14 @@
 <div class="container">
   <h1>CALC Style Guide</h1>
 
+  {% guide %}
   <p>
     CALC uses <a href="http://getskeleton.com/">Skeleton</a> as the foundation
     for its styles, with alterations based on the
     <a href="https://standards.usa.gov/">U.S. Web Design Standards (USWDS)</a>.
   </p>
 
-  <h2 id="upload">Upload</h2>
+  {% guide_section "Upload Widget" %}
 
   <p>
     Our upload widget is implemented using the techniques outlined in
@@ -122,7 +123,7 @@ if (upload.isDegraded) {
     to the <code>&lt;input&gt;</code> element either.
   </p>
 
-  <h2 id="primary-buttons">Primary Buttons</h2>
+  {% guide_section "Primary Buttons" %}
 
   <p>
     The color of primary buttons matches the
@@ -137,7 +138,7 @@ if (upload.isDegraded) {
   <input class="button-primary" type="submit" value="Submit">
   {% endexample %}
 
-  <h2 id="steps">Steps</h2>
+  {% guide_section "Steps Widget" %}
 
   <p>
     The steps widget can be used to visualize the user's progress through a
@@ -175,6 +176,7 @@ if (upload.isDegraded) {
     </li>
   </ol>
   {% endexample %}
+  {% endguide %}
 </div>
 <script src="{% static 'styleguide/vendor/prism.js' %}"></script>
 {% endblock %}

--- a/styleguide/templates/styleguide_section.html
+++ b/styleguide/templates/styleguide_section.html
@@ -1,0 +1,4 @@
+<h3 class="styleguide-section" id="{{ section.id }}">
+  <a href="#{{ section.id }}" aria-hidden="true"></a>
+  {{ section.name }}
+</h3>

--- a/styleguide/templates/styleguide_with_toc.html
+++ b/styleguide/templates/styleguide_with_toc.html
@@ -1,0 +1,7 @@
+<ol class="styleguide-toc">
+  {% for section in sections %}
+    <li><a href="#{{ section.id }}">{{ section.name }}</a></li>
+  {% endfor %}
+</ol>
+
+{{ html }}

--- a/styleguide/templatetags/styleguide.py
+++ b/styleguide/templatetags/styleguide.py
@@ -2,15 +2,72 @@ from textwrap import dedent
 
 from django import template
 from django.utils.safestring import SafeString
+from django.utils.text import slugify
 
 
 register = template.Library()
 
 
 @register.tag
+def guide(parser, token):
+    '''
+    A {% guide %} represents an HTML document composed into sections with a
+    table of contents linking to them.
+    '''
+
+    nodelist = parser.parse(('endguide',))
+    parser.delete_first_token()
+    return GuideNode(nodelist)
+
+
+class GuideNode(template.Node):
+    def __init__(self, nodelist):
+        self.nodelist = nodelist
+
+    def render(self, context):
+        context['_sections'] = []
+
+        html = self.nodelist.render(context)
+
+        t = context.template.engine.get_template('styleguide_with_toc.html')
+
+        result = t.render(template.Context({
+            'html': html,
+            'sections': context['_sections']
+        }))
+
+        del context['_sections']
+
+        return result
+
+
+@register.simple_tag(takes_context=True)
+def guide_section(context, name):
+    '''
+    A section in a guide. It must be used within a {% guide %} tag.
+    '''
+
+    if '_sections' not in context:
+        raise Exception(r'{% guide_section %} tags should only be used '
+                        r'within {% guide%} tags!')
+    section = Section(name)
+    context['_sections'].append(section)
+    t = context.template.engine.get_template('styleguide_section.html')
+
+    return t.render(template.Context({'section': section}))
+
+
+class Section:
+    def __init__(self, name):
+        self.name = name
+        self.id = slugify(name)
+
+
+@register.tag
 def example(parser, token):
     '''
-    An an HTML code snippet example to a style guide.
+    An HTML code snippet example in a style guide. Includes both the
+    rendered version of the example and the source code.
     '''
 
     nodelist = parser.parse(('endexample',))


### PR DESCRIPTION
This gives us a handy table of contents to the style guide, and interactive anchors next to sections that we can use to generate hyperlinks:

> ![toc](https://cloud.githubusercontent.com/assets/124687/16874605/4f7d8e5a-4a68-11e6-969b-0d27163cd3cf.png)

In the above screenshot, the `#` in the margin (across from the "Upload Widget" heading) is being displayed because my cursor is over it; otherwise it doesn't appear. This is based on the interaction model of GitHub READMEs.

It's pretty barebones right now; we can't have subsections (so the subsections of the Upload Widget section are just static headings) and the TOC doesn't stay with you as you scroll along the page or anything, but it's a start! We can upgrade it later as our style guide becomes more complex.
