### PR TITLE
Enable aria alerts for ajaxform.

### DIFF
--- a/data_capture/templates/data_capture/messages.html
+++ b/data_capture/templates/data_capture/messages.html
@@ -1,5 +1,5 @@
 {% if messages %}
-<div class="alerts">
+<div class="alerts" role="alert">
   {% for message in messages %}
     <div class="alert alert-{{ message.tags }}">
       <p>{{ message }}</p>

--- a/frontend/source/js/data-capture/ajaxform.js
+++ b/frontend/source/js/data-capture/ajaxform.js
@@ -125,9 +125,9 @@ function bindForm() {
       req.done((data) => {
         if (data.form_html) {
           replaceForm(data.form_html);
-          let newForm = bindForm();
+          const newForm = bindForm();
           if (newForm) {
-            let newAlerts = $('[role="alert"]', newForm.form).clone();
+            const newAlerts = $('[role="alert"]', newForm.form).clone();
             $ariaAlerts.append(newAlerts);
           }
         } else if (data.redirect_url) {

--- a/frontend/source/js/tests/ajaxform_tests.js
+++ b/frontend/source/js/tests/ajaxform_tests.js
@@ -56,7 +56,7 @@ function makeFormHtml(extraOptions) {
   }
 
   if (options.alert) {
-    $('form', $form).append('<div role="alert">' + options.alert + '</div>');
+    $('form', $form).append(`<div role="alert">${options.alert}</div>`);
   }
 
   $form.find('input[name="foo"]').attr('value', options.fooValue);

--- a/styleguide/ajaxform_example.py
+++ b/styleguide/ajaxform_example.py
@@ -1,6 +1,7 @@
 import time
 from django import forms
 from django.http import HttpResponse
+from django.contrib import messages
 
 from frontend import ajaxform
 from frontend.upload import UploadWidget
@@ -57,6 +58,9 @@ def view(request):
                 raise Exception('Here is the 500 your ordered.')
             else:
                 return HttpResponse('Here is an unexpected response.')
+
+        messages.add_message(request, messages.ERROR,
+                             'Alas, your form submission had errors.')
 
     return ajaxform.render(
         request,

--- a/styleguide/templates/styleguide_ajaxform_example.html
+++ b/styleguide/templates/styleguide_ajaxform_example.html
@@ -3,6 +3,10 @@
       action="{% url 'styleguide:ajaxform' %}">
   {% csrf_token %}
 
+  {% if request.is_ajax %}
+  {% include 'data_capture/messages.html' %}
+  {% endif %}
+
   {% with form=ajaxform_form %}
     {{ form.non_field_errors }}
     {{ form.question.errors }}


### PR DESCRIPTION
This is an attempt to fix #481.

Unfortunately I was hoping just adding `aria-live` somewhere would be enough, but it's not, really. The [web accessibility tutorial on user notifications - listing errors](https://www.w3.org/WAI/tutorials/forms/notifications/#listing-errors) spells everything out in detail, but the gist of it is that we need a `<div role="alert">` at the top of the page that we put stuff in when new stuff is loaded into the page. Blech.

This PR attempts to accomplish this by copying any elements with `role="alert"` and pasting them into a screenreader-only `<div role="alert">` at the top of the page.
