### PR TITLE
[WIP] Add keyboard-focusable tooltips

### DIFF
--- a/hourglass_site/static_source/js/data-capture/focusable-tooltip.js
+++ b/hourglass_site/static_source/js/data-capture/focusable-tooltip.js
@@ -1,0 +1,21 @@
+/* global jQuery, document */
+
+const $ = jQuery;
+
+$.fn.focusableTooltipify = function focusableTooltipify() {
+  this.tooltipster({
+    functionInit: function functionInit() {
+      return $(this).attr('aria-label');
+    },
+  }).on('focus', function onFocus() {
+    $(this).tooltipster('show');
+  }).on('blur', function onBlur() {
+    $(this).tooltipster('hide');
+  });
+
+  return this;
+};
+
+$(document).ready(() => {
+  $('[data-focusable-tooltip]').focusableTooltipify();
+});

--- a/hourglass_site/static_source/js/data-capture/index.js
+++ b/hourglass_site/static_source/js/data-capture/index.js
@@ -3,3 +3,4 @@
 // this is where modules should be `require(...)`'d
 
 require('./upload');
+require('./focusable-tooltip');

--- a/hourglass_site/static_source/style/main.scss
+++ b/hourglass_site/static_source/style/main.scss
@@ -4,6 +4,7 @@
 @import 'skeleton/skeleton';
 @import 'widgets/steps';
 @import 'widgets/upload';
+@import 'vendor/tooltipster';
 
 body {
   font-family: Lato, Helvetica, Arial, sans-serif;

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -20,6 +20,31 @@
     <a href="https://standards.usa.gov/">U.S. Web Design Standards (USWDS)</a>.
   </p>
 
+  {% guide_section "Tooltips" %}
+
+  <p>
+    We use <a href="http://iamceege.github.io/tooltipster/">Tooltipster</a>
+    for tooltips. For tooltips that need to be keyboard-focusable, just add
+    the <code>data-focusable-tooltip</code> attribute.
+  </p>
+
+  {% example %}
+  <a href="javascript:void(0)" data-focusable-tooltip aria-label="I am a tooltip!">
+    What's this?
+  </a>
+  {% endexample %}
+
+  <p>
+    When the page is first loaded, all <code>[data-focusable-tooltip]</code>
+    elements are automatically activated. However, if you dynamically inject
+    content into the page via Ajax, you'll want to manually activate them via
+    code like this:
+  </p>
+
+  <div class="styleguide-example">
+    <pre><code class="language-js">$('.my-new-content [data-focusable-tooltip]').focusableTooltipify();</code></pre>
+  </div>
+
   {% guide_section "Upload Widget" %}
 
   <p>


### PR DESCRIPTION
As per #416 and #421.

![focusable-tooltip](https://cloud.githubusercontent.com/assets/124687/16988912/058c7e36-4e60-11e6-815d-88b32dcc7e94.gif)

## To Do

- [ ] Replace some/all tooltips in the data explorer with this.
- [ ] Add unit tests.
- [ ] Do we want to have the widget itself add some of the attributes upon activation? For example, we could potentially have it add the `href="javascript:void(0)"` programmatically, and perhaps we should just use a `title` attribute and set `aria-label` programmatically too, since `title` will likely gracefully degrade better without JS. I dunno.
- [ ] Rebase this once #390 lands.
