### PR TITLE
Add /healthcheck/ endpoint

### DIFF
--- a/hourglass/healthcheck.py
+++ b/hourglass/healthcheck.py
@@ -1,0 +1,26 @@
+from django.http import JsonResponse
+from django.db.migrations.executor import MigrationExecutor
+from django.db import connections, DEFAULT_DB_ALIAS
+import django_rq
+
+
+def is_database_synchronized(database='default'):
+    connection = connections[database]
+    connection.prepare_database()
+    executor = MigrationExecutor(connection)
+    targets = executor.loader.graph.leaf_nodes()
+    return False if executor.migration_plan(targets) else True
+
+
+def healthcheck(request):
+    results = {
+        'is_database_synchronized': is_database_synchronized(),
+        'rq_jobs': len(django_rq.get_queue().jobs),
+    }
+
+    status_code = 200
+
+    if not results['is_database_synchronized']:
+        status_code = 500
+
+    return JsonResponse(results, status=status_code)

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from django.views.generic import TemplateView
 from django.contrib.auth.decorators import login_required
 
+from .healthcheck import healthcheck
 from .robots import robots_txt
 
 
@@ -17,6 +18,7 @@ urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='index.html'), name='index'),
     url(r'^about/$', TemplateView.as_view(template_name='about.html'),
         name='about'),
+    url(r'^healthcheck/', healthcheck),
     url(r'^api/', include('api.urls')),
     url(r'^data-capture/',
         include('data_capture.urls', namespace='data_capture')),


### PR DESCRIPTION
This fixes #625 by adding a `/healthcheck/` endpoint that checks to make sure the DB is synchronized and that redis/`rq` is working.
