### PR TITLE
Remove steps widget from the a11y tree.

### DIFF
--- a/data_capture/templates/data_capture/step.html
+++ b/data_capture/templates/data_capture/step.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Add price data to CALC / {% block subtitle %}{% endblock %}{% endblock %}
+{% block title %}Add price data to CALC / Step {{ step_number }} of {{ NUM_STEPS }}: {% block subtitle %}{% endblock %}{% endblock %}
 
 {% block head %}
 <script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
@@ -15,7 +15,10 @@
 
 <div class="container">
 
-<h1>Add price data to CALC</h1>
+<h1>
+  Add price data to CALC
+  <span class="sr-only">step {{ step_number }} of {{ NUM_STEPS }}</span>
+</h1>
 
 {% block step_heading %}{% endblock %}
 

--- a/data_capture/templates/data_capture/step.html
+++ b/data_capture/templates/data_capture/step.html
@@ -19,7 +19,7 @@
 
 {% block step_heading %}{% endblock %}
 
-<ol class="steps">
+<ol class="steps" aria-hidden="true">
   <li {% if step_number == 1 %}class="current"{% endif %}>
     <label>Upload price list</label>
   </li>

--- a/data_capture/views.py
+++ b/data_capture/views.py
@@ -11,6 +11,16 @@ from .schedules import registry
 from frontend import ajaxform
 
 
+def step_ctx(step_number, ctx=None):
+    final_ctx = {
+        'step_number': step_number,
+        'NUM_STEPS': NUM_STEPS
+    }
+    if ctx:
+        final_ctx.update(ctx)
+    return final_ctx
+
+
 def add_generic_form_error(request, form):
     messages.add_message(
         request, messages.ERROR,
@@ -38,11 +48,10 @@ def step_1(request):
 
     return ajaxform.render(
         request,
-        context={
-            'step_number': 1,
+        context=step_ctx(1, {
             'form': form,
             'show_debug_ui': settings.DEBUG and not settings.HIDE_DEBUG_UI
-        },
+        }),
         template_name='data_capture/step_1.html',
         ajax_template_name='data_capture/step_1_form.html',
     )
@@ -67,12 +76,11 @@ def step_2(request, gleaned_data):
         request.session['data_capture:schedule']
     )
 
-    return render(request, 'data_capture/step_2.html', {
-        'step_number': 2,
+    return render(request, 'data_capture/step_2.html', step_ctx(2, {
         'gleaned_data': gleaned_data,
         'is_preferred_schedule': isinstance(gleaned_data, preferred_schedule),
         'preferred_schedule': preferred_schedule,
-    })
+    }))
 
 
 @login_required
@@ -103,13 +111,19 @@ def step_3(request, gleaned_data):
         else:
             add_generic_form_error(request, form)
 
-    return render(request, 'data_capture/step_3.html', {
-        'step_number': 3,
+    return render(request, 'data_capture/step_3.html', step_ctx(3, {
         'form': form
-    })
+    }))
 
 
 def step_4(request):
-    return render(request, 'data_capture/step_4.html', {
-        'step_number': 4
-    })
+    return render(request, 'data_capture/step_4.html', step_ctx(4))
+
+
+def get_num_steps():
+    for i in range(1, 999):
+        if 'step_%d' % i not in globals():
+            return i - 1
+
+
+NUM_STEPS = get_num_steps()

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -119,11 +119,21 @@
   </p>
 
   <p>
-    Use <code>li.steps-done</code> to identify a step as being completed.
+    Use <code>li.current</code> to identify a step as being the current
+    one.
+  </p>
+
+  <p>
+    We recommend adding <code>aria-hidden="true"</code> to the list, as
+    there isn't an easy way to communicate the information to vision-impaired
+    users without being overly verbose (thus annoying the user) or confusing.
+    However, <em>do</em> be sure to repeat the name of the current step
+    elsewhere in a header, so that the user knows what step they're currently
+    on.
   </p>
 
   {% example %}
-  <ol class="steps">
+  <ol class="steps" aria-hidden="true">
     <li>
       <label>Upload price list</label>
     </li>


### PR DESCRIPTION
Ok, this is *one* approach to fix #413--by simply removing the steps widget from the accessibility tree entirely.

I think there's a decent argument for this: the fact that it's repeated on every step could get really annoying to vision-impaired users.  And we're always reiterating the current step via a `<h1>` or `<h2>` header on the page, so the user won't be lost if we hide the widget from them.  Hiding the widget also ensures that they won't be confused by it (which will currently be the case, since there's no way for them to tell which step they're currently on--it just sounds like a list of steps).

If this doesn't seem like a good idea to folks, we can go with the solution proposed in #413, whereby we add a `sr-only` "You have completed this step" / "You are currently on this step" / "You haven't reached this step yet" to every single list item.  But this will likely require writing a template helper or something, since it'll get extremely repetitive to write this out for every single step widget we use; as I mentioned earlier, I also have doubts as to the usefulness of even doing this.  It'd be nice to at least do some user testing before embarking on that path.