### PR TITLE
Inspired by wds mods

### DIFF
--- a/hourglass_site/static_source/js/data-capture/index.js
+++ b/hourglass_site/static_source/js/data-capture/index.js
@@ -4,5 +4,7 @@
 
 require('babel-polyfill/dist/polyfill.js');
 require('jquery-tablesort');
+
+require('./tablesort');
 require('./upload');
 require('./step_1');

--- a/hourglass_site/static_source/js/data-capture/tablesort.js
+++ b/hourglass_site/static_source/js/data-capture/tablesort.js
@@ -3,31 +3,18 @@
 const $ = jQuery;
 const sortableTables = document.querySelectorAll('.table-sortable');
 
-function sortInts(intCol) {
-  $(intCol).data('sortBy', (th, td) => parseInt(td.text(), 10));
-}
-
-function sortFloats(floatCol) {
-  $(floatCol).data('sortBy', (th, td) => parseFloat(td.text()));
-}
-
 $(document).ready(() => {
   for (const table of sortableTables) {
-    $(table).tablesort();
+    const $table = $(table);
+    $table.tablesort();
 
     // Floats should be sorted as numbers, not strings
-    [].forEach.call(table.getElementsByClassName('js-float'), function sort() {
-      sortFloats(this);
-    });
+    $('.js-float', $table).data('sortBy', (th, td) => parseFloat(td.text()));
 
     // Don't sort ints as strings, either
-    [].forEach.call(table.getElementsByClassName('js-int'), function sort() {
-      sortInts(this);
-    });
+    $('.js-int', $table).data('sortBy', (th, td) => parseInt(td.text(), 10));
 
     // Sort by default column, if present
-    [].forEach.call(table.getElementsByClassName('js-default-sort'), () => {
-      $(table).data('tablesort').sort($('.js-default-sort'));
-    });
+    $table.data('tablesort').sort($('.js-default-sort', $table));
   }
 });

--- a/hourglass_site/static_source/js/data-capture/tablesort.js
+++ b/hourglass_site/static_source/js/data-capture/tablesort.js
@@ -1,0 +1,33 @@
+/* global jQuery, document */
+
+const $ = jQuery;
+const sortableTables = document.querySelectorAll('.table-sortable');
+
+function sortInts(intCol) {
+  $(intCol).data('sortBy', (th, td) => parseInt(td.text(), 10));
+}
+
+function sortFloats(floatCol) {
+  $(floatCol).data('sortBy', (th, td) => parseFloat(td.text()));
+}
+
+$(document).ready(() => {
+  for (const table of sortableTables) {
+    $(table).tablesort();
+
+    // Floats should be sorted as numbers, not strings
+    [].forEach.call(table.getElementsByClassName('js-float'), function sort() {
+      sortFloats(this);
+    });
+
+    // Don't sort ints as strings, either
+    [].forEach.call(table.getElementsByClassName('js-int'), function sort() {
+      sortInts(this);
+    });
+
+    // Sort by default column, if present
+    [].forEach.call(table.getElementsByClassName('js-default-sort'), () => {
+      $(table).data('tablesort').sort($('.js-default-sort'));
+    });
+  }
+});

--- a/hourglass_site/static_source/style/components/_alerts.scss
+++ b/hourglass_site/static_source/style/components/_alerts.scss
@@ -1,2 +1,2 @@
-@import ('..uswds/alerts');
+@import '../uswds/alerts';
 //TODO: rewrite alerts so the new styles are here

--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -14,7 +14,7 @@ h3.styleguide-section {
 .styleguide-section a {
   color: lightgray;
   text-decoration: none;
-  margin-left: -32px;
+  margin-left: -16px;
   padding-right: 2px;
   display: inline-block;
   opacity: 0;

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -416,42 +416,4 @@ if (upload.isDegraded) {
 </div>
 <script src="{% static 'styleguide/vendor/prism.js' %}"></script>
 <script src="{% static 'hourglass_site/js/built/data-capture/index.min.js' %}"></script>
-<script>
-  //TODO: Figure out where this should actually live
-  var $ = jQuery;
-  var sortableTables = document.querySelectorAll('.table-sortable');
-
-  for (var table of sortableTables) {
-    $(table).tablesort();
-
-    // Floats should be sorted as numbers, not strings
-    [].forEach.call(table.getElementsByClassName('js-float'), function(el) {
-      sortFloats(this);
-    });
-
-    // Don't sort ints as strings, either
-    [].forEach.call(table.getElementsByClassName('js-int'), function(el) {
-      sortInts(this);
-    });
-
-    // Sort by default column, if present
-    [].forEach.call(table.getElementsByClassName('js-default-sort'), function(el) {
-      $(table).data('tablesort').sort($('.js-default-sort'));
-    });
-
-  }
-
-  function sortInts(intCol) {
-    $(intCol).data('sortBy', function(th, td, tablesort) {
-      return parseInt(td.text());
-    });
-  }
-
-  function sortFloats(floatCol){
-    $(floatCol).data('sortBy', function(th, td, tablesort) {
-      return parseFloat(td.text());
-    });
-  }
-
-</script>
 {% endblock %}


### PR DESCRIPTION
I went ahead and made some minor changes to @hbillings original PR #452.

- Fix typo'd `@import`
- Adjust styleguide css to better align h3 headings with their border-bottom
- Extract tablesorting script from styleguide.html to its own file as part of data-capture js bundle. Also ES6ify it and bring it up to our eslint standard. No logic or other changes made.
- Fix table sort handler attachment.


Fixed now: ~~I think there is something not quite right about the sorting logic, or perhaps the way it is attached to the tables.~~

<img width="79" alt="screen shot 2016-08-01 at 8 49 00 am" src="https://cloud.githubusercontent.com/assets/697848/17296041/d6b5db70-57c4-11e6-8136-ec22301339dd.png"> <img width="80" alt="screen shot 2016-08-01 at 8 49 05 am" src="https://cloud.githubusercontent.com/assets/697848/17296045/db49b968-57c4-11e6-9d97-78e46d2d61ed.png">

~~Notice the incorrect placement of `115.99` in relation to the others. It looks like it is still using a string comparison. I'll try to fix that in another issue/PR.~~
