### PR TITLE
Mention, link to web components in style guide.

### DIFF
--- a/frontend/source/js/data-capture/ajaxform.js
+++ b/frontend/source/js/data-capture/ajaxform.js
@@ -108,6 +108,8 @@ class AjaxForm extends window.HTMLFormElement {
   }
 }
 
+AjaxForm.prototype.SOURCE_FILENAME = __filename;
+
 document.registerElement('ajax-form', {
   extends: 'form',
   prototype: AjaxForm.prototype,

--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -89,6 +89,8 @@ class UploadInput extends window.HTMLInputElement {
   }
 }
 
+UploadInput.prototype.SOURCE_FILENAME = __filename;
+
 document.registerElement('upload-input', {
   extends: 'input',
   prototype: UploadInput.prototype,
@@ -213,6 +215,8 @@ class UploadWidget extends window.HTMLElement {
     return finishInitialization();
   }
 }
+
+UploadWidget.prototype.SOURCE_FILENAME = __filename;
 
 UploadWidget.HAS_BROWSER_SUPPORT = HAS_BROWSER_SUPPORT;
 

--- a/frontend/source/js/styleguide/index.js
+++ b/frontend/source/js/styleguide/index.js
@@ -1,0 +1,1 @@
+require('./web-component-link');

--- a/frontend/source/js/styleguide/web-component-link.js
+++ b/frontend/source/js/styleguide/web-component-link.js
@@ -1,0 +1,33 @@
+/* global window, document */
+/* eslint no-alert: "off" */
+
+class WebComponentLink extends window.HTMLAnchorElement {
+  attachedCallback() {
+    const tag = this.getAttribute('data-tag');
+    const extendsClass = this.getAttribute('data-extends');
+    let el;
+
+    if (extendsClass) {
+      el = document.createElement(tag, {
+        is: extendsClass,
+      });
+    } else {
+      el = document.createElement(tag);
+    }
+
+    const proto = Object.getPrototypeOf(el);
+
+    if (!proto.SOURCE_FILENAME) {
+      window.alert(
+        `prototype for web component ${this.textContent} ` +
+        'has no SOURCE_FILENAME property!'
+      );
+    }
+    this.setAttribute('href', this.href + proto.SOURCE_FILENAME.slice(1));
+  }
+}
+
+document.registerElement('web-component-link', {
+  extends: 'a',
+  prototype: WebComponentLink.prototype,
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,6 +34,8 @@ const dirs = {
       dataExplorer: 'frontend/static/frontend/built/js/data-explorer',
       // CALC 2.0 Data Capture scripts
       dataCapture: 'frontend/static/frontend/built/js/data-capture',
+      // Styleguide scripts
+      styleguide: 'frontend/static/frontend/built/js/styleguide',
       // CALC 2.0 Tests
       tests: 'frontend/static/frontend/built/js/tests',
     },
@@ -45,6 +47,8 @@ const paths = {
   js: '**/*.js',
   dataCaptureEntry: 'data-capture/index.js',
   dataCaptureOutfile: 'index.min.js',
+  styleguideEntry: 'styleguide/index.js',
+  styleguideOutfile: 'index.min.js',
   testEntry: 'tests/index.js',
   testOutfile: 'index.min.js',
 };
@@ -116,7 +120,8 @@ gulp.task('sass', () => gulp.src(path.join(dirs.src.style, paths.sass))
 );
 
 // Compile and lint JavaScript sources
-gulp.task('js', ['lint', 'js:data-capture', 'js:tests', 'js:legacy']);
+gulp.task('js', ['lint', 'js:data-capture', 'js:styleguide',
+                 'js:tests', 'js:legacy']);
 
 gulp.task('js:legacy', ['js:data-explorer:index', 'js:common:base']);
 
@@ -197,6 +202,14 @@ gulp.task('js:data-capture', () =>
     path.join(dirs.src.scripts, paths.dataCaptureEntry),
     dirs.dest.scripts.dataCapture,
     paths.dataCaptureOutfile
+  )
+);
+
+gulp.task('js:styleguide', () =>
+  browserifyBundle(
+    path.join(dirs.src.scripts, paths.styleguideEntry),
+    dirs.dest.scripts.styleguide,
+    paths.styleguideOutfile
   )
 );
 

--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -58,3 +58,11 @@ html .styleguide-example pre {
   margin: 0;
   border: none;
 }
+
+code > a {
+  text-decoration: none;
+}
+
+code > a:hover {
+  text-decoration: underline;
+}

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -49,8 +49,11 @@
   </p>
 
   <p>
+    We use an {% webcomponent '<upload-widget>' %} with a nested
+    {% webcomponent '<input is="upload-input">' %} to progressively enhance
+    the front-end. However, using them is rarely needed in practice, as
     {% pyobjname 'frontend.upload.UploadWidget' %} contains the Django
-    widget for rendering the HTML of the upload widget.
+    widget for rendering all the required HTML.
   </p>
 
   <h3>Form Submission</h3>
@@ -58,16 +61,17 @@
   <p>
     Due to the technical limitations of HTML5, forms containing the
     progressively-enhanced upload widget must be submitted via ajax. This can
-    be accomplished via a custom Ajax Form component.
+    be accomplished via a custom {% webcomponent '<form is="ajax-form">' %}
+    web component.
   </p>
 
   <p>
     {% pyobjname 'frontend.ajaxform' %} contains utilities for processing
-    Ajax Forms in a progressively-enhanced way.
+    forms submitted by this web component in a progressively-enhanced way.
   </p>
 
   <p>
-    For a simple Ajax Form code example that also embeds an upload
+    For a simple ajax form code example that also embeds an upload
     widget, see
     {% pathname 'styleguide/ajaxform_example.py' %} and
     {% pathname 'styleguide/templates/styleguide_ajaxform_example.html' %}.
@@ -401,4 +405,5 @@
 </div>
 <script src="{% static 'styleguide/vendor/prism.js' %}"></script>
 <script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
+<script src="{% static 'frontend/built/js/styleguide/index.min.js' %}"></script>
 {% endblock %}

--- a/styleguide/templatetags/styleguide.py
+++ b/styleguide/templatetags/styleguide.py
@@ -79,6 +79,16 @@ class WebComponentHTMLParser(HTMLParser):
 
 @register.simple_tag
 def webcomponent(html):
+    '''
+    Link to the source code of a web component, e.g. <foo> or
+    <input is="bar">.
+
+    This actually renders markup that client-side code will resolve into
+    a definitive link via introspecting the JS runtime environment. The
+    front-end will raise an error if the web component or its source code
+    can't be found, to help prevent documentation rot.
+    '''
+
     parser = WebComponentHTMLParser()
     parser.feed(html)
     return SafeString(

--- a/styleguide/templatetags/styleguide.py
+++ b/styleguide/templatetags/styleguide.py
@@ -1,4 +1,5 @@
 import os.path
+from html.parser import HTMLParser
 from textwrap import dedent
 from inspect import getsourcefile
 
@@ -60,10 +61,34 @@ def github_url_for_path(path):
     GitHub URL to its syntax-highlighted source code.
     '''
 
-    return '{}/blob/{}/{}'.format(
+    return '{}/tree/{}/{}'.format(
         BASE_GITHUB_URL,
         DEFAULT_GITHUB_BRANCH,
         path
+    )
+
+
+class WebComponentHTMLParser(HTMLParser):
+    def handle_starttag(self, tag, attrs):
+        self.tag = tag
+        self.extends = ''
+        for attr, val in attrs:
+            if attr == 'is':
+                self.extends = val
+
+
+@register.simple_tag
+def webcomponent(html):
+    parser = WebComponentHTMLParser()
+    parser.feed(html)
+    return SafeString(
+        '<code><a is="web-component-link" href="{}" '
+        'data-tag="{}" data-extends="{}">{}</a></code>'.format(
+            escape(github_url_for_path('')),
+            escape(parser.tag),
+            escape(parser.extends),
+            escape(html)
+        )
     )
 
 


### PR DESCRIPTION
Ok, this is a bit funkadelic. It basically allows us to link to the source code of web components in our style guide.

As with the changes in #633, this is done both to help onboard new/rusty devs, but also to prevent doc rot: an alert is displayed if any of the web components don't exist, or if metadata about their location isn't found.

The only annoying part of this is that it requires us to add a `SOURCE_FILENAME` property to each web component's prototype that is set to `__filename` (the actual value of which is filled-in by browserify).

It'd be nice to make the QUnit test suite open the style guide in an iframe and verify that no errors are thrown, but I'd prefer to file that as a separate bug. For now just seeing a big alert when visiting `/styleguide/` if anything's broken should be enough.
