### PR TITLE
Add excel table CSS styles

### DIFF
--- a/frontend/source/sass/components/_exceltables.scss
+++ b/frontend/source/sass/components/_exceltables.scss
@@ -1,0 +1,46 @@
+.excel-wrapper {
+  overflow: scroll;
+  padding: 1em;
+  border: 2px solid lightgray;
+}
+
+table.excel {
+  font-family: Arial, Helvetica, serif;
+  width: auto;
+  margin: 0;
+
+  tbody tr {
+    &:hover > * {
+      background: unset !important;
+    }
+
+    &:nth-child(odd) {
+      background: unset;
+    }
+  }
+
+  td {
+    min-width: 10em;
+    padding: 0;
+    border: 1px solid lightgray;
+  }
+}
+
+table.excel.excel-schedule-70 {
+  tr:first-child {
+    background: lightgray;
+
+    td {
+      vertical-align: bottom;
+    }
+  }
+
+  tr:not(:first-child) td:not(:first-child) {
+    font-style: italic;
+  }
+
+  td {
+    border-color: black;
+    text-align: center;
+  }
+}

--- a/frontend/source/sass/components/_exceltables.scss
+++ b/frontend/source/sass/components/_exceltables.scss
@@ -1,7 +1,8 @@
+@import '../base/variables';
+
 .excel-wrapper {
   overflow: scroll;
-  padding: 1em;
-  border: 2px solid lightgray;
+  font-size: $small-font-size;
 }
 
 table.excel {
@@ -21,7 +22,7 @@ table.excel {
 
   td {
     min-width: 10em;
-    padding: 0;
+    padding: 2px;
     border: 1px solid lightgray;
   }
 }

--- a/frontend/source/sass/data_capture.scss
+++ b/frontend/source/sass/data_capture.scss
@@ -1,3 +1,4 @@
 @import 'base/variables';
 @import 'uswds/alerts';
 @import 'components/formbuttonrow';
+@import 'components/exceltables';

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -352,6 +352,64 @@
 
     {% endexample %}
 
+  {% guide_section "Excel Tables" %}
+
+  <p>Defined in {% pathname 'frontend/source/sass/components/_exceltables.scss' %}.</p>
+
+  <p>
+    Sometimes we need to display "screenshots" of Microsoft Excel tables
+    to users, to communicate what kind of spreadsheet they need to upload.
+    Doing this with standard HTML tables that are styled to look like
+    excel tables allows us to accomplish this in an accessible and
+    easily changeable way.
+  </p>
+
+  <p>
+    The base class just styles the table to look like a standard Excel
+    sheet without any styling:
+  </p>
+
+  {% example %}
+  <div class="excel-wrapper">
+    <table class="excel">
+      <tr><td>A1</td><td>B1</td></tr>
+      <tr><td>A2</td><td>B2</td></tr>
+    </table>
+  </div>
+  {% endexample %}
+
+  <p>
+    But we have extra classes that we can layer on top to emulate the
+    styling of specific contract vehicle spreadsheets.
+  </p>
+
+  <p>For example, here's a style for Schedule 70 proposed price lists:</p>
+
+  {% example %}
+  <div class="excel-wrapper">
+    <table class="excel excel-schedule-70">
+      <tr>
+        <td>SIN(s) PROPOSED</td>
+        <td>SERVICE PROPOSED (e.g. Job Title/Task)</td>
+        <td>MINIMUM EDUCATION/CERTIFICATION LEVEL</td>
+        <td>MINIMUM YEARS OF EXPERIENCE</td>
+        <td>COMMERCIAL LIST PRICE (CPL) OR MARKET PRICES</td>
+        <td>UNIT OF ISSUE (e.g. Hour, Task, Sq ft)</td>
+        <td>MOST FAVORED CUSTOMER (MFC)</td>
+      </tr>
+      <tr>
+        <td>132-51</td>
+        <td>Project Manager</td>
+        <td>Bachelors</td>
+        <td>5</td>
+        <td>$125</td>
+        <td>Hour</td>
+        <td>All Commercial</td>
+      </tr>
+    </table>
+  </div>
+  {% endexample %}
+
   {% guide_section "Forms" %}
   {% example %}
   <label for="input-type-text">Text input label</label>


### PR DESCRIPTION
This adds some excel table styles that we can use to show users accessible "screenshots" of what the price list we need them to upload looks like.

It's intended for use in the following section of @hbillings's [mockups](https://gsa.invisionapp.com/d/main/#/console/8513772/182332256/preview):

> ![screen shot 2016-09-01 at 8 18 39 am](https://cloud.githubusercontent.com/assets/124687/18167110/c70ab1e4-701c-11e6-965e-81662909383c.png)

And here's what the new styles look like in the styleguide:

> ![screen shot 2016-09-01 at 8 20 26 am](https://cloud.githubusercontent.com/assets/124687/18167150/fb788f3c-701c-11e6-8a75-d67bf32f7880.png)

## Notes

* I don't think overriding the base table styles, as I'm doing in this PR, is very maintainable, as it starts specificity wars and such.  We might want to consider namespacing our default table styles instead of using them to define what every single table everywhere on our site should look like.

* I'm not distinguishing between `<thead>` and `<tbody>` in the excel tables; everything is assumed to be in a `<tbody>`, basically, which I think makes sense because an Excel spreadsheet is really just a grid of cells without a defined head. But also, reverting our default `<thead>` styling is a *huge pain*.  😣 

* I'm not a big fan of the `excel-wrapper` class here but it's the only way I can see of making really large tables scrollable, and also adding the padded border for the whole thing.
