### PR TITLE
Add support for django debug toolbar

### DIFF
--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
+    'debug_toolbar',
 
     'hourglass_site',
 
@@ -69,6 +70,7 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'hourglass.middleware.DebugOnlyDebugToolbarMiddleware',
     'hourglass.middleware.ComplianceMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -240,3 +242,9 @@ if not UAA_CLIENT_SECRET:
         UAA_AUTH_URL = UAA_TOKEN_URL = 'fake:'
     else:
         raise Exception('UAA_CLIENT_SECRET must be defined in production.')
+
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
+
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': 'hourglass.middleware.show_toolbar',
+}

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -30,9 +30,12 @@ urlpatterns = patterns(
 )
 
 if settings.DEBUG:
+    import debug_toolbar
     import fake_uaa_provider.urls
 
-    urlpatterns += patterns('',
-                            url(r'^', include(fake_uaa_provider.urls,
-                                              namespace='fake_uaa_provider')),
-                            )
+    urlpatterns += patterns(
+        '',
+        url(r'^', include(fake_uaa_provider.urls,
+            namespace='fake_uaa_provider')),
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ requests==2.10.0
 python-dotenv==0.5.1
 httmock==1.2.5
 xlrd==1.0.0
+django-debug-toolbar==1.5


### PR DESCRIPTION
This gives us the fancy [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/stable/index.html) when `DEBUG` is `True`.

> ![screen shot 2016-07-29 at 2 12 17 pm](https://cloud.githubusercontent.com/assets/124687/17258773/8113b366-5596-11e6-9540-8c6d5d5dac30.png)


The one major item of note here is that we *always* show the toolbar when `DEBUG` is `True`, rather than relying on the toolbar's default configuration of consulting `INTERNAL_IPS`, which makes using the toolbar under Docker and e.g. on a tablet over one's local wifi particularly cumbersome.

If this seems too insecure even for debug mode, I can modify the behavior so that it only displays the toolbar if it's running in Docker *or* the client is listed in `INTERNAL_IPS`. This would still make it hard to use the debug toolbar via other virtualization solutions, though, and it'd also make it harder to use it from other devices on one's own wifi network.