### PR TITLE
Implement SplitDateField and use it in step 3

### DIFF
--- a/data_capture/forms.py
+++ b/data_capture/forms.py
@@ -3,6 +3,7 @@ from django import forms
 from .models import SubmittedPriceList
 from .schedules import registry
 from frontend.upload import UploadWidget
+from frontend.date import SplitDateField
 
 
 class Step1Form(forms.Form):
@@ -32,6 +33,9 @@ class Step1Form(forms.Form):
 
 
 class Step3Form(forms.ModelForm):
+    contract_start = SplitDateField(required=False)
+    contract_end = SplitDateField(required=False)
+
     class Meta:
         model = SubmittedPriceList
         fields = [

--- a/data_capture/models.py
+++ b/data_capture/models.py
@@ -28,12 +28,10 @@ class SubmittedPriceList(models.Model):
     contract_start = models.DateField(
         null=True,
         blank=True,
-        help_text='Use MM/DD/YY format, e.g. "10/25/06".'
     )
     contract_end = models.DateField(
         null=True,
         blank=True,
-        help_text='Use MM/DD/YY format, e.g. "10/25/06".'
     )
 
     submitter = models.ForeignKey(User)

--- a/data_capture/templates/data_capture/step_3.html
+++ b/data_capture/templates/data_capture/step_3.html
@@ -8,7 +8,44 @@
 <form method="post" action="{% url 'data_capture:step_3' %}">
 {% csrf_token %}
 
-{{ form.as_p }}
+{{ form.non_field_errors }}
+
+{{ form.contract_number.errors }}
+{{ form.contract_number.label_tag }}
+{{ form.contract_number }}
+<span class="helptext">{{ form.contract_number.help_text }}</span>
+
+{{ form.vendor_name.errors }}
+{{ form.vendor_name.label_tag }}
+{{ form.vendor_name }}
+
+{{ form.is_small_business.errors }}
+{{ form.is_small_business.label_tag }}
+{{ form.is_small_business }}
+
+{{ form.contractor_site.errors }}
+{{ form.contractor_site.label_tag }}
+{{ form.contractor_site }}
+
+{{ form.contract_year.errors }}
+{{ form.contract_year.label_tag }}
+{{ form.contract_year }}
+
+<p>
+  <fieldset>
+    <legend>{{ form.contract_start.label }}</legend>
+    {{ form.contract_start.errors }}
+    {{ form.contract_start }}
+  </fieldset>
+</p>
+
+<p>
+  <fieldset>
+    <legend>{{ form.contract_end.label }}</legend>
+    {{ form.contract_end.errors }}
+    {{ form.contract_end }}
+  </fieldset>
+</p>
 
 <div class="form-button-row clearfix">
   <a href="{% url 'data_capture:step_2' %}" class="button button-previous">Previous</a>

--- a/frontend/date.py
+++ b/frontend/date.py
@@ -1,0 +1,94 @@
+from datetime import date
+
+from django.core.exceptions import ValidationError
+from django.forms import MultiWidget, NumberInput
+from django.forms.fields import MultiValueField, IntegerField
+from django.template.loader import render_to_string
+
+
+class SplitDateWidget(MultiWidget):
+    '''
+    A widget for a USWDS-style date, with separate number fields for
+    date, month, and year.
+
+    The widget is expected to be in a <fieldset>. Instead of a <label>,
+    the label should be rendered inside a <legend>.
+    '''
+
+    def __init__(self, attrs=None):
+        widgets = (
+            NumberInput(),
+            NumberInput(),
+            NumberInput(),
+        )
+        super().__init__(widgets, attrs=attrs)
+
+    def decompress(self, value):
+        if value:
+            return [value.year, value.month, value.day]
+        return [None, None, None]
+
+    def render(self, name, value, attrs=None):
+        # Django MultiWidget rendering is not particularly well-suited to
+        # what we want to do, so we'll have to override it here. Much
+        # of this code is copied from MultiWidget.render(), unfortunately.
+
+        # value is a list of values, each corresponding to a widget
+        # in self.widgets.
+        if not isinstance(value, list):
+            value = self.decompress(value)
+
+        final_attrs = self.build_attrs(attrs)
+        id_ = final_attrs.get('id')
+        widget_infos = []
+        for i, widget in enumerate(self.widgets):
+            try:
+                widget_value = value[i]
+            except IndexError:
+                widget_value = None
+
+            # Note that we're never calling our sub-widgets'
+            # render() method, and that's ok. We're really just defining
+            # our widgets to plug into Django's MultiValueField/MultiWidget
+            # architecture; our template will be rendering the sub-widgets
+            # itself.
+
+            widget_infos.append({
+                'id': '%s_%s' % (id_, i),
+                'name': name + '_%s' % i,
+                'value': widget_value or ''
+            })
+
+        year, month, day = widget_infos
+
+        return render_to_string('frontend/date.html', {
+            'hint_id': '%s_%s' % (id_, 'hint'),
+            'year': year,
+            'month': month,
+            'day': day,
+        })
+
+
+class SplitDateField(MultiValueField):
+    '''
+    A field for a USWDS-style date.
+    '''
+
+    widget = SplitDateWidget
+
+    def __init__(self, *args, **kwargs):
+        fields = (
+            IntegerField(),
+            IntegerField(),
+            IntegerField(),
+        )
+        super().__init__(fields, *args, **kwargs)
+
+    def compress(self, data_list):
+        if data_list:
+            year, month, day = data_list
+            try:
+                return date(year, month, day)
+            except ValueError as e:
+                raise ValidationError('Invalid date: %s.' % str(e))
+        return None

--- a/frontend/templates/frontend/date.html
+++ b/frontend/templates/frontend/date.html
@@ -1,0 +1,17 @@
+<span class="form-hint" id="{{ hint_id }}">For example: 04 28 1986</span>
+
+<div class="date-mm-dd-yy">
+  <div class="form-group form-group-month">
+    <label for="{{ month.id }}">Month</label>
+
+    <input class="input-inline" aria-describedby="{{ hint_id }}" id="{{ month.id }}" name="{{ month.name }}" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="{{ month.value }}">
+  </div>
+  <div class="form-group form-group-day">
+    <label for="{{ day.id }}">Day</label>
+    <input class="input-inline" aria-describedby="{{ hint_id }}" id="{{ day.id }}" name="{{ day.name }}" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="{{ day.value }}">
+  </div>
+  <div class="form-group form-group-year">
+    <label for="{{ year.id }}">Year</label>
+    <input class="input-inline" aria-describedby="{{ hint_id }}" id="{{ year.id }}" name="{{ year.name }}" pattern="[0-9]{4}" type="number" min="1900" max="9999" value="{{ year.value }}">
+  </div>
+</div>

--- a/frontend/tests/test_date.py
+++ b/frontend/tests/test_date.py
@@ -1,0 +1,77 @@
+from datetime import date
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+
+from ..date import SplitDateWidget, SplitDateField
+
+
+class SplitDateWidgetTests(TestCase):
+    def test_render_assigns_ids_and_labels(self):
+        widget = SplitDateWidget()
+        content = widget.render('boop', None, {'id': 'blarg'})
+        self.assertRegexpMatches(content, 'id="blarg_0"')
+        self.assertRegexpMatches(content, 'id="blarg_1"')
+        self.assertRegexpMatches(content, 'id="blarg_2"')
+        self.assertRegexpMatches(content, 'for="blarg_0"')
+        self.assertRegexpMatches(content, 'for="blarg_1"')
+        self.assertRegexpMatches(content, 'for="blarg_2"')
+
+    def test_render_assigns_names(self):
+        widget = SplitDateWidget()
+        content = widget.render('boop', None)
+        self.assertRegexpMatches(content, 'name="boop_0"')
+        self.assertRegexpMatches(content, 'name="boop_1"')
+        self.assertRegexpMatches(content, 'name="boop_2"')
+
+    def test_render_assigns_hint_id_and_aria_describedby(self):
+        widget = SplitDateWidget()
+        content = widget.render('boop', None, {'id': 'foo'})
+        self.assertRegexpMatches(content, 'id="foo_hint"')
+        self.assertRegexpMatches(content, 'aria-describedby="foo_hint"')
+
+    def test_render_takes_value_as_list(self):
+        widget = SplitDateWidget()
+        content = widget.render('boop', [2006, 7, 29])
+        self.assertRegexpMatches(content, 'value="2006"')
+        self.assertRegexpMatches(content, 'value="7"')
+        self.assertRegexpMatches(content, 'value="29"')
+
+    def test_render_takes_value_as_date(self):
+        widget = SplitDateWidget()
+        content = widget.render('boop', date(2005, 6, 28))
+        self.assertRegexpMatches(content, 'value="2005"')
+        self.assertRegexpMatches(content, 'value="6"')
+        self.assertRegexpMatches(content, 'value="28"')
+
+    def test_render_does_not_raise_exception_on_empty_lists(self):
+        widget = SplitDateWidget()
+        content = widget.render('boop', [])
+        self.assertRegexpMatches(content, 'value=""')
+
+    def test_decompress_works_with_dates(self):
+        widget = SplitDateWidget()
+        self.assertEqual(widget.decompress(date(2005, 6, 28)), [2005, 6, 28])
+
+    def test_decompress_works_with_none(self):
+        widget = SplitDateWidget()
+        self.assertEqual(widget.decompress(None), [None, None, None])
+
+
+class SplitDateFieldTests(TestCase):
+    def test_compress_returns_date_for_valid_dates(self):
+        field = SplitDateField()
+        self.assertEqual(field.compress([2005, 6, 28]), date(2005, 6, 28))
+
+    def test_compress_raises_validation_errors_for_invalid_dates(self):
+        field = SplitDateField()
+
+        with self.assertRaisesRegexp(
+            ValidationError,
+            'Invalid date: day is out of range for month.'
+        ):
+            field.compress([2001, 2, 31])
+
+    def test_compress_returns_none_when_data_list_is_falsy(self):
+        field = SplitDateField()
+        self.assertEqual(field.compress(None), None)
+        self.assertEqual(field.compress([]), None)

--- a/styleguide/date_example.py
+++ b/styleguide/date_example.py
@@ -1,0 +1,30 @@
+from django import forms
+from django.shortcuts import render
+
+from frontend.date import SplitDateField
+
+
+class ExampleForm(forms.Form):
+    date = SplitDateField()
+
+
+def create_template_context(form=None, is_valid=False):
+    return {
+        'date_form': form or ExampleForm(),
+        'date_form_is_valid': is_valid
+    }
+
+
+def view(request):
+    form = None
+    is_valid = False
+
+    if request.method == 'POST':
+        form = ExampleForm(request.POST)
+
+        if form.is_valid():
+            is_valid = True
+
+    ctx = create_template_context(form, is_valid)
+
+    return render(request, 'styleguide_date.html', ctx)

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -366,27 +366,24 @@
   </select>
   {% endexample %}
 
-  {% example %}
-  <fieldset>
-    <legend>Date of birth</legend>
-    <span class="form-hint" id="dobHint">For example: 04 28 1986</span>
+  {% guide_section "Dates" %}
 
-    <div class="date-mm-dd-yy">
-      <div class="form-group form-group-month">
-        <label for="date_of_birth_1">Month</label>
-        <input class="input-inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
-      </div>
-      <div class="form-group form-group-day">
-        <label for="date_of_birth_2">Day</label>
-        <input class="input-inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
-      </div>
-      <div class="form-group form-group-year">
-        <label for="date_of_birth_3">Year</label>
-        <input class="input-inline" aria-describedby="dobHint" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
-      </div>
+  <p>
+    We have a custom Django form field and widget that
+    offers three separate text fields for users to enter
+    dates, as per the <a href="https://standards.usa.gov/form-controls/#date-input">USWDS section on date input</a>.
+
+  <p>
+    For a simple code example, see
+    {% pathname 'styleguide/date_example.py' %}.
+  </p>
+
+  <div class="styleguide-example">
+    <div class="rendering">
+      <h3 class="example-heading">Example</h3>
+      {% include "styleguide_date_example.html" %}
     </div>
-  </fieldset>
-  {% endexample %}
+  </div>
 
   {% endguide %}
 </div>

--- a/styleguide/templates/styleguide_date.html
+++ b/styleguide/templates/styleguide_date.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block body %}
+<div class="container">
+  <h1>Date Widget Example</h1>
+
+  {% if date_form_is_valid %}
+    <p>Form submitted successfully.</p>
+  {% endif %}
+
+  {% include "styleguide_date_example.html" %}
+</div>
+
+<script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
+{% endblock %}

