### PR TITLE
Add an <alerts-widget>

### DIFF
--- a/data_capture/templates/data_capture/messages.html
+++ b/data_capture/templates/data_capture/messages.html
@@ -1,9 +1,9 @@
 {% if messages %}
-<div class="alerts">
+<alerts-widget>
   {% for message in messages %}
     <div class="alert alert-{{ message.tags }}">
       <p>{{ message }}</p>
     </div>
   {% endfor %}
-</div>
+</alerts-widget>
 {% endif %}

--- a/frontend/source/js/data-capture/alerts.js
+++ b/frontend/source/js/data-capture/alerts.js
@@ -1,5 +1,7 @@
 /* global window, document */
 
+import { dispatchBubbly } from './custom-event';
+
 /**
  * AlertsWidget represents an <alerts-widget> web component.
  *
@@ -13,6 +15,7 @@ class AlertsWidget extends window.HTMLInputElement {
   attachedCallback() {
     this.setAttribute('tabindex', '-1');
     this.focus();
+    dispatchBubbly(this, 'alertswidgetready');
   }
 }
 

--- a/frontend/source/js/data-capture/alerts.js
+++ b/frontend/source/js/data-capture/alerts.js
@@ -1,0 +1,10 @@
+class AlertsWidget extends window.HTMLInputElement {
+  attachedCallback() {
+    this.setAttribute('tabindex', '-1');
+    this.focus();
+  }
+}
+
+document.registerElement('alerts-widget', {
+  prototype: AlertsWidget.prototype,
+});

--- a/frontend/source/js/data-capture/alerts.js
+++ b/frontend/source/js/data-capture/alerts.js
@@ -1,9 +1,22 @@
+/* global window, document */
+
+/**
+ * AlertsWidget represents an <alerts-widget> web component.
+ *
+ * This component is useful for wrapping alerts that should be
+ * telegraphed to screen-reader users in particular, as it is
+ * focused when attached to the document tree, which causes screen
+ * readers to announce the content of the widget immediately.
+ */
+
 class AlertsWidget extends window.HTMLInputElement {
   attachedCallback() {
     this.setAttribute('tabindex', '-1');
     this.focus();
   }
 }
+
+AlertsWidget.prototype.SOURCE_FILENAME = __filename;
 
 document.registerElement('alerts-widget', {
   prototype: AlertsWidget.prototype,

--- a/frontend/source/js/data-capture/index.js
+++ b/frontend/source/js/data-capture/index.js
@@ -8,3 +8,4 @@ require('jquery-tablesort');
 require('./tablesort');
 require('./upload');
 require('./ajaxform');
+require('./alerts');

--- a/frontend/source/js/tests/alerts_tests.js
+++ b/frontend/source/js/tests/alerts_tests.js
@@ -1,0 +1,28 @@
+/* global QUnit document */
+
+QUnit.module('alerts');
+
+QUnit.test('sets tabindex=-1 and focuses itself when attached', assert => {
+  const alerts = document.createElement('alerts-widget');
+  alerts.focus = () => {
+    assert.equal(alerts.getAttribute('tabindex'), '-1');
+  };
+  alerts.attachedCallback();
+});
+
+QUnit.test('emits alertswidgetready event', assert => {
+  const done = assert.async();
+
+  const fixture = document.getElementById('qunit-fixture');
+  const div = document.createElement('div');
+
+  div.addEventListener('alertswidgetready', () => {
+    fixture.removeChild(div);
+    assert.ok(true, 'alertswidgetready received');
+    done();
+  });
+
+  div.innerHTML = '<alerts-widget>hi</alerts-widget>';
+
+  fixture.appendChild(div);
+});

--- a/frontend/source/js/tests/index.js
+++ b/frontend/source/js/tests/index.js
@@ -3,3 +3,4 @@ require('../data-capture');
 require('./ajaxform_tests');
 require('./upload_tests');
 require('./expandable-area_tests');
+require('./alerts_tests');

--- a/styleguide/ajaxform_example.py
+++ b/styleguide/ajaxform_example.py
@@ -1,6 +1,7 @@
 import time
 from django import forms
 from django.http import HttpResponse
+from django.contrib import messages
 
 from frontend import ajaxform
 from frontend.upload import UploadWidget
@@ -57,6 +58,11 @@ def view(request):
                 raise Exception('Here is the 500 your ordered.')
             else:
                 return HttpResponse('Here is an unexpected response.')
+
+        messages.add_message(
+            request, messages.ERROR,
+            'Uh oh. Please correct the error(s) below and try again.'
+        )
 
     return ajaxform.render(
         request,

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -84,6 +84,22 @@
     </div>
   </div>
 
+  <h3>Accessibility</h3>
+
+  <p>
+    Any response from the ajax form that dynamically updates content on
+    the page instead of redirecting the user to a new page should
+    contain an {% webcomponent '<alerts-widget>' %} which wraps
+    a message to inform users about what just happened. This will
+    automatically be focused when the content is injected into the
+    page, allowing screen readers to announce it.
+  </p>
+
+  <p>
+    To experience this in action, try submitting invalid data into the
+    example form above.
+  </p>
+
   <h3>Graceful Degradation</h3>
 
   <p>

--- a/styleguide/templates/styleguide_ajaxform_example.html
+++ b/styleguide/templates/styleguide_ajaxform_example.html
@@ -3,6 +3,10 @@
       action="{% url 'styleguide:ajaxform' %}">
   {% csrf_token %}
 
+  {% if request.is_ajax %}
+  {% include 'data_capture/messages.html' %}
+  {% endif %}
+
   {% with form=ajaxform_form %}
     {{ form.non_field_errors }}
     {{ form.question.errors }}


### PR DESCRIPTION
This is an alternative attempt to fix #481.

Whereas #575 was a really complex attempt to fix the issue, this solution is far more simple. The following is suggested by  [WebAIM's Accessibility of Rich Internet Applications guide](http://webaim.org/techniques/aria/#keyboard):

> Additionally, it is often necessary to set focus to page elements. For instance, a form validation error message might be displayed as text (not a link or form element) within a page using scripting. Visual users can immediately see the error message. However, a screen reader user may not know that the new message is present. In order to set focus to the error message so it can be read by a screen reader, the message must be able to receive focus - something it cannot typically do unless it is a link or form control.

This basically implements the above approach through the use of an extremely simple `<alerts-widget>` web component that just sets `tabindex="-1"` on itself and focuses itself on attachment.  That is literally all it does, and it seems to work great on voiceover and NVDA.

Another nice benefit of this approach is that because the alerts appear just above the form fields, the user only has to press tab to instantly focus on the first field.  (I believe that without this focusing, the focus became undefined when loading an ajax-form, as the submit button which previously had focus was replaced by the new content, which led to weird keyboard accessibility issues.)

Note, though, that this *does* also mean that alerts which appear on non-ajax-loaded content (i.e., a normal page) will be auto-focused.  I think this is probably OK though, because they're still the first thing we want screen readers to announce when the users visit a new page.

In the future we may consider changing the `:focus` styling of the web component.  Currently it puts a big fuzzy blue outline around the alerts on a Mac, which is kind of overkill, especially since the alerts themselves already have very visible borders (though those borders don't indicate keyboard focus).

## To Do

- [x] Add tests.

- [x] Document the widget in the style guide.
