### PR TITLE
Disable DjDT profiling panel by default

### DIFF
--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -297,6 +297,10 @@ if not UAA_CLIENT_SECRET:
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 DEBUG_TOOLBAR_CONFIG = {
+    'DISABLE_PANELS': set([
+        'debug_toolbar.panels.redirects.RedirectsPanel',
+        'debug_toolbar.panels.profiling.ProfilingPanel',
+    ]),
     'SHOW_TOOLBAR_CALLBACK': 'hourglass.middleware.show_toolbar',
 }
 


### PR DESCRIPTION
This just disables the profiling panel by default, i.e.:

> ![screen shot 2016-09-08 at 8 02 27 am](https://cloud.githubusercontent.com/assets/124687/18348654/9e58488c-759a-11e6-82ee-b2532b32b433.png)

Developers can just mark the checkbox and reload the page to enable it.  I think that this is good because we don't actually need profiling most of the time, and it tends to slow down our pages a lot.