### PR TITLE
Ignore 'node_modules' in docker volume mount.

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,9 +1,12 @@
 app:
   volumes:
     - .:/calc
+    # http://stackoverflow.com/a/37898591
+    - /calc/node_modules/
   command: python manage.py runserver 0.0.0.0:${DOCKER_EXPOSED_PORT}
 gulp:
   build: .
   volumes:
     - .:/calc
+    - /calc/node_modules/
   command: gulp


### PR DESCRIPTION
This fixes #401.

Now only one annoyance remains when using nodeJS in Docker, which is that [ESLint doesn't respect `NODE_PATH`](https://github.com/benmosher/eslint-plugin-import/issues/142), so it will think that all our `require()` statements are bogus, but whatever.