### PR TITLE
Remove unused imports, run flake8 during travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 - gulp build
 script:
 - phantomjs --version
+- python manage.py ultratest flake8
 - echo "For details on why we're ignoring selenium tests, see https://github.com/18F/calc/issues/330"
 - bandit -r .
 - py.test --ignore=selenium_tests --cov

--- a/data_capture/decorators.py
+++ b/data_capture/decorators.py
@@ -1,8 +1,6 @@
 from functools import wraps
 
 from django.shortcuts import redirect
-from django.http import JsonResponse
-from django.core.urlresolvers import reverse
 
 from frontend import ajaxform
 

--- a/meta/management/commands/ultratest.py
+++ b/meta/management/commands/ultratest.py
@@ -79,6 +79,12 @@ def command(verbosity, testtype):
     '''
     is_verbose = verbosity > 1
 
+    # This is kind of annoying; 'testtype' is the most readable name for the
+    # CLI end-user, but 'testtype_names' is more readable for the actual
+    # implementation, so we'll just assign the latter to the former.
+    testtype_names = testtype
+    del testtype
+
     TESTTYPES_TO_REPORT_COVERAGE_ON = ['py.test']
     ESLINT_CMD = 'npm run failable-eslint'
     PYTEST_CMD = 'py.test --cov-report xml {} --cov'.format(
@@ -133,8 +139,8 @@ def command(verbosity, testtype):
             )
         )
 
-    if testtype:
-        to_run = [get_testtype(t) for t in testtype]
+    if testtype_names:
+        to_run = [get_testtype(t) for t in testtype_names]
     else:
         to_run = testtypes
 


### PR DESCRIPTION
This adds the `ultratest` functionality described in https://github.com/18F/calc/issues/636#issuecomment-243761792 and runs `python manage.py ultratest flake8` during travis, fixing #636:

![screen shot 2016-09-01 at 1 48 45 pm](https://cloud.githubusercontent.com/assets/124687/18178070/e13721e6-704a-11e6-9d82-bf52bf1f3977.png)

It also removes some unused imports from `decorators.py`, as `flake8` was actually failing 😄 