### PR TITLE
add bandit scanning to ultratest and travis

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: node_modules,selenium_tests,qunit_tests,api/tests,meta/management/commands,docker_django_management.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 script:
 - phantomjs --version
 - echo "For details on why we're ignoring selenium tests, see https://github.com/18F/calc/issues/330"
+- bandit -r .
 - py.test --ignore=selenium_tests --cov
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ If you are managing https://calc.gsa.gov or any other cloud.gov-based deployment
 
 ## Testing
 
+CALC provides a custom Django management command to run all linters and tests:
+
+```sh
+python manage.py ultratest
+```
+
+### Unit Tests
 To run unit tests:
 
 ```sh
@@ -73,11 +80,17 @@ py.test --cov
 For more information on running only specific tests, see
 [`py.test` Usage and Invocations][pytest].
 
-CALC also provides a custom Django management command to run all linters and unit tests:
+### Security Scans
+
+We use [bandit](https://github.com/openstack/bandit) for security-related static analysis.
+
+To run bandit:
 
 ```sh
-python manage.py ultratest
+bandit -r .
 ```
+
+bandit's configuration is in the [.bandit](/.bandit) file.
 
 ## Using Docker (optional)
 

--- a/meta/management/commands/ultratest.py
+++ b/meta/management/commands/ultratest.py
@@ -82,6 +82,10 @@ def command(verbosity, lintonly):
 
     tests = [
         {
+            'name': 'bandit',
+            'cmd': 'bandit -r .'
+        },
+        {
             'name': 'py.test',
             'cmd': 'py.test'
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bandit>=1.0
 dj-database-url==0.3.0
 django-click==1.2.0
 Django==1.8.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bandit>=1.0
+bandit>=1.0,<2.0
 dj-database-url==0.3.0
 django-click==1.2.0
 Django==1.8.14


### PR DESCRIPTION
This adds `bandit` to both ultratest and to our CI tests. 

Ready for review, @toolness 

Related: https://github.com/18F/calc/pull/405 and https://github.com/18F/Infrastructure/issues/649 (our ATO issue)

