### PR TITLE
Add support for sending email

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ string), the boolean is true; otherwise, it's false.
 * `DATABASE_URL` is the URL for the database, as per the
   [DJ-Database-URL schema][].
 
+* `EMAIL_URL` is the URL for the service to use when sending
+  email, as per the [dj-email-url schema][]. When `DEBUG` is true,
+  this defaults to `console:`. The setting can easily be manually
+  tested via the `manage.py sendtestemail` command.
+
 * `ENABLE_SEO_INDEXING` is a boolean value that indicates whether to
   indicate to search engines that they can index the site.
 
@@ -405,6 +410,7 @@ for other than small business.
 [SASS]: http://sass-lang.com/
 [`deploy.md`]: https://github.com/18F/calc/blob/master/deploy.md
 [DJ-Database-URL schema]: https://github.com/kennethreitz/dj-database-url#url-schema
+[dj-email-url schema]: https://github.com/migonzalvar/dj-email-url#supported-backends
 [pytest]: https://pytest.org/latest/usage.html
 [docker-machine-cloud]: https://docs.docker.com/machine/get-started-cloud/
 [Django Debug Toolbar]: https://github.com/jazzband/django-debug-toolbar/

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import dj_database_url
+import dj_email_url
 from dotenv import load_dotenv
 
 from .settings_utils import load_cups_from_vcap_services, get_whitelisted_ips
@@ -34,6 +35,19 @@ if DEBUG:
         'SECRET_KEY',
         'I am an insecure secret key intended ONLY for dev/testing.'
     )
+    os.environ.setdefault('EMAIL_URL', 'console:')
+
+
+email_config = dj_email_url.config()
+
+EMAIL_FILE_PATH = email_config['EMAIL_FILE_PATH']
+EMAIL_HOST_USER = email_config['EMAIL_HOST_USER']
+EMAIL_HOST_PASSWORD = email_config['EMAIL_HOST_PASSWORD']
+EMAIL_HOST = email_config['EMAIL_HOST']
+EMAIL_PORT = email_config['EMAIL_PORT']
+EMAIL_BACKEND = email_config['EMAIL_BACKEND']
+EMAIL_USE_TLS = email_config['EMAIL_USE_TLS']
+EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']
 
 API_HOST = os.environ.get('API_HOST', '/api/')
 

--- a/meta/management/commands/sendtestemail.py
+++ b/meta/management/commands/sendtestemail.py
@@ -1,0 +1,45 @@
+# This file has been taken directly from Django 1.9:
+# https://github.com/django/django/blob/master/django/core/management/commands/sendtestemail.py
+
+# We should remove it once we've upgraded to 1.9.
+
+import socket
+
+from django.core.mail import mail_admins, mail_managers, send_mail
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = "Sends a test email to the email addresses specified as arguments."
+    missing_args_message = "You must specify some email recipients, or pass the --managers or --admin options." # NOQA
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'email', nargs='*',
+            help='One or more email addresses to send a test email to.',
+        )
+        parser.add_argument(
+            '--managers', action='store_true', dest='managers', default=False,
+            help='Send a test email to the addresses specified in settings.MANAGERS.',  # NOQA
+        )
+        parser.add_argument(
+            '--admins', action='store_true', dest='admins', default=False,
+            help='Send a test email to the addresses specified in settings.ADMINS.',  # NOQA
+        )
+
+    def handle(self, *args, **kwargs):
+        subject = 'Test email from %s on %s' % (socket.gethostname(), timezone.now())  # NOQA
+
+        send_mail(
+            subject=subject,
+            message="If you\'re reading this, it was successful.",
+            from_email=None,
+            recipient_list=kwargs['email'],
+        )
+
+        if kwargs['managers']:
+            mail_managers(subject, "This email was sent to the site managers.")
+
+        if kwargs['admins']:
+            mail_admins(subject, "This email was sent to the site admins.")

--- a/meta/management/commands/sendtestemail.py
+++ b/meta/management/commands/sendtestemail.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 
 class Command(BaseCommand):
     help = "Sends a test email to the email addresses specified as arguments."
-    missing_args_message = "You must specify some email recipients, or pass the --managers or --admin options." # NOQA
+    missing_args_message = "You must specify some email recipients, or pass the --managers or --admin options."  # NOQA
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bandit>=1.0,<2.0
 dj-database-url==0.4.1
+dj-email-url==0.0.8
 django-click==1.2.0
 Django==1.8.14
 django-cors-headers==1.1.0


### PR DESCRIPTION
This adds [dj-email-url](https://github.com/migonzalvar/dj-email-url), and also cherry-picks the [`manage.py sendtestemail`](https://docs.djangoproject.com/en/1.10/ref/django-admin/#sendtestemail) command from Django 1.9 (we'll remove it once we actually upgrade to 1.9).

It also adds documentation about configuring email to the readme.

(Context: I asked around on Slack and it looks like we use Mandrill for email sending, which is super easy to use and works via SMTP, so this PR should give us what we need.)
