### PR TITLE
Make it possible to sort and "mute" individual price list rows

### DIFF
--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -48,6 +48,7 @@ approve.short_description = (
     'Approve selected price lists (add their data to CALC)'
 )
 
+
 def unapprove(modeladmin, request, queryset):
     for obj in queryset.filter(is_approved=True):
         obj.unapprove()

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -85,6 +85,10 @@ class SubmittedPriceListAdmin(admin.ModelAdmin):
         'current_status'
     )
 
+    list_filter = (
+        'is_approved',
+    )
+
     inlines = [
         SubmittedPriceListRowInline
     ]

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 from django.db import models
 from django import forms
+from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 from .schedules import registry
 from .models import SubmittedPriceList, SubmittedPriceListRow
@@ -12,7 +14,20 @@ class SubmittedPriceListRowInline(admin.TabularInline):
 
     can_delete = False
 
-    exclude = ('contract_model',)
+    fields = (
+        'labor_category',
+        'education_level',
+        'min_years_experience',
+        'hourly_rate_year1',
+        'current_price',
+        'sin',
+        'is_muted',
+    )
+
+    # Because of the fact that inline formsets are saved
+    # *after* their parent model, it's safest to not allow
+    # any of our fields to be editable.
+    readonly_fields = fields
 
     formfield_overrides = {
         models.TextField: {'widget': forms.TextInput}
@@ -27,9 +42,24 @@ class SubmittedPriceListAdmin(admin.ModelAdmin):
     list_display = ('contract_number', 'vendor_name', 'submitter',
                     'is_approved')
 
-    exclude = ('serialized_gleaned_data', 'schedule')
+    fields = (
+        'contract_number',
+        'vendor_name',
+        'is_small_business',
+        'schedule_title',
+        'contractor_site',
+        'contract_year',
+        'contract_start',
+        'contract_end',
+        'submitter',
+        'is_approved',
+        'current_status',
+    )
 
-    readonly_fields = ('schedule_title', 'current_status')
+    readonly_fields = (
+        'schedule_title',
+        'current_status'
+    )
 
     inlines = [
         SubmittedPriceListRowInline
@@ -69,3 +99,60 @@ class SubmittedPriceListAdmin(admin.ModelAdmin):
             else:
                 obj.unapprove()
         obj.save()
+
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = self.readonly_fields
+        if obj and obj.is_approved:
+            readonly_fields = tuple([
+                field for field in self.fields
+                if field != 'is_approved'
+            ])
+        return readonly_fields
+
+
+@admin.register(SubmittedPriceListRow)
+class SubmittedPriceListRowAdmin(admin.ModelAdmin):
+    list_display = (
+        'contract_number',
+        'vendor_name',
+        'labor_category',
+        'education_level',
+        'min_years_experience',
+        'hourly_rate_year1',
+        'current_price',
+        'sin',
+        'is_muted',
+    )
+
+    list_editable = (
+        'is_muted',
+    )
+
+    # http://stackoverflow.com/a/25813184/2422398
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        del actions['delete_selected']
+        return actions
+
+    def contract_number(self, obj):
+        url = reverse('admin:data_capture_submittedpricelist_change',
+                      args=(obj.price_list.id,))
+        return format_html(
+            '<a href="{}">{}</a>',
+            url,
+            obj.price_list.contract_number
+        )
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.filter(price_list__is_approved=False)
+
+    def vendor_name(self, obj):
+        return obj.price_list.vendor_name
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -79,8 +79,25 @@ unapprove.short_description = (
 )
 
 
+class UndeletableModelAdmin(admin.ModelAdmin):
+    '''
+    Represents a model admin UI that offers no way of deleting
+    instances. This is useful to ensure accidental data loss, especially
+    when we want to keep it around for historical/data provenance purposes.
+    '''
+
+    # http://stackoverflow.com/a/25813184/2422398
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        del actions['delete_selected']
+        return actions
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 @admin.register(SubmittedPriceList)
-class SubmittedPriceListAdmin(admin.ModelAdmin):
+class SubmittedPriceListAdmin(UndeletableModelAdmin):
     list_display = ('contract_number', 'vendor_name', 'submitter',
                     'created_at', 'is_approved')
 
@@ -142,16 +159,7 @@ class SubmittedPriceListAdmin(admin.ModelAdmin):
 
     schedule_title.short_description = 'Schedule'
 
-    # http://stackoverflow.com/a/25813184/2422398
-    def get_actions(self, request):
-        actions = super().get_actions(request)
-        del actions['delete_selected']
-        return actions
-
     def has_add_permission(self, request):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
         return False
 
     def get_readonly_fields(self, request, obj=None):
@@ -161,7 +169,7 @@ class SubmittedPriceListAdmin(admin.ModelAdmin):
 
 
 @admin.register(SubmittedPriceListRow)
-class SubmittedPriceListRowAdmin(admin.ModelAdmin):
+class SubmittedPriceListRowAdmin(UndeletableModelAdmin):
     list_display = (
         'contract_number',
         'vendor_name',
@@ -177,12 +185,6 @@ class SubmittedPriceListRowAdmin(admin.ModelAdmin):
     list_editable = (
         'is_muted',
     )
-
-    # http://stackoverflow.com/a/25813184/2422398
-    def get_actions(self, request):
-        actions = super().get_actions(request)
-        del actions['delete_selected']
-        return actions
 
     def contract_number(self, obj):
         url = reverse('admin:data_capture_submittedpricelist_change',
@@ -201,7 +203,4 @@ class SubmittedPriceListRowAdmin(admin.ModelAdmin):
         return obj.price_list.vendor_name
 
     def has_add_permission(self, request):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
         return False

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -100,7 +100,9 @@ class SubmittedPriceListAdmin(admin.ModelAdmin):
                 "This price list has been approved, so its data is now "
                 "in CALC. To unapprove it, you will need to use the "
                 "'Unapprove selected price lists' action from the "
-                "<a href=\"..\">list view</a>."
+                "<a href=\"..\">list view</a>. Note also that in order "
+                "to edit the fields in this price list, you will first "
+                "need to unapprove it."
             )
         return mark_safe(
             "<span style=\"color: red\">"

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -118,6 +118,12 @@ class SubmittedPriceListAdmin(admin.ModelAdmin):
 
     schedule_title.short_description = 'Schedule'
 
+    # http://stackoverflow.com/a/25813184/2422398
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        del actions['delete_selected']
+        return actions
+
     def has_add_permission(self, request):
         return False
 

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -4,6 +4,8 @@ from django import forms
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.html import format_html
+from django.contrib import messages
+
 
 from .schedules import registry
 from .models import SubmittedPriceList, SubmittedPriceListRow
@@ -40,8 +42,17 @@ class SubmittedPriceListRowInline(admin.TabularInline):
 
 
 def approve(modeladmin, request, queryset):
-    for obj in queryset.filter(is_approved=False):
+    unapproved = queryset.filter(is_approved=False)
+    count = unapproved.count()
+    for obj in unapproved:
         obj.approve()
+    messages.add_message(
+        request,
+        messages.INFO,
+        '{} price list(s) have been approved and added to CALC.'.format(
+            count
+        )
+    )
 
 
 approve.short_description = (
@@ -50,8 +61,17 @@ approve.short_description = (
 
 
 def unapprove(modeladmin, request, queryset):
-    for obj in queryset.filter(is_approved=True):
+    approved = queryset.filter(is_approved=True)
+    count = approved.count()
+    for obj in approved:
         obj.unapprove()
+    messages.add_message(
+        request,
+        messages.INFO,
+        '{} price list(s) have been unapproved and removed from CALC.'.format(
+            count
+        )
+    )
 
 
 unapprove.short_description = (

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -82,7 +82,7 @@ unapprove.short_description = (
 @admin.register(SubmittedPriceList)
 class SubmittedPriceListAdmin(admin.ModelAdmin):
     list_display = ('contract_number', 'vendor_name', 'submitter',
-                    'is_approved')
+                    'created_at', 'is_approved')
 
     actions = [approve, unapprove]
 
@@ -96,12 +96,16 @@ class SubmittedPriceListAdmin(admin.ModelAdmin):
         'contract_start',
         'contract_end',
         'submitter',
+        'created_at',
+        'updated_at',
         'is_approved',
         'current_status',
     )
 
     readonly_fields = (
         'schedule_title',
+        'created_at',
+        'updated_at',
         'is_approved',
         'current_status'
     )

--- a/data_capture/migrations/0003_auto_20160826_1930.py
+++ b/data_capture/migrations/0003_auto_20160826_1930.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.utils.timezone import utc
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_capture', '0002_auto_20160823_2147'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='submittedpricelist',
+            name='created_at',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 26, 19, 30, 24, 636881, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='submittedpricelist',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, default=datetime.datetime(2016, 8, 26, 19, 30, 28, 408909, tzinfo=utc)),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='submittedpricelistrow',
+            name='is_muted',
+            field=models.BooleanField(default=False, help_text='Whether to include this row in CALC data once its price list has been approved'),
+        ),
+    ]

--- a/data_capture/models.py
+++ b/data_capture/models.py
@@ -5,6 +5,9 @@ from contracts.models import Contract, EDUCATION_CHOICES
 
 
 class SubmittedPriceList(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
     # This is the equivalent of Contract.idv_piid.
     contract_number = models.CharField(
         max_length=128,

--- a/data_capture/models.py
+++ b/data_capture/models.py
@@ -67,7 +67,7 @@ class SubmittedPriceList(models.Model):
 
     def approve(self):
         self.is_approved = True
-        for row in self.rows.all():
+        for row in self.rows.filter(is_muted=False):
             if row.contract_model is not None:
                 raise AssertionError()
             contract = Contract(
@@ -102,7 +102,7 @@ class SubmittedPriceList(models.Model):
     def unapprove(self):
         self.is_approved = False
 
-        for row in self.rows.all():
+        for row in self.rows.filter(is_muted=False):
             row.contract_model.delete()
 
         self.save()
@@ -118,6 +118,14 @@ class SubmittedPriceListRow(models.Model):
     current_price = models.DecimalField(
         max_digits=10, decimal_places=2, null=True, blank=True)
     sin = models.TextField(null=True, blank=True)
+
+    is_muted = models.BooleanField(
+        help_text=(
+            "Whether to include this row in CALC data once its "
+            "price list has been approved"
+        ),
+        default=False
+    )
 
     price_list = models.ForeignKey(
         SubmittedPriceList,

--- a/data_capture/templates/admin/data_capture/submittedpricelist/change_list.html
+++ b/data_capture/templates/admin/data_capture/submittedpricelist/change_list.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_list.html" %}
+
+{% block content %}
+<p>
+  You can use this page to approve or unapprove price lists
+  by check-marking one or more and using the <strong>Action</strong> drop-down.
+</p>
+<p>
+  If you'd like to preview the actual data for unapproved
+  price lists and mute individual entries, see the
+  <a href="{% url 'admin:data_capture_submittedpricelistrow_changelist' %}">Submitted price list row</a> admin page.
+</p>
+{{ block.super }}
+{% endblock %}

--- a/data_capture/templates/admin/data_capture/submittedpricelistrow/change_list.html
+++ b/data_capture/templates/admin/data_capture/submittedpricelistrow/change_list.html
@@ -1,0 +1,18 @@
+{% extends "admin/change_list.html" %}
+
+{% block content %}
+<p>
+  The following rows are <em>only</em> for unapproved price lists that
+  haven't yet made their way into CALC.
+</p>
+<p>
+  For rows that are somehow out-of-the-ordinary, you can click the
+  <strong>Is muted</strong> checkbox to prevent it from being included in
+  CALC's data once you approve the price list.
+</p>
+<p>
+  Remember to click the <strong>Save</strong> button to submit your
+  changes.
+</p>
+{{ block.super }}
+{% endblock %}

--- a/data_capture/templates/admin/data_capture/submittedpricelistrow/change_list.html
+++ b/data_capture/templates/admin/data_capture/submittedpricelistrow/change_list.html
@@ -14,5 +14,10 @@
   Remember to click the <strong>Save</strong> button to submit your
   changes.
 </p>
+<p>
+  Once you've muted any necessary rows, you can visit the
+  <a href="{% url 'admin:data_capture_submittedpricelist_changelist' %}">Submitted price list</a> admin page to approve the data
+  for inclusion into CALC.
+</p>
 {{ block.super }}
 {% endblock %}

--- a/data_capture/tests/test_admin.py
+++ b/data_capture/tests/test_admin.py
@@ -1,0 +1,47 @@
+from django.test import override_settings
+
+from .common import FAKE_SCHEDULE
+from .test_models import ModelTestCase
+
+
+@override_settings(
+    DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE],
+    # Strangely, disabling DEBUG mode silences some errors in Django
+    # admin views, so we'll enforce it so that any errors are raised.
+    DEBUG=True
+)
+class AdminTests(ModelTestCase):
+    def setUp(self):
+        super().setUp()
+        self.price_list = self.create_price_list()
+        self.price_list.save()
+        self.row = self.create_row(price_list=self.price_list)
+        self.row.save()
+
+    def setup_user(self):
+        self.user = self.login(is_superuser=True)
+
+    def test_submittedpricelistrow_list_returns_200(self):
+        res = self.client.get('/admin/data_capture/submittedpricelistrow/')
+        self.assertEqual(res.status_code, 200)
+
+    def test_submittedpricelist_list_returns_200(self):
+        res = self.client.get('/admin/data_capture/submittedpricelist/')
+        self.assertEqual(res.status_code, 200)
+
+    def test_unapproved_submittedpricelist_detail_returns_200(self):
+        res = self.client.get(
+            '/admin/data_capture/submittedpricelist/{}/'.format(
+                self.price_list.id
+            )
+        )
+        self.assertEqual(res.status_code, 200)
+
+    def test_approved_submittedpricelist_detail_returns_200(self):
+        self.price_list.approve()
+        res = self.client.get(
+            '/admin/data_capture/submittedpricelist/{}/'.format(
+                self.price_list.id
+            )
+        )
+        self.assertEqual(res.status_code, 200)

--- a/data_capture/tests/test_admin.py
+++ b/data_capture/tests/test_admin.py
@@ -1,16 +1,16 @@
+from unittest.mock import patch
+from django.contrib import messages
 from django.test import override_settings
 
+from .. import admin, models
 from .common import FAKE_SCHEDULE
 from .test_models import ModelTestCase
 
 
 @override_settings(
     DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE],
-    # Strangely, disabling DEBUG mode silences some errors in Django
-    # admin views, so we'll enforce it so that any errors are raised.
-    DEBUG=True
 )
-class AdminTests(ModelTestCase):
+class AdminTestCase(ModelTestCase):
     def setUp(self):
         super().setUp()
         self.price_list = self.create_price_list()
@@ -21,6 +21,13 @@ class AdminTests(ModelTestCase):
     def setup_user(self):
         self.user = self.login(is_superuser=True)
 
+
+@override_settings(
+    # Strangely, disabling DEBUG mode silences some errors in Django
+    # admin views, so we'll enforce it so that any errors are raised.
+    DEBUG=True,
+)
+class ViewTests(AdminTestCase):
     def test_submittedpricelistrow_list_returns_200(self):
         res = self.client.get('/admin/data_capture/submittedpricelistrow/')
         self.assertEqual(res.status_code, 200)
@@ -45,3 +52,48 @@ class AdminTests(ModelTestCase):
             )
         )
         self.assertEqual(res.status_code, 200)
+
+
+@patch.object(messages, 'add_message')
+class ActionTests(AdminTestCase):
+    def test_approve_ignores_approved_price_lists(self, mock):
+        self.price_list.approve()
+        admin.approve(None, "fake request",
+                      models.SubmittedPriceList.objects.all())
+        mock.assert_called_once_with(
+            "fake request",
+            messages.INFO,
+            '0 price list(s) have been approved and added to CALC.'
+        )
+
+    def test_unapprove_ignores_unapproved_price_lists(self, mock):
+        admin.unapprove(None, "fake request",
+                        models.SubmittedPriceList.objects.all())
+        mock.assert_called_once_with(
+            "fake request",
+            messages.INFO,
+            '0 price list(s) have been unapproved and removed from CALC.'
+        )
+
+    def test_approve_works(self, mock):
+        admin.approve(None, "fake request",
+                      models.SubmittedPriceList.objects.all())
+        mock.assert_called_once_with(
+            "fake request",
+            messages.INFO,
+            '1 price list(s) have been approved and added to CALC.'
+        )
+        self.price_list.refresh_from_db()
+        self.assertTrue(self.price_list.is_approved)
+
+    def test_unapprove_works(self, mock):
+        self.price_list.approve()
+        admin.unapprove(None, "fake request",
+                        models.SubmittedPriceList.objects.all())
+        mock.assert_called_once_with(
+            "fake request",
+            messages.INFO,
+            '1 price list(s) have been unapproved and removed from CALC.'
+        )
+        self.price_list.refresh_from_db()
+        self.assertFalse(self.price_list.is_approved)

--- a/data_capture/tests/test_models.py
+++ b/data_capture/tests/test_models.py
@@ -87,6 +87,7 @@ class ModelsTests(ModelTestCase):
         row = self.create_row(labor_category='Software Engineer',
                               price_list=p)
         row.save()
+        self.create_row(price_list=p, is_muted=True).save()
         p.approve()
 
         self.assertEqual(Contract.objects.all().count(), 1)
@@ -101,8 +102,8 @@ class ModelsTests(ModelTestCase):
     def test_unapprove_works(self):
         p = self.create_price_list()
         p.save()
-        row = self.create_row(price_list=p)
-        row.save()
+        self.create_row(price_list=p).save()
+        self.create_row(price_list=p, is_muted=True).save()
         p.approve()
         p.unapprove()
 

--- a/data_capture/tests/test_models.py
+++ b/data_capture/tests/test_models.py
@@ -1,19 +1,22 @@
-from django.test import TestCase, override_settings
-from django.contrib.auth.models import User
+from django.test import override_settings
 
 from contracts.models import Contract
 from ..schedules import registry
 from ..schedules.fake_schedule import FakeSchedulePriceList
 from ..models import SubmittedPriceList, SubmittedPriceListRow
-from .common import FAKE_SCHEDULE
+from .common import BaseTestCase, FAKE_SCHEDULE
 
 
-class ModelTestCase(TestCase):
+class ModelTestCase(BaseTestCase):
     DEFAULT_SCHEDULE = FAKE_SCHEDULE
 
     def setUp(self):
-        self.user = User.objects.create_user(username='foo')
+        super().setUp()
         registry._init()
+        self.setup_user()
+
+    def setup_user(self):
+        self.user = self.create_user(username='foo')
 
     def create_price_list(self, **kwargs):
         final_kwargs = dict(
@@ -22,24 +25,6 @@ class ModelTestCase(TestCase):
             contract_number='GS-123-4567',
             vendor_name='UltraCorp',
             schedule=self.DEFAULT_SCHEDULE
-        )
-        final_kwargs.update(kwargs)
-        return SubmittedPriceList(**final_kwargs)
-
-
-@override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE])
-class ModelsTests(ModelTestCase):
-    def setUp(self):
-        self.user = User.objects.create_user(username='foo')
-        registry._init()
-
-    def create_price_list(self, **kwargs):
-        final_kwargs = dict(
-            submitter=self.user,
-            is_small_business=False,
-            contract_number='GS-123-4567',
-            vendor_name='UltraCorp',
-            schedule=FAKE_SCHEDULE
         )
         final_kwargs.update(kwargs)
         return SubmittedPriceList(**final_kwargs)
@@ -53,6 +38,9 @@ class ModelsTests(ModelTestCase):
         final_kwargs.update(kwargs)
         return SubmittedPriceListRow(**final_kwargs)
 
+
+@override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE])
+class ModelsTests(ModelTestCase):
     def test_add_row_works(self):
         p = self.create_price_list()
         p.save()


