### PR TITLE
improve Step 2 valid rows table markup

### DIFF
--- a/data_capture/templates/data_capture/step_2.html
+++ b/data_capture/templates/data_capture/step_2.html
@@ -73,18 +73,22 @@
 {% endwith %}
 
 <table>
-  <tr>
-  {% for field in rows.0 %}
-    <th style="font-weight: bold">{{ field.label }}</th>
-  {% endfor %}
-  </tr>
+  <thead>
+    <tr>
+    {% for field in rows.0 %}
+      <th>{{ field.label }}</th>
+    {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
   {% for row in rows %}
-  <tr>
-  {% for field in row %}
-    <td>{{ field.value }}</td>
+    <tr>
+    {% for field in row %}
+      <td>{{ field.value }}</td>
+    {% endfor %}
+    </tr>
   {% endfor %}
-  </tr>
-  {% endfor %}
+  </tbody>
 </table>
 
 {% endwith %}


### PR DESCRIPTION
fixes #493

Now the valid price list rows table in Step 2 looks like

<img width="966" alt="screen shot 2016-08-01 at 11 35 09 am" src="https://cloud.githubusercontent.com/assets/697848/17301344/19a6c0e0-57dc-11e6-9771-93fc75624056.png">
