### PR TITLE
Add a test suite for step_1

### DIFF
--- a/frontend/source/js/data-capture/step_1.js
+++ b/frontend/source/js/data-capture/step_1.js
@@ -29,6 +29,10 @@ function bindForm() {
   $upload.uploadify();
 
   const upload = $fileInput.data('upload');
+  const self = { form, upload, $upload, $fileInput, $submit };
+
+  // This is mostly just for test suites to use.
+  $('form').data('step1-form', self);
 
   // Disable the submit button until a file is selected.
   $submit.prop('disabled', true);
@@ -102,11 +106,12 @@ function bindForm() {
     }
   });
 
-  return { form, upload, $upload, $fileInput, $submit };
+  return self;
 }
 
 $(bindForm);
 
+exports.getForm = getForm;
 exports.bindForm = bindForm;
 
 window.testingExports__step_1 = exports;

--- a/frontend/source/js/data-capture/step_1.js
+++ b/frontend/source/js/data-capture/step_1.js
@@ -2,6 +2,16 @@
 
 const $ = jQuery;
 
+let delegate = {
+  redirect(url) {
+    window.location = url;
+  },
+  alert(msg) {
+    // TODO: Be more user-friendly here.
+    window.alert(msg);   // eslint-disable-line no-alert
+  },
+};
+
 function getForm() {
   return $('[data-step1-form]')[0];
 }
@@ -88,20 +98,14 @@ function bindForm() {
           replaceForm(data.form_html);
           bindForm();
         } else if (data.redirect_url) {
-          window.location = data.redirect_url;
+          delegate.redirect(data.redirect_url);
         } else {
-          // TODO: Be more user-friendly here.
-          window.alert( // eslint-disable-line no-alert
-            `Invalid server response: ${data}`
-          );
+          delegate.alert(`Invalid server response: ${data}`);
         }
       });
 
       req.fail(() => {
-        // TODO: Be more user-friendly here.
-        window.alert( // eslint-disable-line no-alert
-          'An error occurred when submitting your data.'
-        );
+        delegate.alert('An error occurred when submitting your data.');
       });
     }
   });
