### PR TITLE
Degrade upload widget if not in ajaxform

### DIFF
--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -100,6 +100,21 @@ class UploadWidget extends window.HTMLElement {
     event.preventDefault();
   }
 
+  _checkForAjaxFormParent() {
+    if (this.uploadInput.form &&
+        this.uploadInput.form.getAttribute('is') !== 'ajax-form') {
+      if (window.console && window.console.log) {
+        window.console.log(
+          'Warning: <upload-widget> must have a ' +
+          '<form is="ajax-form"> parent in order to support ' +
+          'drag-and-drop.'
+        );
+      }
+      return false;
+    }
+    return true;
+  }
+
   attachedCallback() {
     const $el = $(this);
     const $input = $('input', $el);
@@ -155,7 +170,8 @@ class UploadWidget extends window.HTMLElement {
       $el.append(err);
     }
 
-    if (!HAS_BROWSER_SUPPORT || supports.isForciblyDegraded(this)) {
+    if (!this._checkForAjaxFormParent() || !HAS_BROWSER_SUPPORT ||
+        supports.isForciblyDegraded(this)) {
       $el.addClass('degraded');
       this.isDegraded = true;
       return finishInitialization();

--- a/frontend/source/js/tests/upload_tests.js
+++ b/frontend/source/js/tests/upload_tests.js
@@ -69,6 +69,21 @@ import { UploadWidget } from '../data-capture/upload';
     assert.equal(typeof UploadWidget.HAS_BROWSER_SUPPORT, 'boolean');
   });
 
+  test('widget w/ non-ajaxform form is always degraded', assert => {
+    const div = document.createElement('div');
+    const done = assert.async();
+
+    div.addEventListener('uploadwidgetready', e => {
+      assert.ok(e.target.isDegraded);
+      done();
+    });
+
+    div.innerHTML = '<form style="display: none"><upload-widget>' +
+                    '<input type="file" is="upload-input">' +
+                    '</upload-widget></form>';
+    document.body.appendChild(div);
+  });
+
   test('upload-input removes "required" attr on upgrade', assert => {
     upload = document.createElement('input', { is: 'upload-input' });
     upload.setAttribute('required', '');


### PR DESCRIPTION
Fixes #628.

Note that `<upload-widget>` actually only cares if it's in a `<form>` that is not an ajaxform.  If it's not in a `<form>` *at all*, then it actually doesn't care, which allows us to still test it and stuff without having to put it in a form.