--- a/styleguide/templates/styleguide_date_example.html
+++ b/styleguide/templates/styleguide_date_example.html
@@ -1,0 +1,14 @@
+<form method="post"
+      action="{% url 'styleguide:date' %}">
+  {% csrf_token %}
+
+  {% with form=date_form %}
+    <fieldset>
+      <legend>{{ form.date.label }}</legend>
+      {{ form.date.errors }}
+      {{ form.date }}
+    </fieldset>
+  {% endwith %}
+
+  <button type="submit" class="button-primary">Submit</button>
+</form>

--- a/styleguide/tests.py
+++ b/styleguide/tests.py
@@ -10,3 +10,7 @@ class StyleguideTests(TestCase):
     def test_styleguide_ajaxform_returns_200(self):
         response = self.client.get('/styleguide/ajaxform')
         self.assertEqual(response.status_code, 200)
+
+    def test_styleguide_date_returns_200(self):
+        response = self.client.get('/styleguide/date')
+        self.assertEqual(response.status_code, 200)

--- a/styleguide/urls.py
+++ b/styleguide/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import patterns, url
 
-from . import views, ajaxform_example
+from . import views, ajaxform_example, date_example
 
 
 urlpatterns = patterns(
     '',
     url(r'^$', views.index, name='index'),
     url(r'^ajaxform$', ajaxform_example.view, name='ajaxform'),
+    url(r'^date$', date_example.view, name='date'),
 )

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -2,7 +2,7 @@ from django import forms
 from django.shortcuts import render
 
 from data_capture.forms import UploadWidget
