### PR TITLE
fix typo in styleguide ajax form example.

### DIFF
--- a/styleguide/templates/styleguide_ajaxform_example.html
+++ b/styleguide/templates/styleguide_ajaxform_example.html
@@ -6,10 +6,10 @@
   {% with form=ajaxform_form %}
     {{ form.non_field_errors }}
     {{ form.question.errors }}
-    {{ form.question.label }}
+    {{ form.question.label_tag }}
     {{ form.question }}
     {{ form.on_valid_submit.errors }}
-    {{ form.on_valid_submit.label }}
+    {{ form.on_valid_submit.label_tag }}
     {{ form.on_valid_submit }}
     {{ form.file.errors }}
     {{ form.file }}


### PR DESCRIPTION
Doh. I mistakenly wrote `.label` in the template when I should have written `.label_tag`.  Oof.
