### PR TITLE
Ignore unresolved imports from eslint for Docker support.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,3 @@
 {
-  "extends": "airbnb-base",
-  "rules": {
-    // Until https://github.com/benmosher/eslint-plugin-import/issues/142 is
-    // fixed, we need to disable the following rule for Docker support.
-    "import/no-unresolved": "off"
-  }
+  "extends": "airbnb-base"
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,8 @@
 {
-  "extends": "airbnb-base"
+  "extends": "airbnb-base",
+  "rules": {
+    // Until https://github.com/benmosher/eslint-plugin-import/issues/142 is
+    // fixed, we need to disable the following rule for Docker support.
+    "import/no-unresolved": "off"
+  }
 }

--- a/meta/management/commands/ultratest.py
+++ b/meta/management/commands/ultratest.py
@@ -3,6 +3,9 @@ import sys
 import subprocess
 import djclick as click
 
+from docker_django_management import IS_RUNNING_IN_DOCKER
+
+
 # This is based on:
 #
 # https://gist.github.com/danielrehn/d2e6f2129e5f853c3166
@@ -58,6 +61,14 @@ def command(verbosity, lintonly):
     '''
     Management command to test and lint everything
     '''
+
+    ESLINT_CMD = 'npm run failable-eslint'
+
+    if IS_RUNNING_IN_DOCKER:
+        # Until https://github.com/benmosher/eslint-plugin-import/issues/142
+        # is fixed, we need to disable the following rule for Docker support.
+        ESLINT_CMD = 'eslint --rule "import/no-unresolved: off" .'
+
     linters = [
         {
             'name': 'flake8',
@@ -65,7 +76,7 @@ def command(verbosity, lintonly):
         },
         {
             'name': 'eslint',
-            'cmd': 'npm run failable-eslint'
+            'cmd': ESLINT_CMD
         },
     ]
 


### PR DESCRIPTION
This is a workaround for https://github.com/benmosher/eslint-plugin-import/issues/142. I figure it's OK to ignore this warning since there's a very high likelihood that our code simply won't run / compile if there are any unresolved imports.