### PR TITLE
Styleguide ajaxform label typo fix

### DIFF
--- a/frontend/date.py
+++ b/frontend/date.py
@@ -1,0 +1,94 @@
+from datetime import date
+
+from django.core.exceptions import ValidationError
+from django.forms import MultiWidget, NumberInput
+from django.forms.fields import MultiValueField, IntegerField
+from django.template.loader import render_to_string
+
+
+class SplitDateWidget(MultiWidget):
+    '''
+    A widget for a USWDS-style date, with separate number fields for
+    date, month, and year.
+
+    The widget is expected to be in a <fieldset>. Instead of a <label>,
+    the label should be rendered inside a <legend>.
+    '''
+
+    def __init__(self, attrs=None):
+        widgets = (
+            NumberInput(),
+            NumberInput(),
+            NumberInput(),
+        )
+        super().__init__(widgets, attrs=attrs)
+
+    def decompress(self, value):
+        if value:
+            return [value.year, value.month, value.day]
+        return [None, None, None]
+
+    def render(self, name, value, attrs=None):
+        # Django MultiWidget rendering is not particularly well-suited to
+        # what we want to do, so we'll have to override it here. Much
+        # of this code is copied from MultiWidget.render(), unfortunately.
+
+        # value is a list of values, each corresponding to a widget
+        # in self.widgets.
+        if not isinstance(value, list):
+            value = self.decompress(value)
+
+        final_attrs = self.build_attrs(attrs)
+        id_ = final_attrs.get('id')
+        widget_infos = []
+        for i, widget in enumerate(self.widgets):
+            try:
+                widget_value = value[i]
+            except IndexError:
+                widget_value = None
+
+            # Note that we're never calling our sub-widgets'
+            # render() method, and that's ok. We're really just defining
+            # our widgets to plug into Django's MultiValueField/MultiWidget
+            # architecture; our template will be rendering the sub-widgets
+            # itself.
+
+            widget_infos.append({
+                'id': '%s_%s' % (id_, i),
+                'name': name + '_%s' % i,
+                'value': widget_value or ''
+            })
+
+        year, month, day = widget_infos
+
+        return render_to_string('frontend/date.html', {
+            'hint_id': '%s_%s' % (id_, 'hint'),
+            'year': year,
+            'month': month,
+            'day': day,
+        })
+
+
+class SplitDateField(MultiValueField):
+    '''
+    A field for a USWDS-style date.
+    '''
+
+    widget = SplitDateWidget
+
+    def __init__(self, *args, **kwargs):
+        fields = (
+            IntegerField(),
+            IntegerField(),
+            IntegerField(),
+        )
+        super().__init__(fields, *args, **kwargs)
+
+    def compress(self, data_list):
+        if data_list:
+            year, month, day = data_list
+            try:
+                return date(year, month, day)
+            except ValueError as e:
+                raise ValidationError('Invalid date: %s.' % str(e))
+        return None

--- a/frontend/templates/frontend/date.html
+++ b/frontend/templates/frontend/date.html
@@ -1,0 +1,17 @@
+<span class="form-hint" id="{{ hint_id }}">For example: 04 28 1986</span>
+
+<div class="date-mm-dd-yy">
+  <div class="form-group form-group-month">
+    <label for="{{ month.id }}">Month</label>
+
+    <input class="input-inline" aria-describedby="{{ hint_id }}" id="{{ month.id }}" name="{{ month.name }}" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="{{ month.value }}">
+  </div>
+  <div class="form-group form-group-day">
+    <label for="{{ day.id }}">Day</label>
+    <input class="input-inline" aria-describedby="{{ hint_id }}" id="{{ day.id }}" name="{{ day.name }}" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="{{ day.value }}">
+  </div>
+  <div class="form-group form-group-year">
+    <label for="{{ year.id }}">Year</label>
+    <input class="input-inline" aria-describedby="{{ hint_id }}" id="{{ year.id }}" name="{{ year.name }}" pattern="[0-9]{4}" type="number" min="1900" max="9999" value="{{ year.value }}">
+  </div>
+</div>

--- a/styleguide/date_example.py
+++ b/styleguide/date_example.py
@@ -1,0 +1,30 @@
+from django import forms
+from django.shortcuts import render
+
+from frontend.date import SplitDateField
+
+
+class ExampleForm(forms.Form):
+    date = SplitDateField()
+
+
+def create_template_context(form=None, is_valid=False):
+    return {
+        'date_form': form or ExampleForm(),
+        'date_form_is_valid': is_valid
+    }
+
+
+def view(request):
+    form = None
+    is_valid = False
+
+    if request.method == 'POST':
+        form = ExampleForm(request.POST)
+
+        if form.is_valid():
+            is_valid = True
+
+    ctx = create_template_context(form, is_valid)
+
+    return render(request, 'styleguide_date.html', ctx)

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -366,27 +366,24 @@
   </select>
   {% endexample %}
 
