### PR TITLE
Only expose QUnit tests when DEBUG is enabled

### DIFF
--- a/frontend/tests/test_qunit.py
+++ b/frontend/tests/test_qunit.py
@@ -1,8 +1,9 @@
 import os
 import subprocess
 
-from django.test import LiveServerTestCase
+from django.test import LiveServerTestCase, override_settings
 
+from hourglass.urls import urlpatterns, tests_url
 from .utils import build_static_assets
 
 
@@ -10,6 +11,10 @@ RUNNER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                            'vendor', 'runner.js')
 
 
+urlpatterns += [tests_url]
+
+
+@override_settings(ROOT_URLCONF=__name__)
 class QunitTests(LiveServerTestCase):
 
     def test_qunit(self):

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -21,18 +21,22 @@ urlpatterns = [
     url(r'^data-capture/',
         include('data_capture.urls', namespace='data_capture')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^tests/$', TemplateView.as_view(template_name='tests.html')),
-    url(r'^styleguide/', include('styleguide.urls', namespace='styleguide')),
     url(r'^robots.txt$', robots_txt),
     url(r'^auth/', include('uaa_client.urls', namespace='uaa_client')),
 ]
 
+tests_url = url(r'^tests/$', TemplateView.as_view(template_name='tests.html'))
+
+styleguide_url = url(r'^styleguide/', include('styleguide.urls',
+                                              namespace='styleguide'))
+
 if settings.DEBUG:
     import debug_toolbar
-    import fake_uaa_provider.urls
 
     urlpatterns += [
-        url(r'^', include(fake_uaa_provider.urls,
-            namespace='fake_uaa_provider')),
+        url(r'^', include('fake_uaa_provider.urls',
+                          namespace='fake_uaa_provider')),
         url(r'^__debug__/', include(debug_toolbar.urls)),
+        tests_url,
+        styleguide_url,
     ]

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -21,14 +21,12 @@ urlpatterns = [
     url(r'^data-capture/',
         include('data_capture.urls', namespace='data_capture')),
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^styleguide/', include('styleguide.urls', namespace='styleguide')),
     url(r'^robots.txt$', robots_txt),
     url(r'^auth/', include('uaa_client.urls', namespace='uaa_client')),
 ]
 
 tests_url = url(r'^tests/$', TemplateView.as_view(template_name='tests.html'))
-
-styleguide_url = url(r'^styleguide/', include('styleguide.urls',
-                                              namespace='styleguide'))
 
 if settings.DEBUG:
     import debug_toolbar
@@ -38,5 +36,4 @@ if settings.DEBUG:
                           namespace='fake_uaa_provider')),
         url(r'^__debug__/', include(debug_toolbar.urls)),
         tests_url,
-        styleguide_url,
     ]

--- a/styleguide/tests.py
+++ b/styleguide/tests.py
@@ -1,6 +1,12 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
+
+from hourglass.urls import urlpatterns, styleguide_url
 
 
+urlpatterns += [styleguide_url]
+
+
+@override_settings(ROOT_URLCONF=__name__)
 class StyleguideTests(TestCase):
 
     def test_styleguide_returns_200(self):

--- a/styleguide/tests.py
+++ b/styleguide/tests.py
@@ -1,12 +1,6 @@
-from django.test import TestCase, override_settings
-
-from hourglass.urls import urlpatterns, styleguide_url
+from django.test import TestCase
 
 
-urlpatterns += [styleguide_url]
-
-
-@override_settings(ROOT_URLCONF=__name__)
 class StyleguideTests(TestCase):
 
     def test_styleguide_returns_200(self):


### PR DESCRIPTION
I thought we had an issue filed for this but apparently we don't, or I can't find it.

This disables the `/tests/` ~~and `/styleguide/`~~ endpoint on production, purely for the sake of reducing the attack surface of the app.

~~I'm not sure how I feel about disabling the styleguide here, actually.  It's nice to be able to easily point to it as an example of a style guide (of sorts).  I guess we could add another environment setting that allows it to be exposed even when `DEBUG` is `False`, which we can enable on dev/staging but not prod...~~

~~Note that this PR is currently against #564 because that PR changes `urlpatterns` to be standard arrays. We can always re-target this PR to `develop` if that PR is merged before this one though.~~