### PR TITLE
Add custom HTML5 form validation messaging for upload widget

### DIFF
--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -45,6 +45,20 @@ class UploadInput extends window.HTMLInputElement {
     $(this).on('change', () => {
       this.upgradedValue = this.files[0];
     });
+    if (this.hasAttribute('required')) {
+      // We don't want the browser to enforce the required attribute, because
+      // if we programmatically set our file (e.g. via a drag-and-drop)
+      // the browser will still think the file input is empty.
+
+      this.removeAttribute('required');
+
+      // Instead, we'll set our own custom validity manually, assuming the
+      // user's browser supports HTML5 form validation.
+
+      if (this.setCustomValidity) {
+        this.setCustomValidity('Please choose a file.');
+      }
+    }
   }
 
   get upgradedValue() {
@@ -63,6 +77,11 @@ class UploadInput extends window.HTMLInputElement {
 
     this._upgradedValue = file;
     $(this).val('');
+
+    if (this.setCustomValidity) {
+      this.setCustomValidity('');
+    }
+
     dispatchBubbly(this, 'changefile', {
       detail: file,
     });

--- a/frontend/source/js/tests/upload_tests.js
+++ b/frontend/source/js/tests/upload_tests.js
@@ -1,4 +1,7 @@
 /* global QUnit jQuery document test QUNIT_FIXTURE_DATA */
+
+const sinon = require('sinon');
+
 (function uploadTests(QUnit, $) {
   const UPLOAD_HTML = QUNIT_FIXTURE_DATA.UPLOAD_TESTS_HTML;
 
@@ -62,6 +65,38 @@
 
   test('$.support.advancedUpload is a boolean', (assert) => {
     assert.equal(typeof $.support.advancedUpload, 'boolean');
+  });
+
+  test('upload-input removes "required" attr on upgrade', assert => {
+    upload = document.createElement('input', { is: 'upload-input' });
+    upload.setAttribute('required', '');
+    upload.upgrade();
+    assert.ok(!upload.hasAttribute('required'));
+  });
+
+  test('upload-input calls setCustomValidity() if required', assert => {
+    upload = document.createElement('input', { is: 'upload-input' });
+    upload.setAttribute('required', '');
+    upload.setCustomValidity = sinon.spy();
+    upload.upgrade();
+    assert.deepEqual(upload.setCustomValidity.args, [
+      ['Please choose a file.'],
+    ]);
+    upload.upgradedValue = 'fakefile';
+    assert.deepEqual(upload.setCustomValidity.args, [
+      ['Please choose a file.'],
+      [''],
+    ]);
+    assert.ok(upload.upgradedValue, 'fakefile');
+  });
+
+  test('upload-input works when setCustomValidity is undefined', assert => {
+    upload = document.createElement('input', { is: 'upload-input' });
+    upload.setAttribute('required', '');
+    upload.setCustomValidity = undefined;
+    upload.upgrade();
+    upload.upgradedValue = 'fakefile';
+    assert.ok(upload.upgradedValue, 'fakefile');
   });
 
   degradedTest('degraded upload has falsy .isUpgraded', (assert) => {

--- a/frontend/upload.py
+++ b/frontend/upload.py
@@ -9,10 +9,11 @@ class UploadWidget(forms.widgets.FileInput):
     It is tightly coupled to upload.js.
     '''
 
-    def __init__(self, attrs=None, degraded=False,
+    def __init__(self, attrs=None, degraded=False, required=True,
                  accept=(".xlsx", ".xls", ".csv"),
                  extra_instructions='XLS, XLSX, or CSV format, please.'):
         super().__init__(attrs=attrs)
+        self.required = required
         self.degraded = degraded
         self.accept = accept
         self.extra_instructions = extra_instructions
@@ -22,6 +23,13 @@ class UploadWidget(forms.widgets.FileInput):
         final_attrs = {}
         if attrs:
             final_attrs.update(attrs)
+
+        if self.required:
+            # TODO: Django 1.10 automatically adds this attribute as needed
+            # based on the form field, so we should remove this once we
+            # upgrade.
+            final_attrs['required'] = ''
+
         final_attrs['accept'] = ",".join(self.accept)
         final_attrs['is'] = 'upload-input'
 


### PR DESCRIPTION
This adds HTML5 form validation support to the upload widget so that users with supported browsers will see the following if they click "submit" without uploading a required file:

> ![screen shot 2016-08-22 at 5 03 20 pm](https://cloud.githubusercontent.com/assets/124687/17871627/5e96b048-688a-11e6-8b96-630b3c2a9ac1.png)

I think this is a more humane solution than graying out the submit button (#585) because it tells the user *why* they can't submit the form.  This could be particularly useful for larger forms, where there could be many reasons why they can't submit the form.

Aside from that, it's also technically much simpler than #585.

Of course, server-side form validation still works too, so users on older browsers will just get a slightly degraded experience.

To do:

- [x] Add tests.
