### PR TITLE
Fix multi-word autocomplete

### DIFF
--- a/api/tests/test_doctests.py
+++ b/api/tests/test_doctests.py
@@ -1,4 +1,3 @@
-import unittest
 import doctest
 
 from .. import views

--- a/api/tests/test_doctests.py
+++ b/api/tests/test_doctests.py
@@ -1,0 +1,9 @@
+import unittest
+import doctest
+
+from .. import views
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(views))
+    return tests

--- a/api/views.py
+++ b/api/views.py
@@ -15,7 +15,18 @@ import csv
 
 
 def convert_to_tsquery(query):
-    """ converts multi-word phrases into AND boolean queries for postgresql """
+    """
+    Converts multi-word phrases into AND boolean queries for postgresql.
+
+    Examples:
+
+        >>> convert_to_tsquery('interpretation')
+        'interpretation:*'
+
+        >>> convert_to_tsquery('interpretation services')
+        'interpretation:* & services:*'
+    """
+
     # remove all non-alphanumeric or whitespace chars
     pattern = re.compile('[^a-zA-Z\s]')
     query = pattern.sub('', query)

--- a/hourglass_site/static/hourglass_site/js/hourglass_tests.js
+++ b/hourglass_site/static/hourglass_site/js/hourglass_tests.js
@@ -3,6 +3,16 @@ var test = QUnit.test,
 
 module("hourglass");
 
+test("getLastCommaSeparatedTerm()", function(assert) {
+  var get = hourglass.getLastCommaSeparatedTerm;
+
+  assert.equal(get("foo"), "foo");
+  assert.equal(get("foo,bar"), "bar");
+  assert.equal(get("foo, bar"), "bar");
+  assert.equal(get("foo , bar"), "bar");
+  assert.equal(get("foo bar"), "foo bar");
+});
+
 test("extend()", function(assert) {
   var extend = hourglass.extend;
   assert.deepEqual(

--- a/hourglass_site/static_source/js/common/hourglass.js
+++ b/hourglass_site/static_source/js/common/hourglass.js
@@ -136,6 +136,12 @@
   hourglass.noop = function noop() {
   };
 
+  hourglass.getLastCommaSeparatedTerm = function getLastCST(term) {
+    var pieces = term.split(/\s*,\s*/);
+
+    return pieces[pieces.length-1];
+  };
+
   // export hourglass.extend()
   hourglass.extend = extend;
 

--- a/hourglass_site/static_source/js/data-explorer/index.js
+++ b/hourglass_site/static_source/js/data-explorer/index.js
@@ -128,9 +128,7 @@
         // save inputted search terms for display later
         searchTerms = term;
 
-        // search only last comma separated term
-        var pieces = term.split(/[\s,]+/);
-        term = pieces[pieces.length-1];
+        terms = hourglass.getLastCommaSeparatedTerm(term);
 
         if (autoCompReq) {autoCompReq.abort();}
         var data = form.getData();

--- a/hourglass_site/static_source/js/data-explorer/index.js
+++ b/hourglass_site/static_source/js/data-explorer/index.js
@@ -128,7 +128,7 @@
         // save inputted search terms for display later
         searchTerms = term;
 
-        terms = hourglass.getLastCommaSeparatedTerm(term);
+        term = hourglass.getLastCommaSeparatedTerm(term);
 
         if (autoCompReq) {autoCompReq.abort();}
         var data = form.getData();


### PR DESCRIPTION
This fixes #458.

At first I thought that the problem was in `convert_to_tsquery()`, so I started by writing a doctest for it, but it turned out to work fine.  I left the doctest in, though, since I think it helps improve readability of the code.
