### PR TITLE
eslint fail on warnings for ultratest

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "gulp": "gulp",
     "eslint": "eslint . || true",
-    "failable-eslint": "eslint ."
+    "failable-eslint": "eslint --max-warnings 0 ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use `--max-warnings 0` arg so `npm run failable-eslint` fails on warnings

