### PR TITLE
remove csslint from codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,8 +18,6 @@ engines:
     checks:
       import/no-unresolved:
         enabled: false
-  csslint:
-    enabled: true
   pep8:
     enabled: true
 ratings:


### PR DESCRIPTION
We aren't writing CSS any more, just SCSS, so CodeClimate's csslint just produces noise on vendor files mostly.