### PR DESCRIPTION
This adds a new "submitted price list row view" admin view that allows the data administrator to view all *unapproved* price list rows and "mute" them if they're out of the ordinary:

> ![screen shot 2016-08-24 at 5 42 24 pm](https://cloud.githubusercontent.com/assets/124687/17949189/3f519ab0-6a22-11e6-8198-e424484f2e85.png)

Unfortunately, actually *approving* the price lists is a different step and can be accomplished from the "submitted price list view":

> ![screen shot 2016-08-24 at 5 42 57 pm](https://cloud.githubusercontent.com/assets/124687/17949200/454b3926-6a22-11e6-9d66-d266a02516cd.png)

I'm not a huge fan of this but it's what seems to be easily doable via django admin customization, alas.

Other changes:

* The admin detail view for submitted price lists still exists, but the "is approved" field is no longer an editable checkbox--the *only* way that a price list can be approved is via the "Approve selected price lists" bulk action from the screenshot above.  The reasons for this are annoyingly technical, but hopefully it's not that big a deal since we expect data administrators to approve price lists in bulk anyways.

* When visiting an admin detail view for *approved* price lists, all fields are read-only. This has been done to ensure that the data administrator doesn't think that they're editing live CALC data.

To do:

- [x] Add tests for the `is_muted` functionality, at least. Would be nice to add tests for the django admin functionality too but I'm not sure how easy that will be.
- [x] Add a DB migration.
- [X] Ask Kelly if he thinks this is total crap. (He thinks it's fine.)
- [x] Remove the "Delete selected rows" action from price list admin view, or at least move it to the end, to make it harder to accidentally choose.
- [x] Add a date created field to price lists and show it in the change list view so that admins can make sure they're not approving lists that have just been added in the past few seconds or something.
- [ ] Include a [short comment](https://github.com/18F/calc/pull/602/files/62e7393656f8a379052cb7a2afa0c1a028763b2b#r76493796) on why we are removing the "delete selected entries" bulk action.
