### PR TITLE
add gemnasium badge to readme

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -48,7 +48,10 @@ services:
   category: Code Review
   url: https://www.quantifiedcode.com/app/project/68ae46ef5bd84f7db471f67ba3ca7f03/snapshot/origin:develop:HEAD
   badge: https://www.quantifiedcode.com/api/v1/project/68ae46ef5bd84f7db471f67ba3ca7f03/snapshot/origin:develop:HEAD/badge.svg
-
+- name: Gemnasium
+  category: Code Review
+  url: https://gemnasium.com/github.com/18F/calc
+  badge: https://gemnasium.com/badges/github.com/18F/calc.svg
 
 licenses:
   mirage:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Code Climate](https://codeclimate.com/github/18F/calc/badges/gpa.svg)](https://codeclimate.com/github/18F/calc)
 [![Test Coverage](https://codeclimate.com/github/18F/calc/badges/coverage.svg)](https://codeclimate.com/github/18F/calc/coverage)
 [![Code Issues](https://www.quantifiedcode.com/api/v1/project/68ae46ef5bd84f7db471f67ba3ca7f03/snapshot/origin:develop:HEAD/badge.svg)](https://www.quantifiedcode.com/app/project/68ae46ef5bd84f7db471f67ba3ca7f03/snapshot/origin:develop:HEAD)
+[![Dependency Status](https://gemnasium.com/badges/github.com/18F/calc.svg)](https://gemnasium.com/github.com/18F/calc)
 
 CALC (formerly known as "Hourglass"), which stands for Contracts Awarded Labor Category, is a tool to help contracting personnel estimate their per-hour labor costs for a contract, based on historical pricing information. The tool is live at [https://calc.gsa.gov](https://calc.gsa.gov). You can track our progress on our [trello board](https://trello.com/b/LjXJaVbZ/prices) or file an issue on this repo.
 


### PR DESCRIPTION
Related: https://github.com/18F/calc/pull/405

I don't know how often gemnasium updates, but right now it says our Django version needs to be updated from 1.8.13 to 1.8.14, but we have already made that upgrade in https://github.com/18F/calc/blob/develop/requirements.txt#L3 