### PR TITLE
Price list alert markup and styling

### DIFF
--- a/data_capture/templates/data_capture/step.html
+++ b/data_capture/templates/data_capture/step.html
@@ -5,6 +5,8 @@
 
 {% block head %}
 <script src="{% static 'hourglass_site/js/built/data-capture/index.min.js' %}"></script>
+<link rel="stylesheet" href="{% static 'hourglass_site/style/built/data_capture.min.css' %}">
+
 <style>
 /* TODO: Django's default form rendering uses a <ul class="errorlist">
    for errors, and <span class="helptext"> for help text. We should either

--- a/data_capture/templates/data_capture/step_2.html
+++ b/data_capture/templates/data_capture/step_2.html
@@ -15,45 +15,50 @@
 {% endif %}
 
 {% if gleaned_data.invalid_rows %}
+<div class="alert alert-error" role="alert">
 
-<div style="background: #F9DEDE; padding: 1em; margin-bottom: 1em">
+  {% with rows=gleaned_data.invalid_rows %}
 
-{% with rows=gleaned_data.invalid_rows %}
+  {% with total=rows|length %}
+  <h3>{{ total }} row{{ total|pluralize:" has,s have" }} errors</h3>
 
-{% with total=rows|length %}
-<h3>{{ total }} row{{ total|pluralize:" has,s have" }} errors</h3>
+  <p>
+    The row{{ total|pluralize }} below appear{{ total|pluralize:"s," }} to be
+    invalid and <strong>will be discarded</strong> when you upload your
+    price list.
+    If you'd like, you may correct {{ total|pluralize:"this row,these rows" }}
+    in your original spreadsheet and try uploading it again.
+  </p>
+  {% endwith %}
 
-<p>
-  The affected row{{ total|pluralize }} will be discarded and
-  not uploaded to CALC.
-</p>
-{% endwith %}
+  <table>
+    <thead>
+      <tr>
+      {% for field in rows.0 %}
+        <th>{{ field.label }}</th>
+      {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
 
-<table>
-  <tr style="background: inherit">
-  {% for field in rows.0 %}
-    <th style="font-weight: bold">{{ field.label }}</th>
-  {% endfor %}
-  </tr>
-  {% for row in rows %}
+        {# TODO: Should we print out non-field errors here? #}
 
-  {# TODO: Should we print out non-field errors here? #}
+        <tr>
+        {% for field in row %}
+          <td class="{% if field.errors %} error {% endif %}">
+            {{ field.errors }}
 
-  <tr style="background: inherit">
-  {% for field in row %}
-    <td style="vertical-align: bottom">
-      {{ field.errors }}
+            {{ field.value }}
+          </td>
+        {% endfor %}
+        </tr>
 
-      {{ field.value }}
-    </td>
-  {% endfor %}
-  </tr>
-
-  {% endfor %}
-</table>
-
-{% endwith %}
-
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{% url 'data_capture:step_1' %}" class="button">Upload revised list</a>
+  {% endwith %}
 </div>
 {% endif %}
 


### PR DESCRIPTION
Part of #454 - This removes the inline styles and matches the styleguide markup for the price list errors found during upload. It also brings in `data_capture.min.css` to the `step.html` template.

<img width="943" alt="screen shot 2016-07-27 at 11 14 22 am" src="https://cloud.githubusercontent.com/assets/697848/17183011/51abcc46-53eb-11e6-96ae-85fdfd3d1634.png">

It still shows the red box'd errors in the table cells with errors. @hbillings: how should we display these error messages, via a tooltip perhaps?