@@ -111,6 +115,10 @@ function bindForm() {
 
 $(bindForm);
 
+exports.setDelegate = newDelegate => {
+  delegate = newDelegate;
+  return delegate;
+};
 exports.getForm = getForm;
 exports.bindForm = bindForm;
 

--- a/frontend/source/js/data-capture/step_1.js
+++ b/frontend/source/js/data-capture/step_1.js
@@ -23,10 +23,12 @@ function bindForm() {
 
   if (!form) {
     // We're not on step 1.
-    return;
+    return null;
   }
 
   $upload.uploadify();
+
+  const upload = $fileInput.data('upload');
 
   // Disable the submit button until a file is selected.
   $submit.prop('disabled', true);
@@ -41,8 +43,6 @@ function bindForm() {
   $fileInput.on('change', enableSubmit);
 
   $(form).on('submit', (e) => {
-    const upload = $fileInput.data('upload');
-
     if (upload.isDegraded) {
       // The upload widget is degraded; we should assume the browser has
       // minimal HTML5 support and just let the user submit the form manually.
@@ -101,6 +101,12 @@ function bindForm() {
       });
     }
   });
+
+  return { form, upload, $upload, $fileInput, $submit };
 }
 
 $(bindForm);
+
+exports.bindForm = bindForm;
+
+window.testingExports__step_1 = exports;

--- a/frontend/source/js/tests/index.js
+++ b/frontend/source/js/tests/index.js
@@ -1,2 +1,2 @@
-
+require('./step_1_tests');
 require('./upload_tests');

--- a/frontend/source/js/tests/step_1_tests.js
+++ b/frontend/source/js/tests/step_1_tests.js
@@ -1,0 +1,57 @@
+/* global QUnit $ test window */
+
+const step1 = window.testingExports__step_1;
+
+QUnit.module('step_1', {
+  beforeEach() {
+    $('[data-step1-form]').remove();
+  },
+  afterEach() {
+    $('[data-step1-form]').remove();
+  },
+});
+
+const FORM_HTML = `
+  <form enctype="multipart/form-data" method="post"
+        data-step1-form
+        action="/post-stuff">
+    <input type="text" name="foo" value="bar">
+    <div class="upload">
+      <input type="file" name="file"
+             id="id_file" accept=".xlsx,.xls,.csv">
+      <div class="upload-chooser">
+        <label for="id_file">Choose file</label>
+        <span class="js-only" aria-hidden="true">or drag+drop here.</span>
+        XLS, XLSX, or CSV format, please.
+      </div>
+    </div>
+    <button type="submit">submit</button>
+  </form>
+`;
+
+function addForm() {
+  $('<div></div>').html(FORM_HTML).appendTo('body').hide();
+  return step1.bindForm();
+}
+
+test('bindForm() returns null when data-step1-form not on page', assert => {
+  assert.strictEqual(step1.bindForm(), null);
+});
+
+test('submit btn disabled on startup', assert => {
+  assert.ok(addForm().$submit.prop('disabled'));
+});
+
+test('submit btn enabled on file input change', assert => {
+  const s = addForm();
+
+  s.$fileInput.trigger('change');
+  assert.ok(!s.$submit.prop('disabled'), 'submit button is enabled');
+});
+
+test('submit btn enabled on upload widget changefile', assert => {
+  const s = addForm();
+
+  s.$fileInput.trigger('changefile', { name: 'baz' });
+  assert.ok(!s.$submit.prop('disabled'), 'submit button is enabled');
+});

--- a/frontend/source/js/tests/step_1_tests.js
+++ b/frontend/source/js/tests/step_1_tests.js
@@ -1,35 +1,64 @@
 /* global QUnit $ test window */
 
+const urlParse = require('url').parse;
+const sinon = require('sinon');
+
 const step1 = window.testingExports__step_1;
+
+let server;
 
 QUnit.module('step_1', {
   beforeEach() {
+    server = sinon.fakeServer.create();
     $('[data-step1-form]').remove();
   },
   afterEach() {
     $('[data-step1-form]').remove();
+    server.restore();
   },
 });
 
-const FORM_HTML = `
-  <form enctype="multipart/form-data" method="post"
-        data-step1-form
-        action="/post-stuff">
-    <input type="text" name="foo" value="bar">
-    <div class="upload">
-      <input type="file" name="file"
-             id="id_file" accept=".xlsx,.xls,.csv">
-      <div class="upload-chooser">
-        <label for="id_file">Choose file</label>
-        <span class="js-only" aria-hidden="true">or drag+drop here.</span>
-        XLS, XLSX, or CSV format, please.
-      </div>
-    </div>
-    <button type="submit">submit</button>
-  </form>
-`;
+function createBlob(content) {
+  if (typeof(window.Blob) === 'function') {
+    return new window.Blob([content]);
+  }
 
-function addForm() {
+  // We're in PhantomJS.
+  const builder = new window.WebKitBlobBuilder();
+  builder.append(content);
+  return builder.getBlob();
+}
+
+function advancedTest(name, cb) {
+  if (!$.support.advancedUpload) {
+    return QUnit.skip(name, cb);
+  }
+  return QUnit.test(name, cb);
+}
+
+function addForm(extraOptions) {
+  const options = Object.assign({
+    uploadAttrs: '',
+  }, extraOptions || {});
+
+  const FORM_HTML = `
+    <form enctype="multipart/form-data" method="post"
+          data-step1-form
+          action="/post-stuff">
+      <input type="text" name="foo" value="bar">
+      <div class="upload" ${options.uploadAttrs}>
+        <input type="file" name="file"
+               id="id_file" accept=".xlsx,.xls,.csv">
+        <div class="upload-chooser">
+          <label for="id_file">Choose file</label>
+          <span class="js-only" aria-hidden="true">or drag+drop here.</span>
+          XLS, XLSX, or CSV format, please.
+        </div>
+      </div>
+      <button type="submit">submit</button>
+    </form>
+  `;
+
   $('<div></div>').html(FORM_HTML).appendTo('body').hide();
   return step1.bindForm();
 }
@@ -54,4 +83,40 @@ test('submit btn enabled on upload widget changefile', assert => {
 
   s.$fileInput.trigger('changefile', { name: 'baz' });
   assert.ok(!s.$submit.prop('disabled'), 'submit button is enabled');
+});
+
+test('degraded input does not cancel form submission', assert => {
+  const s = addForm({ uploadAttrs: 'data-force-degradation' });
+
+  $(s.form).on('submit', e => {
+    assert.ok(!e.isDefaultPrevented());
+    e.preventDefault();
+  });
+
+  $(s.form).submit();
+});
+
+advancedTest('submit triggers ajax w/ form data', assert => {
+  const s = addForm();
+
+  $(s.form).on('submit', e => {
+    assert.ok(e.isDefaultPrevented());
+    assert.equal(server.requests.length, 1);
+
+    const req = server.requests[0];
+    const formData = req.requestBody;
+
+    assert.equal(req.method, 'POST');
+    assert.equal(urlParse(req.url).path, '/post-stuff');
+
+    // Ugh, only newer browsers support FormData.prototype.get().
+    if (typeof(formData.get) === 'function') {
+      assert.equal(formData.get('foo'), 'bar');
+      assert.equal(formData.get('file').size, 'hello there'.length);
+    }
+  });
+
+  s.upload.file = createBlob('hello there');
+
+  $(s.form).submit();
 });

--- a/frontend/source/js/tests/step_1_tests.js
+++ b/frontend/source/js/tests/step_1_tests.js
@@ -147,3 +147,52 @@ advancedTest('form_html replaces form & rebinds it', assert => {
   assert.ok(sNew.form !== s.form);
   assert.equal($('input[name="foo"]', sNew.form).val(), 'blargyblarg');
 });
+
+advancedTest('redirect_url redirects browser', assert => {
+  const s = addForm();
+
+  s.upload.file = createBlob('blah');
+  $(s.form).submit();
+
+  const delegate = step1.setDelegate({ redirect: sinon.spy() });
+
+  server.requests[0].respond(
+    200,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify({
+      redirect_url: 'http://boop',
+    })
+  );
+
+  assert.ok(delegate.redirect.calledWith('http://boop'));
+});
+
+advancedTest('500 results in alert', assert => {
+  const s = addForm();
+
+  s.upload.file = createBlob('blah');
+  $(s.form).submit();
+
+  const delegate = step1.setDelegate({ alert: sinon.spy() });
+
+  server.requests[0].respond(500);
+
+  assert.ok(delegate.alert.calledWith(
+    'An error occurred when submitting your data.'
+  ));
+});
+
+advancedTest('unrecognized 200 results in alert', assert => {
+  const s = addForm();
+
+  s.upload.file = createBlob('blah');
+  $(s.form).submit();
+
+  const delegate = step1.setDelegate({ alert: sinon.spy() });
+
+  server.requests[0].respond(200);
+
+  assert.ok(delegate.alert.calledWith(
+    'Invalid server response: '
+  ));
+});

--- a/frontend/source/js/tests/step_1_tests.js
+++ b/frontend/source/js/tests/step_1_tests.js
@@ -62,7 +62,10 @@ function makeFormHtml(extraOptions) {
 }
 
 function addForm(extraOptions) {
-  $('<div></div>').html(makeFormHtml(extraOptions)).appendTo('body').hide();
+  $('<div></div>')
+    .html(makeFormHtml(extraOptions))
+    .appendTo('body')
+    .hide();
   return step1.bindForm();
 }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp-uglify": "^1.5.4",
     "gulp-util": "^3.0.7",
     "jquery-tablesort": "0.0.9",
+    "sinon": "1.17.5",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"


### PR DESCRIPTION
This will fix #461.

We're adding [sinon](http://sinonjs.org/) to `package.json` for this.

To do:

- [X] Ensure degraded upload widgets pass-through to just submitting the form (no ajax).
- [X] Ensure ajax submission works.
- [X] Ensure ajax `form_html` response works.
- [x] Ensure ajax `redirect_url` response works.
- [x] Ensure other ajax errors work.
- [ ] File a separate issue for figuring out how to `require()` a module from a different bundle for tests. Right now I'm hacking around this by setting `window.testingExports__step_1 = exports` in `step_1.js` and retrieving it in the test suite, but there is probably a better way to do this via browserify. I don't think it should block merging this PR, though.