### PR TITLE
Log JS bundle writes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,7 +173,11 @@ function browserifyBundle(entryPath, outputPath, outputFile) {
       .pipe(sourcemaps.init({ loadMaps: true }))
         .pipe(uglify())
       .pipe(sourcemaps.write('./'))
-      .pipe(gulp.dest(outputPath));
+      .pipe(gulp.dest(outputPath)).on('data', function(e) {
+        const pathname = path.relative(__dirname, e.path);
+
+        gutil.log(`Wrote ${pathname}.`);
+      });
   }
 
   if (isWatching) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,8 +173,9 @@ function browserifyBundle(entryPath, outputPath, outputFile) {
       .pipe(sourcemaps.init({ loadMaps: true }))
         .pipe(uglify())
       .pipe(sourcemaps.write('./'))
-      .pipe(gulp.dest(outputPath)).on('data', function(e) {
-        const pathname = path.relative(__dirname, e.path);
+      .pipe(gulp.dest(outputPath))
+      .on('data', file => {
+        const pathname = path.relative(__dirname, file.path);
 
         gutil.log(`Wrote ${pathname}.`);
       });


### PR DESCRIPTION
I'm experiencing some weird issues where every so often, it seems like JS bundle files aren't being written to my filesystem, at least not for a really long time.

Even regularly, though, there are at least 1-2 seconds in between when the last log message from gulp displays (e.g. `Finished 'lint' after 698 ms`) and when the JS bundle is actually written to the filesystem.  This means that I sometimes reload my browser page before the JS bundle has actually been written, which leaves me constantly paranoid about whether or not I'm viewing a page that has my latest code changes in it.

This PR just adds a log message at the end of writing the bundle, so I know when JS is actually written to disk, e.g.:

```
gulp_1  | [21:09:38] -> Rebundling frontend/source/js/tests/index.js
gulp_1  | [21:09:39] Finished 'js:common:base' after 453 ms
gulp_1  | [21:09:39] Finished 'js:data-explorer:index' after 475 ms
gulp_1  | [21:09:39] Starting 'js:legacy'...
gulp_1  | [21:09:39] Finished 'js:legacy' after 7.39 μs
gulp_1  | [21:09:39] Finished 'lint' after 698 ms
gulp_1  | [21:09:41] Wrote frontend/static/frontend/built/js/tests/index.min.js.map.
gulp_1  | [21:09:41] Wrote frontend/static/frontend/built/js/tests/index.min.js.
```

I'm hoping this will also help me debug the situations where the JS bundles don't seem to be written for a *really* long time.
