### PR TITLE
Make drag-and-drop widget's draggable state more noticeable

### DIFF
--- a/data_capture/templates/data_capture/step_1_form.html
+++ b/data_capture/templates/data_capture/step_1_form.html
@@ -24,7 +24,7 @@
   <div class="upload-chooser">
     <label for="{{ form.file.id_for_label }}">Choose file</label>
     <span class="js-only" aria-hidden="true">or drag and drop here.</span>
-    XLS, XLSX, or CSV format, please.
+    <span>XLS, XLSX, or CSV format, please.</span>
   </div>
 </div>
 

--- a/frontend/source/sass/components/_upload.scss
+++ b/frontend/source/sass/components/_upload.scss
@@ -68,18 +68,24 @@
   display: none;
 }
 
-.no-js .upload, .js .upload.degraded {
-  font-size: 1.5rem;
-  text-align: center;
-
-  .upload-chooser {
-    display: inline;
-  }
+.no-js .upload,
+.js .upload.degraded {
+  font-size: 1.3rem;
+  display: block;
+  border: none;
 
   input {
+    border: none;
+    font-size: 1.3rem;
+    color: $color-primary;
+    font-weight: $font-weight-bold;
+    padding: 1.5rem 0 1rem;
     // TODO: This is just clearing out the margin-bottom from our standard
     // CSS, which feels like a hack.
     margin-bottom: 0;
+    &:focus {
+      box-shadow: none;
+    }
   }
 
   label {

--- a/frontend/source/sass/components/_upload.scss
+++ b/frontend/source/sass/components/_upload.scss
@@ -47,7 +47,7 @@
         visibility: hidden;
       }
       &:before {
-        content: "Drop files here!"
+        content: "Drop file here!"
       }
     }
   }

--- a/frontend/source/sass/components/_upload.scss
+++ b/frontend/source/sass/components/_upload.scss
@@ -1,13 +1,17 @@
 @import "../base/variables";
+
 .upload {
+  margin: 3rem 0;
   display: flex;
   height: 6em;
   position: relative;
   align-items: center;
   padding: 0 3em;
   background-color: $color-gray-lightest;
-  transition: background-color 0.5s;
-
+  transition: background-color 0.5s, border-color 0.5s;
+  -webkit-transition: background-color 0.5s, border-color 0.5s;
+  -moz-transition: background-color 0.5s, border-color 0.5s;
+  -o-transition: background-color 0.5s, border-color 0.5s;
   border: 2px dashed $color-gray;
   color: $color-gray;
   font-size: 2rem;
@@ -36,7 +40,16 @@
   }
 
   &.dragged-over {
-    background-color: $color-white;
+    background-color: $color-green-lightest;
+    border: 2px dashed $color-green;
+    .upload-chooser {
+      * {
+        visibility: hidden;
+      }
+      &:before {
+        content: "Drop files here!"
+      }
+    }
   }
 }
 

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -54,7 +54,7 @@
       <div class="upload-chooser">
         <label for="file">Choose file</label>
         <span class="js-only" aria-hidden="true">or drag and drop here.</span>
-        XLS, XLSX, or CSV format, please.
+        <span>XLS, XLSX, or CSV format, please.</span>
       </div>
     </div>
   </form>
@@ -87,7 +87,7 @@
           <div class="upload-chooser">
             <label for="file2">Choose file</label>
             <span class="js-only" aria-hidden="true">or drag and drop here.</span>
-            XLS, XLSX, or CSV format, please.
+            <span>XLS, XLSX, or CSV format, please.</span>
           </div>
         </div>
     </div>


### PR DESCRIPTION
Addresses #397. Both the text and color will change, though TBH I'm not sure I love the color change. Feedback very welcome! 
<img width="1006" alt="screen shot 2016-08-05 at 5 45 39 pm" src="https://cloud.githubusercontent.com/assets/509309/17452490/1fd7c5a2-5b35-11e6-8675-0438cc6a7597.png">