-from . import ajaxform_example
+from . import ajaxform_example, date_example
 
 
 def get_degraded_upload_widget():
@@ -17,5 +17,6 @@ def index(request):
         'degraded_upload_widget': get_degraded_upload_widget()
     }
     ctx.update(ajaxform_example.create_template_context())
+    ctx.update(date_example.create_template_context())
 
     return render(request, 'styleguide.html', ctx)


### PR DESCRIPTION
This is an ~~experimental~~ attempt to fix #534 by using Django's [`MultiValueField`](https://docs.djangoproject.com/en/1.9/ref/forms/fields/#django.forms.MultiValueField) and [`MultiWidget`](https://docs.djangoproject.com/en/1.9/ref/forms/widgets/#django.forms.MultiWidget):

> ![screen shot 2016-08-18 at 7 48 31 am](https://cloud.githubusercontent.com/assets/124687/17772685/3174fc7a-6518-11e6-9959-86bbb7a055d7.png)

The implementation feels kind of weird, mostly because of the way Django's architecture forces a separation between form inputs and their labels. This makes it difficult to render a single multi-value field/widget as its own "component".

Another weirdness is that our date widget is meant to be placed in a `<fieldset>`, with the main "label" (e.g. "contract start date") in a `<legend>` rather than a `<label>`, which Django's form rendering framework *really* doesn't like.  We'll probably need to ensure that users don't use this widget with standard form-rendering methods like `as_p()`, `as_table()`, and so on, which is a bummer.

An alternative is to have each sub-field (month, day, year) be its own actual form field, and combine them in the form's `clean()` method, but this could get rather annoying if there are lots of dates in a form.

Also, if we use lots of forms with dates, we can always add a custom template filter that does the form rendering for us, e.g. `{{ form|our_cool_form_renderer }}` (this is how Django crispy forms does things).

To do:

- [x] Add tests. There's lots of weird branching here and Django's documentation doesn't fully elucidate what kinds of edge cases might occur in a multi-value field/widget and why.
- [x] Replace the date widget example in the style guide.
- [x] ~~It might also be nice to add a "disable form validation" button to the styleguide pages that runs the JS mentioned at [novalidate.com](http://novalidate.com/), to make it easy to simulate what will happen on browsers that don't have HTML5 form validation.~~ Spun off to #568.
- [x] Replace the date fields in the data capture form with this new field/widget. Unfortunately I don't see any way to do this that doesn't involve replacing our `form.as_p()` with a manual displaying of every single widget on the form, which is annoying.
