### PR TITLE
fix generation of style sourcemaps so they include the sass sources

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,9 +101,9 @@ gulp.task('clean', () => {
 
 // compile SASS sources
 gulp.task('sass', () => gulp.src(path.join(dirs.src.style, paths.sass))
-  .pipe(sass())
-  .pipe(rename({ suffix: '.min' }))
   .pipe(sourcemaps.init())
+    .pipe(sass().on('error', sass.logError))
+    .pipe(rename({ suffix: '.min' }))
     .pipe(cleancss())
   .pipe(sourcemaps.write('./'))
   .pipe(gulp.dest(dirs.dest.style.built))


### PR DESCRIPTION
Previously, I wasn't including enough of the steps of the SASS->CSS pipeline within the `gulp-sourcemap` transforms. Now when an element is inspected with developer tools, you will be able to see in which `.scss` file a rule is defined.

<img width="182" alt="screen shot 2016-07-22 at 10 25 02 am" src="https://cloud.githubusercontent.com/assets/697848/17061971/996fb4c8-4ff6-11e6-9ab0-41ac51f34539.png">
