### PR TITLE
Low-impact docker/requirements fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ RUN ln -s /usr/bin/python2.7.distrib /usr/bin/python && \
   curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
   rm /usr/bin/python
 
+# Note that we want postgresql-client so 'manage.py dbshell' works.
 RUN apt-get update && \
-  apt-get install -y nodejs
+  apt-get install -y nodejs postgresql-client
 
 COPY package.json /node/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,13 @@ RUN \
   mv /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/ /srv/var/phantomjs && \
   ln -s /srv/var/phantomjs/bin/phantomjs /usr/bin/phantomjs
 
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
+# As of 2016/08/02, this requires the Debian distributed version of
+# python 2.7 to be located at /usr/bin/python. However, the official
+# python 3 docker image we're using renames it, so we're going to
+# temporarily rename it *back* so that this command succeeds. Oy.
+RUN ln -s /usr/bin/python2.7.distrib /usr/bin/python && \
+  curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
+  rm /usr/bin/python
 
 RUN apt-get update && \
   apt-get install -y nodejs

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,11 @@ dj-database-url==0.3.0
 django-click==1.2.0
 Django==1.8.14
 django-cors-headers==1.1.0
-django-nose==1.4.3
 djangorestframework==3.3.3
 djorm-ext-pgfulltext==0.9.3
 model-mommy==1.2.6
 flake8==2.6.0
 newrelic==2.66.0.49
-nose==1.3.7
 psycopg2==2.5.5
 pytest==2.9.2
 pytest-cov==2.2.1


### PR DESCRIPTION
A few quick fixes:

* Fix #510 so the Dockerfile builds from scratch again
* Fix #515 so `manage.py dbshell` works
* Fix #517 to get rid of the unused `nose` and `django-nose` python packages
