### PR TITLE
Add full text search tests, a few refactorings

### DIFF
--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -3,7 +3,6 @@ from model_mommy import mommy
 from model_mommy.recipe import seq
 from contracts.models import Contract
 from contracts.mommy_recipes import get_contract_recipe
-from api.views import convert_to_tsquery
 
 from itertools import cycle
 
@@ -53,13 +52,6 @@ class ContractsTest(TestCase):
 
         self.c = Client()
         self.path = RATES_API_PATH
-
-    def test_convert_to_tsquery(self):
-        self.assertEqual(convert_to_tsquery(
-            'staff  consultant'), 'staff:* & consultant:*')
-        self.assertEqual(convert_to_tsquery(
-            'senior typist (st)'), 'senior:* & typist:* & st:*')
-        self.assertEqual(convert_to_tsquery('@$(#)%&**#'), '')
 
     def test_empty_results(self):
         self.make_test_set()

--- a/api/views.py
+++ b/api/views.py
@@ -8,7 +8,7 @@ from rest_framework.views import APIView
 from api.pagination import ContractPagination
 from api.serializers import ContractSerializer
 from api.utils import get_histogram, stdev
-from contracts.models import Contract, EDUCATION_CHOICES, convert_to_tsquery
+from contracts.models import Contract, EDUCATION_CHOICES
 
 import csv
 
@@ -75,10 +75,7 @@ def get_contracts_queryset(request_params, wage_field):
         qs = query.split(',')
 
         if query_type not in ('match_phrase', 'match_exact'):
-            queries = [convert_to_tsquery(q) for q in qs]
-            # remove empty strings, most commonly from trailing commas
-            queries = filter(None, queries)
-            contracts = contracts.search(" | ".join(queries), raw=True)
+            contracts = contracts.multi_phrase_search(qs)
         else:
             q_objs = Q()
             for q in qs:
@@ -270,7 +267,7 @@ class GetAutocomplete(APIView):
             if query_type == 'match_phrase':
                 data = Contract.objects.filter(labor_category__icontains=q)
             else:
-                data = Contract.objects.search(convert_to_tsquery(q), raw=True)
+                data = Contract.objects.multi_phrase_search(q)
             data = data.values('labor_category').annotate(
                 count=Count('labor_category')).order_by('-count')
             return Response(data)

--- a/api/views.py
+++ b/api/views.py
@@ -8,34 +8,9 @@ from rest_framework.views import APIView
 from api.pagination import ContractPagination
 from api.serializers import ContractSerializer
 from api.utils import get_histogram, stdev
-from contracts.models import Contract, EDUCATION_CHOICES
+from contracts.models import Contract, EDUCATION_CHOICES, convert_to_tsquery
 
-import re
 import csv
-
-
-def convert_to_tsquery(query):
-    """
-    Converts multi-word phrases into AND boolean queries for postgresql.
-
-    Examples:
-
-        >>> convert_to_tsquery('interpretation')
-        'interpretation:*'
-
-        >>> convert_to_tsquery('interpretation services')
-        'interpretation:* & services:*'
-    """
-
-    # remove all non-alphanumeric or whitespace chars
-    pattern = re.compile('[^a-zA-Z\s]')
-    query = pattern.sub('', query)
-    query_parts = query.split()
-    # remove empty strings and add :* to use prefix matching on each chunk
-    query_parts = ["%s:*" % s for s in query_parts if s]
-    tsquery = ' & '.join(query_parts)
-
-    return tsquery
 
 
 def get_contracts_queryset(request_params, wage_field):

--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -2,6 +2,8 @@ from django.test import TestCase
 from contracts.mommy_recipes import get_contract_recipe
 from itertools import cycle
 
+from ..models import Contract
+
 
 class ContractTestCase(TestCase):
 
@@ -22,3 +24,44 @@ class ContractTestCase(TestCase):
     def test_normalize_rate(self):
         c = get_contract_recipe().make()
         self.assertEqual(c.normalize_rate('$1,000.00,'), 1000.0)
