### PR TITLE
Gray out submit button if ajax form is invalid

### DIFF
--- a/frontend/source/js/data-capture/feature-detection.js
+++ b/frontend/source/js/data-capture/feature-detection.js
@@ -17,6 +17,12 @@ module.exports = {
     return 'FileReader' in window;
   },
 
+  formValidation() {
+    // http://stackoverflow.com/a/8550926
+    const input = document.createElement('input');
+    return typeof input.checkValidity === 'function';
+  },
+
   // We'd like to make it possible to forcibly degrade components that have
   // a `data-force-degradation` attribute on them or one of their
   // ancestors. This makes it easier to test degraded functionality and

--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -42,6 +42,9 @@ class UploadInput extends window.HTMLInputElement {
 
   upgrade() {
     this.isUpgraded = true;
+    if (supports.formValidation()) {
+      this.setCustomValidity('You must choose a file.');
+    }
     $(this).on('change', () => {
       this.upgradedValue = this.files[0];
     });
@@ -59,6 +62,10 @@ class UploadInput extends window.HTMLInputElement {
     if (!isFileValid(file, this)) {
       dispatchBubbly(this, 'invalidfile');
       return;
+    }
+
+    if (supports.formValidation()) {
+      this.setCustomValidity('');
     }
 
     this._upgradedValue = file;


### PR DESCRIPTION
This is basically a broader version of what our ajax form currently does--it disables the submit button on the form (i.e., grays it out and makes it unclickable) if *any* field is invalid, by consulting the HTML5 form validation API:

> ![screen shot 2016-08-22 at 5 53 43 pm](https://cloud.githubusercontent.com/assets/124687/17873075/6da1155e-6891-11e6-9aae-3d3d5f07d54f.png)

There's some reasons I don't like this approach:

* It's not actually very user-friendly, because we're not giving the user any feedback on *why* the submit button is disabled. This could get particularly bad for very large forms. In fact, because we're making the submit button unclickable, it renders a lot of valuable user feedback mediated via the HTML5 form validation API unreachable.

* I am not a fan of the technical implementation. Right now it actually works by polling the form every 250ms; the alternative would be to re-check the form's validity every time some kind of event occurs that might result in a valid form, but this list of events would be hard to maintain, and forgetting one could result in a lot of user frustration. Blerg.

For an alternate solution that I find both more humane and technically simpler, see #584.

To do:

- [ ] Add tests.
- [ ] Make it work w/ multiple kinds of submit buttons (e.g. `<input>` and `<button>`).
