### PR TITLE
Fix Dockerfile to work again based on /usr/bin/python change blah.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.4.5
 
 ENV PHANTOMJS_VERSION 1.9.7
 
@@ -11,13 +11,7 @@ RUN \
   mv /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/ /srv/var/phantomjs && \
   ln -s /srv/var/phantomjs/bin/phantomjs /usr/bin/phantomjs
 
-# As of 2016/08/02, this requires the Debian distributed version of
-# python 2.7 to be located at /usr/bin/python. However, the official
-# python 3 docker image we're using renames it, so we're going to
-# temporarily rename it *back* so that this command succeeds. Oy.
-RUN ln -s /usr/bin/python2.7.distrib /usr/bin/python && \
-  curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
-  rm /usr/bin/python
+RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
 
 # Note that we want postgresql-client so 'manage.py dbshell' works.
 RUN apt-get update && \


### PR DESCRIPTION
Blergh, in #526 we had to make a weird change to the dockerfile because the official Python Docker Hub image made `/usr/bin/python` inaccessible.

However, they just undid this in https://github.com/docker-library/python/pull/137, which made our weird change *break* our Dockerfile.  Awesome.

This undoes our weird change so that everything works again.

Blah.
