### PR TITLE
Only call attachedCallback() once on web components.

### DIFF
--- a/frontend/source/js/data-capture/ajaxform.js
+++ b/frontend/source/js/data-capture/ajaxform.js
@@ -31,6 +31,10 @@ exports.MISC_ERROR = MISC_ERROR;
 
 class AjaxForm extends window.HTMLFormElement {
   attachedCallback() {
+    if ('isDegraded' in this) {
+      return;
+    }
+
     this.isDegraded = !supports.formData() ||
                       supports.isForciblyDegraded(this);
     if (!this.isDegraded) {

--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -11,6 +11,10 @@ const HAS_BROWSER_SUPPORT = supports.dragAndDrop() && supports.formData() &&
 
 class UploadInput extends window.HTMLInputElement {
   attachedCallback() {
+    if ('isUpgraded' in this) {
+      return;
+    }
+
     this.isUpgraded = false;
     this._upgradedValue = null;
     if (this.getAttribute('type') !== 'file') {
@@ -107,6 +111,10 @@ class UploadWidget extends window.HTMLElement {
     if ($input.length !== 1 || $input.attr('is') !== 'upload-input') {
       throw new Error('<upload-widget> must contain exactly one ' +
                       '<input is="upload-input">.');
+    }
+
+    if ('isDegraded' in this) {
+      return;
     }
 
     this.uploadInput = $input[0];


### PR DESCRIPTION
Fixes #626.

Blerg, I thought for a while about how to test this and the only thing I could think of is to attach an event listener for the components' ready events, remove them from the DOM and re-attach them and wait a certain amount of time to make sure the ready events don't fire again.  But I don't really like that.