+
+
+class ContractSearchTestCase(TestCase):
+    CATEGORIES = [
+        'Sign Language Interpreter',
+        'Foreign Language Staff Interpreter (Spanish sign language)',
+        'Aircraft Servicer',
+        'Service Order Dispatcher',
+        'Disposal Services',
+        'Interpretation Services Class 4: Afrikan,Akan,Albanian',
+        'Interpretation Services Class 1: Spanish',
+        'Interpretation Services Class 2: French, German, Italian',
+    ]
+
+    def assertCategoriesEqual(self, results, categories):
+        self.assertEqual([
+            result.labor_category
+            for result in results
+        ], categories)
+
+    def setUp(self):
+        self.contracts = get_contract_recipe().make(
+            labor_category=cycle(self.CATEGORIES),
+            _quantity=len(self.CATEGORIES)
+        )
+
+    def test_search_index_works_via_raw_sql(self):
+        results = Contract.objects.raw(
+            '''
+            SELECT id, labor_category
+            FROM contracts_contract
+            WHERE search_index @@ to_tsquery('Interpretation')
+            '''
+        )
+        self.assertCategoriesEqual(results, [
+            u'Sign Language Interpreter',
+            u'Foreign Language Staff Interpreter (Spanish sign language)',
+            u'Interpretation Services Class 4: Afrikan,Akan,Albanian',
+            u'Interpretation Services Class 1: Spanish',
+            u'Interpretation Services Class 2: French, German, Italian'
+        ])

--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from contracts.mommy_recipes import get_contract_recipe
 from itertools import cycle
 
-from ..models import Contract
+from ..models import Contract, convert_to_tsquery
 
 
 class ContractTestCase(TestCase):
@@ -24,6 +24,13 @@ class ContractTestCase(TestCase):
     def test_normalize_rate(self):
         c = get_contract_recipe().make()
         self.assertEqual(c.normalize_rate('$1,000.00,'), 1000.0)
+
+    def test_convert_to_tsquery(self):
+        self.assertEqual(convert_to_tsquery(
+            'staff  consultant'), 'staff:* & consultant:*')
+        self.assertEqual(convert_to_tsquery(
+            'senior typist (st)'), 'senior:* & typist:* & st:*')
+        self.assertEqual(convert_to_tsquery('@$(#)%&**#'), '')
 
 
 class ContractSearchTestCase(TestCase):
@@ -56,6 +63,7 @@ class ContractSearchTestCase(TestCase):
             SELECT id, labor_category
             FROM contracts_contract
             WHERE search_index @@ to_tsquery('Interpretation')
+            ORDER BY id
             '''
         )
         self.assertCategoriesEqual(results, [

--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -57,6 +57,38 @@ class ContractSearchTestCase(TestCase):
             _quantity=len(self.CATEGORIES)
         )
 
+    def test_multi_phrase_search_works_with_single_word_phrase(self):
+        results = Contract.objects.multi_phrase_search('interpretation')
+        self.assertCategoriesEqual(results, [
+            u'Sign Language Interpreter',
+            u'Foreign Language Staff Interpreter (Spanish sign language)',
+            u'Interpretation Services Class 4: Afrikan,Akan,Albanian',
+            u'Interpretation Services Class 1: Spanish',
+            u'Interpretation Services Class 2: French, German, Italian'
+        ])
+
+    def test_multi_phrase_search_works_with_multi_word_phrase(self):
+        results = Contract.objects.multi_phrase_search([
+            'interpretation services'
+        ])
+        self.assertCategoriesEqual(results, [
+            u'Interpretation Services Class 4: Afrikan,Akan,Albanian',
+            u'Interpretation Services Class 1: Spanish',
+            u'Interpretation Services Class 2: French, German, Italian'
+        ])
+
+    def test_multi_phrase_search_works_with_multiple_phrases(self):
+        results = Contract.objects.multi_phrase_search([
+            'interpretation services',
+            'disposal'
+        ])
+        self.assertCategoriesEqual(results, [
+            u'Disposal Services',
+            u'Interpretation Services Class 4: Afrikan,Akan,Albanian',
+            u'Interpretation Services Class 1: Spanish',
+            u'Interpretation Services Class 2: French, German, Italian'
+        ])
+
     def test_search_index_works_via_raw_sql(self):
         results = Contract.objects.raw(
             '''

--- a/contracts/tests/test_doctests.py
+++ b/contracts/tests/test_doctests.py
@@ -1,8 +1,8 @@
 import doctest
 
-from .. import views
+from .. import models
 
 
 def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(views))
+    tests.addTests(doctest.DocTestSuite(models))
     return tests


### PR DESCRIPTION
This adds a number of full text search tests and refactors things a bit by moving full text-related functionality from `api.views` into `contracts.models`.

Aside from increasing the robustness of our test suite, this is intended to collect all full-text search functionality in one place so that clients don't have to be concerned the concept of a `tsquery`. This will allow us to more easily migrate to [Django 1.10's full text search](https://docs.djangoproject.com/en/1.10/ref/contrib/postgres/search/) in the future (see #291 for more details).