### PR TITLE
Add a Documentation DjDT panel

### DIFF
--- a/data_capture/panels.py
+++ b/data_capture/panels.py
@@ -3,6 +3,19 @@ from debug_toolbar.panels import Panel
 from .apps import DataCaptureSchedulerApp
 
 
+class DocsPanel(Panel):
+    '''
+    A Django Debug Toolbar panel that links to various
+    documentation artifacts for developers.
+    '''
+
+    title = 'Documentation'
+
+    template = 'data_capture/panels/docs.html'
+
+    nav_subtitle = 'Read me first!'
+
+
 class ScheduledJobsPanel(Panel):
     '''
     A Django Debug Toolbar panel that displays information about

--- a/data_capture/templates/data_capture/panels/docs.html
+++ b/data_capture/templates/data_capture/panels/docs.html
@@ -1,0 +1,20 @@
+<h4>Welcome to CALC!</h4>
+
+<p>
+  Please make sure you read the
+  <a href="https://github.com/18F/calc#readme">README</a> thoroughly. It
+  should answer most of your questions.
+</p>
+
+<p>
+  Also check out
+  <a href="https://github.com/18F/calc/blob/develop/CONTRIBUTING.md">CONTRIBUTING</a>
+  if you'd like to improve this tool.
+</p>
+
+<h4>Useful Links</h4>
+
+<ul>
+  <li><a href="{% url 'styleguide:index' %}">Style guide</a></li>
+  <li><a href="{% url 'tests' %}">Test suite</a></li>
+</ul>

--- a/data_capture/templates/data_capture/panels/docs.html
+++ b/data_capture/templates/data_capture/panels/docs.html
@@ -16,5 +16,5 @@
 
 <ul>
   <li><a href="{% url 'styleguide:index' %}">Style guide</a></li>
-  <li><a href="{% url 'tests' %}">Test suite</a></li>
+  <li><a href="{% url 'tests' %}">Front-end test suite</a></li>
 </ul>

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -301,6 +301,7 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 
 DEBUG_TOOLBAR_PANELS = [
+    'data_capture.panels.DocsPanel',
     'debug_toolbar.panels.versions.VersionsPanel',
     'debug_toolbar.panels.profiling.ProfilingPanel',
     'debug_toolbar.panels.timer.TimerPanel',

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -31,7 +31,8 @@ urlpatterns = [
     url(r'^auth/', include('uaa_client.urls', namespace='uaa_client')),
 ]
 
-tests_url = url(r'^tests/$', TemplateView.as_view(template_name='tests.html'))
+tests_url = url(r'^tests/$', TemplateView.as_view(template_name='tests.html'),
+                name="tests")
 
 if settings.DEBUG:
     import debug_toolbar


### PR DESCRIPTION
This adds a **Documentation** panel at the top of the panel list:

> ![screen shot 2016-09-08 at 8 43 19 am](https://cloud.githubusercontent.com/assets/124687/18349693/897e8060-75a0-11e6-9595-fe2fc9dfbf9a.png)

Specifically, it makes our style guide and test suite actually discoverable, so that should hopefully help new devs.

(I originally tried adding links to the style guide and tests in the top-right nav area of the base template, but I didn't like how much visual noise it added, so I resorted to a DjDT panel. Also, there's no way to embed links directly in the toolbar itself, which would've been preferable, so I resorted to a Documentation panel.)