### PR TITLE
Fix sticky footer on ie11

### DIFF
--- a/frontend/source/sass/components/_page.scss
+++ b/frontend/source/sass/components/_page.scss
@@ -5,5 +5,6 @@ body {
 }
 
 main {
-  flex: 1;
+  // https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
+  flex: 1 0 auto;
 }


### PR DESCRIPTION
This fixes #535. It's basically just a port of https://github.com/18F/brand/pull/107 and it seems to get the job done.