### PR TITLE
Fix #499 by making 'is small business' radios.

### DIFF
--- a/data_capture/forms.py
+++ b/data_capture/forms.py
@@ -33,6 +33,15 @@ class Step1Form(forms.Form):
 
 
 class Step3Form(forms.ModelForm):
+    is_small_business = forms.ChoiceField(
+        label='Business size',
+        choices=[
+            (True, 'Small business'),
+            (False, 'Not a small business'),
+        ],
+        widget=forms.widgets.RadioSelect,
+    )
+
     contract_start = SplitDateField(required=False)
     contract_end = SplitDateField(required=False)
 

--- a/data_capture/tests/test_views.py
+++ b/data_capture/tests/test_views.py
@@ -161,6 +161,7 @@ class Step3Tests(StepTestCase):
         'contract_number': 'GS-123-4567',
         'vendor_name': 'foo',
         'contractor_site': 'Customer',
+        'is_small_business': False
     }
 
     def test_login_is_required(self):

--- a/frontend/source/sass/components/_forms.scss
+++ b/frontend/source/sass/components/_forms.scss
@@ -33,9 +33,9 @@ label input[type="radio"] {
   width: auto; // WDS override for width: 100%;
 }
 
-/* A <ul> with an id attribute is a Django-rendered radio widget. */
+/* A <ul> holds a Django-rendered list of radio buttons. */
 
-form ul[id] {
+form ul {
   list-style-type: none;
 }
 

--- a/frontend/source/sass/components/_forms.scss
+++ b/frontend/source/sass/components/_forms.scss
@@ -33,6 +33,12 @@ label input[type="radio"] {
   width: auto; // WDS override for width: 100%;
 }
 
+/* A <ul> with an id attribute is a Django-rendered radio widget. */
+
+form ul[id] {
+  list-style-type: none;
+}
+
 /* TODO: Django's default form rendering uses a <ul class="errorlist">
    for errors, and <span class="helptext"> for help text. We should either
    style them properly, or render our own markup. The following are some


### PR DESCRIPTION
This fixes #499:

> ![screen shot 2016-08-18 at 7 41 41 am](https://cloud.githubusercontent.com/assets/124687/17772520/3f92318e-6517-11e6-893b-8fde2e63b5ed.png)

As discussed earlier, this UI requires the user to explicitly choose one of the radios, rather than defaulting to "not a small business", which is what happens when we use a single checkbox.

~~Currently this PR is against #561, but it doesn't actually *require* any of the functionality in that PR; I'm just doing it b/c there will be slightly annoying merge conflicts otherwise, since both PRs modify the `Step3Form`. (Due to the fact that github PRs can now change the base branch they're being merged into, though, it'll be easy to first merge #561 and later merge this one, if we want, which is nice.)~~

@hbillings does this look OK?