-  {% example %}
-  <fieldset>
-    <legend>Date of birth</legend>
-    <span class="form-hint" id="dobHint">For example: 04 28 1986</span>
+  {% guide_section "Dates" %}
 
-    <div class="date-mm-dd-yy">
-      <div class="form-group form-group-month">
-        <label for="date_of_birth_1">Month</label>
-        <input class="input-inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
-      </div>
-      <div class="form-group form-group-day">
-        <label for="date_of_birth_2">Day</label>
-        <input class="input-inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
-      </div>
-      <div class="form-group form-group-year">
-        <label for="date_of_birth_3">Year</label>
-        <input class="input-inline" aria-describedby="dobHint" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
-      </div>
+  <p>
+    We have a custom Django form field and widget that
+    offers three separate text fields for users to enter
+    dates, as per the <a href="https://standards.usa.gov/form-controls/#date-input">USWDS section on date input</a>.
+
+  <p>
+    For a simple code example, see
+    {% pathname 'styleguide/date_example.py' %}.
+  </p>
+
+  <div class="styleguide-example">
+    <div class="rendering">
+      <h3 class="example-heading">Example</h3>
+      {% include "styleguide_date_example.html" %}
     </div>
-  </fieldset>
-  {% endexample %}
+  </div>
 
   {% endguide %}
 </div>

--- a/styleguide/templates/styleguide_ajaxform_example.html
+++ b/styleguide/templates/styleguide_ajaxform_example.html
@@ -6,10 +6,10 @@
   {% with form=ajaxform_form %}
     {{ form.non_field_errors }}
     {{ form.question.errors }}
-    {{ form.question.label }}
+    {{ form.question.label_tag }}
     {{ form.question }}
     {{ form.on_valid_submit.errors }}
-    {{ form.on_valid_submit.label }}
+    {{ form.on_valid_submit.label_tag }}
     {{ form.on_valid_submit }}
     {{ form.file.errors }}
     {{ form.file }}

--- a/styleguide/templates/styleguide_date.html
+++ b/styleguide/templates/styleguide_date.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block body %}
+<div class="container">
+  <h1>Date Widget Example</h1>
+
+  {% if date_form_is_valid %}
+    <p>Form submitted successfully.</p>
+  {% endif %}
+
+  {% include "styleguide_date_example.html" %}
+</div>
+
+<script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
+{% endblock %}

--- a/styleguide/templates/styleguide_date_example.html
+++ b/styleguide/templates/styleguide_date_example.html
@@ -1,0 +1,14 @@
+<form method="post"
+      action="{% url 'styleguide:date' %}">
+  {% csrf_token %}
+
+  {% with form=date_form %}
+    <fieldset>
+      <legend>{{ form.date.label }}</legend>
+      {{ form.date.errors }}
+      {{ form.date }}
+    </fieldset>
+  {% endwith %}
+
+  <button type="submit" class="button-primary">Submit</button>
+</form>

--- a/styleguide/tests.py
+++ b/styleguide/tests.py
@@ -10,3 +10,7 @@ class StyleguideTests(TestCase):
     def test_styleguide_ajaxform_returns_200(self):
         response = self.client.get('/styleguide/ajaxform')
         self.assertEqual(response.status_code, 200)
+
+    def test_styleguide_date_returns_200(self):
+        response = self.client.get('/styleguide/date')
+        self.assertEqual(response.status_code, 200)

--- a/styleguide/urls.py
+++ b/styleguide/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import patterns, url
 
-from . import views, ajaxform_example
+from . import views, ajaxform_example, date_example
 
 
 urlpatterns = patterns(
     '',
     url(r'^$', views.index, name='index'),
     url(r'^ajaxform$', ajaxform_example.view, name='ajaxform'),
+    url(r'^date$', date_example.view, name='date'),
 )

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -2,7 +2,7 @@ from django import forms
 from django.shortcuts import render
 
 from data_capture.forms import UploadWidget
-from . import ajaxform_example
+from . import ajaxform_example, date_example
 
 
 def get_degraded_upload_widget():
@@ -17,5 +17,6 @@ def index(request):
         'degraded_upload_widget': get_degraded_upload_widget()
     }
     ctx.update(ajaxform_example.create_template_context())
+    ctx.update(date_example.create_template_context())
 
     return render(request, 'styleguide.html', ctx)


### PR DESCRIPTION
Doh. I mistakenly wrote `.label` in the template when I should have written `.label_tag`.  Oof.
