### PR TITLE
Friendlier ajax error copy.

### DIFF
--- a/frontend/source/js/data-capture/ajaxform.js
+++ b/frontend/source/js/data-capture/ajaxform.js
@@ -2,6 +2,9 @@
 
 const $ = jQuery;
 
+const MISC_ERROR = 'Sorry, we’re having trouble. ' +
+                   'Please try again later or refresh your browser.';
+
 let delegate = {
   redirect(url) {
     window.location = url;
@@ -108,13 +111,13 @@ function bindForm() {
         } else if (data.redirect_url) {
           delegate.redirect(data.redirect_url);
         } else {
-          delegate.alert(`Invalid server response: ${data}`);
+          delegate.alert(MISC_ERROR);
           $(form).removeClass('submit-in-progress');
         }
       });
 
       req.fail(() => {
-        delegate.alert('An error occurred when submitting your data.');
+        delegate.alert(MISC_ERROR);
         $(form).removeClass('submit-in-progress');
       });
     }
@@ -129,6 +132,7 @@ exports.setDelegate = newDelegate => {
   delegate = newDelegate;
   return delegate;
 };
+exports.MISC_ERROR = MISC_ERROR;
 exports.getForm = getForm;
 exports.bindForm = bindForm;
 

--- a/frontend/source/js/tests/ajaxform_tests.js
+++ b/frontend/source/js/tests/ajaxform_tests.js
@@ -177,9 +177,7 @@ advancedTest('500 results in alert', assert => {
 
   server.requests[0].respond(500);
 
-  assert.ok(delegate.alert.calledWith(
-    'An error occurred when submitting your data.'
-  ));
+  assert.ok(delegate.alert.calledWith(ajaxform.MISC_ERROR));
 });
 
 advancedTest('unrecognized 200 results in alert', assert => {
@@ -192,7 +190,5 @@ advancedTest('unrecognized 200 results in alert', assert => {
 
   server.requests[0].respond(200);
 
-  assert.ok(delegate.alert.calledWith(
-    'Invalid server response: '
-  ));
+  assert.ok(delegate.alert.calledWith(ajaxform.MISC_ERROR));
 });


### PR DESCRIPTION
This is an attempt to fix #456 by using friendlier copy when network or other unexpected errors occur. I [asked on `#g-content`](https://18f.slack.com/archives/g-content/p1471615533000559) in Slack and they recommended this:

> <img width="456" alt="screen shot 2016-08-19 at 10 36 11 am" src="https://cloud.githubusercontent.com/assets/124687/17813480/8aeda8e2-65f9-11e6-8b32-96b4996e2333.png">

Because these errors happen so infrequently (um, hopefully), I think it's ok to keep using a standard `window.alert()` for now, but let me know if you disagree!
