### PR TITLE
Use slim header for data capture.

### DIFF
--- a/data_capture/templates/data_capture/step.html
+++ b/data_capture/templates/data_capture/step.html
@@ -33,6 +33,9 @@
 </style>
 {% endblock %}
 
+{# Eliminate the header extension so we have a "slim" header. #}
+{% block header_extension %}{% endblock %}
+
 {% block body %}
 
 <div class="container">

--- a/hourglass_site/static_source/style/components/_header.scss
+++ b/hourglass_site/static_source/style/components/_header.scss
@@ -34,6 +34,9 @@ header {
   background-repeat: repeat;
   background-size: auto 100%;
 }
+.base-header {
+  margin-bottom: .6em;
+}
 .logo {
   display: inline-block;
   width:140px;
@@ -43,7 +46,6 @@ header {
   font-size: 2.2em;
   font-weight: 400;
   margin-bottom: .3em;
-  margin-top: .6em;
 }
 .description-secondary {
   color: rgba(255,255,255,.6);

--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -41,19 +41,19 @@
     <header>
       <div class="container">
         <div class="base-header">
-        <a href="{% url 'index' %}"><img class="logo" src="{% static 'hourglass_site/images/calc_logo.png' %}" alt="CALC: Contract Awarded Labor Category Tool"></a>
-        <nav>
-          <ul>
-            <li><a href="{% url 'about' %}">About this tool</a></li>
-            {% if user.is_authenticated %}
-              <li><a href="{% url 'data_capture:step_1' %}">Add price data</a></li>
-              {% if user.is_staff %}
-              <li><a href="{% url 'admin:index' %}">Site administration</a></li>
+          <a href="{% url 'index' %}"><img class="logo" src="{% static 'hourglass_site/images/calc_logo.png' %}" alt="CALC: Contract Awarded Labor Category Tool"></a>
+          <nav>
+            <ul>
+              <li><a href="{% url 'about' %}">About this tool</a></li>
+              {% if user.is_authenticated %}
+                <li><a href="{% url 'data_capture:step_1' %}">Add price data</a></li>
+                {% if user.is_staff %}
+                <li><a href="{% url 'admin:index' %}">Site administration</a></li>
+                {% endif %}
+                <li><a href="{% url 'uaa_client:logout' %}">Log out {{ user.email }}</a></li>
               {% endif %}
-              <li><a href="{% url 'uaa_client:logout' %}">Log out {{ user.email }}</a></li>
-            {% endif %}
-          </ul>
-        </nav>
+            </ul>
+          </nav>
         </div>
 
 {% block header_extension %}

--- a/hourglass_site/templates/base.html
+++ b/hourglass_site/templates/base.html
@@ -40,6 +40,7 @@
 
     <header>
       <div class="container">
+        <div class="base-header">
         <a href="{% url 'index' %}"><img class="logo" src="{% static 'hourglass_site/images/calc_logo.png' %}" alt="CALC: Contract Awarded Labor Category Tool"></a>
         <nav>
           <ul>
@@ -53,7 +54,9 @@
             {% endif %}
           </ul>
         </nav>
+        </div>
 
+{% block header_extension %}
       <div class="row">
         <div class="twelve columns">
           <h1 class="description-main">Search awarded ceiling rates for labor categories</h1>
@@ -84,6 +87,7 @@
         </div>
       </div>
 
+{% endblock %}
 
       </div>
     </header>


### PR DESCRIPTION
This fixes #383 by enclosing the non-slim part of the header in a `header_extension` block, which allows child templates to redefine it as empty (or, alternatively, add their own custom extension content). It also shuffles around some CSS so that there's a decent bottom margin on the slim version of the header.

Here is the normal header:

> ![fattington-header](https://cloud.githubusercontent.com/assets/124687/17247243/e50e8102-555f-11e6-94fc-a69f32086354.png)

And here's the slim one:

> ![slim-header](https://cloud.githubusercontent.com/assets/124687/17247245/e8cd6826-555f-11e6-9eb4-8325599f4dbf.png)

In the future we can potentially reverse things so that the header is actually slim by default, and the index and about pages are the only ones that include the big version, but I wanted to make as few changes as possible to the legacy codebase for now.