### PR TITLE
Validate upload file type

### DIFF
--- a/hourglass_site/static/hourglass_site/js/upload_tests.js
+++ b/hourglass_site/static/hourglass_site/js/upload_tests.js
@@ -89,9 +89,17 @@
     });
     upload.trigger(evt);
     assert.strictEqual(input.data('upload').file, goodFileExt);
-
   });
 
+  advancedTest("advanced upload allows any file when 'accept' not specified", function(assert) {
+    input.attr('accept', null);
+    var fakeFile = {name: "boop"};
+    var evt = jQuery.Event('drop', {
+     originalEvent: { dataTransfer: { files: [fakeFile] } }
+    });
+    upload.trigger(evt);
+    assert.strictEqual(input.data('upload').file, fakeFile);
+  });
 
   advancedTest("'changefile' event triggered on drop", function(assert) {
     var fakeFile = {name: "boop", type: "application/test"};

--- a/hourglass_site/static/hourglass_site/js/upload_tests.js
+++ b/hourglass_site/static/hourglass_site/js/upload_tests.js
@@ -72,6 +72,7 @@
 
     upload.trigger(evt);
     assert.strictEqual(input.data('upload').file, null);
+    assert.ok(upload.find('.upload-error').length);
   });
 
   advancedTest("advanced upload allows accepted file types", function(assert) {

--- a/hourglass_site/static/hourglass_site/js/upload_tests.js
+++ b/hourglass_site/static/hourglass_site/js/upload_tests.js
@@ -1,7 +1,7 @@
 (function(QUnit, $) {
   var UPLOAD_HTML = (
     '<div class="upload">' +
-    '<input type="file" name="file" id="file">' +
+    '<input type="file" name="file" id="file" accept=".csv, application/test">' +
     '<div class="upload-chooser">' +
     '<label for="file">Choose file or drag and drop here</label>' +
     '</div>' +
@@ -64,8 +64,37 @@
     assert.strictEqual(input.data('upload').file, null);
   });
 
+  advancedTest("advanced upload does not allow non-accepted file types", function(assert) {
+    var badFakeFile = {name: "boop", type: "application/badtest"};
+    var evt = jQuery.Event('drop', {
+      originalEvent: { dataTransfer: { files: [badFakeFile] } }
+    });
+
+    upload.trigger(evt);
+    assert.strictEqual(input.data('upload').file, null);
+  });
+
+  advancedTest("advanced upload allows accepted file types", function(assert) {
+    var goodFileMime = {name: "boop", type: "application/test"};
+    var evt = jQuery.Event('drop', {
+      originalEvent: { dataTransfer: { files: [goodFileMime] } }
+    });
+
+    upload.trigger(evt);
+    assert.strictEqual(input.data('upload').file, goodFileMime);
+
+    var goodFileExt = {name: "boop.csv", type: "whatever"};
+    evt = jQuery.Event('drop', {
+     originalEvent: { dataTransfer: { files: [goodFileExt] } }
+    });
+    upload.trigger(evt);
+    assert.strictEqual(input.data('upload').file, goodFileExt);
+
+  });
+
+
   advancedTest("'changefile' event triggered on drop", function(assert) {
-    var fakeFile = {name: "boop"};
+    var fakeFile = {name: "boop", type: "application/test"};
     var evt = jQuery.Event('drop', {
       originalEvent: { dataTransfer: { files: [fakeFile] } }
     });
@@ -82,7 +111,7 @@
   });
 
   advancedTest("'changefile' sets current file", function(assert) {
-    var fakeFile = {name: "foo.txt"};
+    var fakeFile = {name: "foo.txt", type: "application/test"};
     input.trigger('changefile', fakeFile);
 
     assert.strictEqual(input.data('upload').file, fakeFile);

--- a/hourglass_site/static_source/js/data-capture/upload.js
+++ b/hourglass_site/static_source/js/data-capture/upload.js
@@ -53,7 +53,7 @@ function activateUploadWidget($el) {
     $el.append(current);
   }
 
-  function fileIsValid(file) {
+  function isFileValid(file) {
     const accepts = $input.attr('accept');
     if (!accepts || !accepts.length) {
       // nothing specified, so just return true
@@ -73,7 +73,7 @@ function activateUploadWidget($el) {
   }
 
   function setFile(file) {
-    if (file && fileIsValid(file)) {
+    if (file && isFileValid(file)) {
       $input.trigger('changefile', file);
     }
   }

--- a/hourglass_site/static_source/js/data-capture/upload.js
+++ b/hourglass_site/static_source/js/data-capture/upload.js
@@ -53,6 +53,20 @@ function activateUploadWidget($el) {
     $el.append(current);
   }
 
+  function showInvalidFileMessage() {
+    $('input', $el).nextAll().remove();
+
+    const id = $('input', $el).attr('id');
+    const err = $(
+      '<div class="upload-error">' +
+      '<div class="upload-error-message">Sorry, that type of file is not allowed.</div>' +
+      'Please <label>choose a different file</label> or drag and drop one here.' +
+      '</div></div>'
+    );
+    $('label', err).attr('for', id);
+    $el.append(err);
+  }
+
   function isFileValid(file) {
     const accepts = $input.attr('accept');
     if (!accepts || !accepts.length) {
@@ -73,9 +87,13 @@ function activateUploadWidget($el) {
   }
 
   function setFile(file) {
-    if (file && isFileValid(file)) {
-      $input.trigger('changefile', file);
+    if (!file) { return; }
+    if (!isFileValid(file)) {
+      showInvalidFileMessage();
+      return;
     }
+    // else
+    $input.trigger('changefile', file);
   }
 
   if ($input.data('upload')) {

--- a/hourglass_site/static_source/js/data-capture/upload.js
+++ b/hourglass_site/static_source/js/data-capture/upload.js
@@ -53,8 +53,29 @@ function activateUploadWidget($el) {
     $el.append(current);
   }
 
+  function fileIsValid(file) {
+    const accepts = $input.attr('accept');
+    if (!accepts || !accepts.length) {
+      // nothing specified, so just return true
+      return true;
+    }
+    const acceptsList = accepts.split(',').map((s) => s.trim().toLowerCase());
+    for (const extOrType of acceptsList) {
+      const fileType = file.type.toLowerCase();
+      const fileName = file.name.toLowerCase();
+
+      // test that either the file type or file extension meets
+      // the list of accepted values
+      if (fileType === extOrType || fileName.lastIndexOf(extOrType,
+        fileName.length - extOrType.length) !== -1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   function setFile(file) {
-    if (file) {
+    if (file && fileIsValid(file)) {
       $input.trigger('changefile', file);
     }
   }

--- a/hourglass_site/static_source/js/data-capture/upload.js
+++ b/hourglass_site/static_source/js/data-capture/upload.js
@@ -59,13 +59,11 @@ function activateUploadWidget($el) {
       // nothing specified, so just return true
       return true;
     }
+    const fileType = file.type.toLowerCase();
+    const fileName = file.name.toLowerCase();
     const acceptsList = accepts.split(',').map((s) => s.trim().toLowerCase());
-    for (const extOrType of acceptsList) {
-      const fileType = file.type.toLowerCase();
-      const fileName = file.name.toLowerCase();
-
-      // test that either the file type or file extension meets
-      // the list of accepted values
+    for (let i = 0; i < acceptsList.length; i++) {
+      const extOrType = acceptsList[i];
       if (fileType === extOrType || fileName.lastIndexOf(extOrType,
         fileName.length - extOrType.length) !== -1) {
         return true;

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -35,10 +35,18 @@
     for single-file uploads only.
   </p>
 
+  <p>
+    If the <code>accept</code> attribute on the <code>&lt;input&gt;</code>
+    element is set, then simple file type validation will be done when a file
+    is dropped, or when the user initiates their file chooser via a click.
+    The upload widget's file data will not be set when an invalid file type
+    is dropped.
+  </p>
+
   {% example %}
   <form enctype="multipart/form-data">
     <div class="upload">
-      <input type="file" name="file" id="file" accept=".xlsx,.xls, text/csv">
+      <input type="file" name="file" id="file" accept=".xlsx,.xls,.csv">
       <div class="upload-chooser">
         <label for="file">Choose file</label>
         <span class="js-only" aria-hidden="true">or drag and drop here.</span>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -38,7 +38,7 @@
   {% example %}
   <form enctype="multipart/form-data">
     <div class="upload">
-      <input type="file" name="file" id="file">
+      <input type="file" name="file" id="file" accept=".xlsx,.xls, text/csv">
       <div class="upload-chooser">
         <label for="file">Choose file</label>
         <span class="js-only" aria-hidden="true">or drag and drop here.</span>
@@ -71,7 +71,7 @@
     <div class="rendering">
       <h3 class="example-heading">Example (no JavaScript)</h3>
         <div class="upload" data-force-degradation>
-          <input type="file" name="file2" id="file2">
+          <input type="file" name="file2" id="file2" accept=".xlsx,.xls,.csv">
           <div class="upload-chooser">
             <label for="file2">Choose file</label>
             <span class="js-only" aria-hidden="true">or drag and drop here.</span>


### PR DESCRIPTION
Adds validation to the upload widget via the `accept` attribute on the file `<input>`.  Note that this behavior is not fool-proof, so server-side validation will obviously still need to be done. However, it should be slightly nicer user-wise because 1) their OS file chooser will only show accepted file types (unless they manually override it) and 2) non-accepted files will not populate the widget when dropped.

Another thing I had wanted to do was add a class when a non-accepted file type was dragged over but not yet dropped. Unfortunately the list of file objects doesn't seem to get populated in the drag event, only in the drop event, so that is not possible.

TODO:
- [x] add styleguide documentation of `accept` attribute
- [x] get qunit test to work via py.test. They currently work when viewed in a browser, but not when using the runner for some reason.
- [x] figure out how to show user feedback that an invalid file type was dropped

Here is what it looks like when an invalid file type is dropped or selected:

<img width="953" alt="screen shot 2016-07-20 at 2 13 04 pm" src="https://cloud.githubusercontent.com/assets/697848/16999837/9768f328-4e85-11e6-84c4-3f0c3d8bf426.png">


Closes https://github.com/18F/calc/issues/394