### PR TITLE
Fix form button row styling

### DIFF
--- a/data_capture/templates/data_capture/bulk_upload/region_10_step_2.html
+++ b/data_capture/templates/data_capture/bulk_upload/region_10_step_2.html
@@ -25,7 +25,6 @@
             <span class="submit-label">
               Load data and view results
             </span>
-            {# TODO: It would be nice to have JS that disables this button once clicked #}
             <button type="submit" class="button-primary" name="submit">Confirm</button>
           </div>
         {% endif %}

--- a/frontend/source/sass/components/_formbuttonrow.scss
+++ b/frontend/source/sass/components/_formbuttonrow.scss
@@ -5,6 +5,7 @@
   margin-top: 2em;
 
   button,
+  button[type="submit"],
   .button {
     display: inline-block;
     margin: 0 2em 0 0;

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -153,27 +153,6 @@
   </ol>
   {% endexample %}
 
-  {% guide_section "Form Button Row" %}
-
-  <p>Defined in {% pathname 'frontend/source/sass/components/_formbuttonrow.scss' %}.</p>
-
-  <p>The form-button-row widget is used to add common buttons to the bottom of forms in a multi-step process, such as the Data Capture Upload flow.</p>
-
-  {% example %}
-  <div class="form-button-row clearfix">
-    <a href="#" class="button button-previous">Previous</a>
-
-    <button type="submit" name="cancel" class="button-secondary">Cancel</button>
-
-    <div class="submit-group">
-      <span class="submit-label">
-        Provide details about the contract.
-      </span>
-      <button type="submit" class="button-primary">Next</button>
-    </div>
-  </div>
-  {% endexample %}
-
   {% guide_section "Alerts" %}
 
   <p>
@@ -463,6 +442,27 @@
       {% include "styleguide_date_example.html" %}
     </div>
   </div>
+
+  {% guide_section "Form Button Row" %}
+
+  <p>Defined in {% pathname 'frontend/source/sass/components/_formbuttonrow.scss' %}.</p>
+
+  <p>The form-button-row widget is used to add common buttons to the bottom of forms in a multi-step process, such as the Data Capture Upload flow.</p>
+
+  {% example %}
+  <div class="form-button-row clearfix">
+    <a href="#" class="button button-previous">Previous</a>
+
+    <button type="submit" name="cancel" class="button-secondary">Cancel</button>
+
+    <div class="submit-group">
+      <span class="submit-label">
+        Provide details about the contract.
+      </span>
+      <button type="submit" class="button-primary">Next</button>
+    </div>
+  </div>
+  {% endexample %}
 
   {% guide_section "Expandable Area" %}
 


### PR DESCRIPTION
Basically I had to also target `button[type="submit"]` in the rule to make `.form-button-row` buttons display as `inline-block`.

Also made a slight adjustment to the styleguide to put the Form Button Row section after the Form section (it was before, which is weird, logically).

Closes #691