### PR TITLE
Use a ModelForm in step 1 of price list upload

### DIFF
--- a/data_capture/forms/__init__.py
+++ b/data_capture/forms/__init__.py
@@ -1,6 +1,6 @@
 
-from .price_list import Step1Form, Step2Form, Step3Form, Step4Form
+from .price_list import Step1Form, Step2Form, Step3Form
 from .bulk_upload import Region10BulkUploadForm
 
-__all__ = ['Step1Form', 'Step2Form', 'Step3Form', 'Step4Form',
+__all__ = ['Step1Form', 'Step2Form', 'Step3Form',
            'Region10BulkUploadForm']

--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -71,33 +71,3 @@ class Step3Form(forms.Form):
             cleaned_data['gleaned_data'] = gleaned_data
 
         return cleaned_data
-
-
-class Step4Form(forms.ModelForm):
-    class Meta:
-        model = SubmittedPriceList
-        fields = [
-            'contract_number',
-            'vendor_name',
-            'schedule',
-            'is_small_business',
-            'contractor_site',
-            'contract_start',
-            'contract_end',
-            'contract_year',
-        ]
-
-        # TODO: It'd be nice if we could actually get rid of all these
-        # hidden inputs, since all this data is already stored in our request
-        # session.
-
-        widgets = {
-            'contract_number': forms.HiddenInput(),
-            'vendor_name': forms.HiddenInput(),
-            'schedule': forms.HiddenInput(),
-            'is_small_business': forms.HiddenInput(),
-            'contractor_site': forms.HiddenInput(),
-            'contract_year': forms.HiddenInput(),
-            'contract_start': forms.HiddenInput(),
-            'contract_end': forms.HiddenInput()
-        }

--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -6,19 +6,18 @@ from frontend.upload import UploadWidget
 from frontend.date import SplitDateField
 
 
-class Step1Form(forms.Form):
-    # TODO: Consider making this a ModelForm that we just don't save; that
-    # way, the fields are generated through introspecting the
-    # SubmittedPriceList model and we keep things nice and DRY.
-
+class Step1Form(forms.ModelForm):
     schedule = forms.ChoiceField(
         choices=registry.get_choices
     )
-    contract_number = forms.CharField(
-        max_length=128,
-        help_text='This should be the full contract number, e.g. GS-XXX-XXXX.'
-    )
-    vendor_name = forms.CharField(max_length=128)
+
+    class Meta:
+        model = SubmittedPriceList
+        fields = [
+            'schedule',
+            'contract_number',
+            'vendor_name',
+        ]
 
 
 class Step2Form(forms.ModelForm):

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -65,24 +65,14 @@
 
   {% if gleaned_data.valid_rows %}
   <form method="post">
-  {% csrf_token %}
-    <input type="hidden" name="contract_number" value="{{ price_list.contract_number }}">
-    <input type="hidden" name="vendor_name" value="{{ price_list.vendor_name }}">
-    <input type="hidden" name="schedule" value="{{ price_list.schedule }}">
-    <input type="hidden" name="is_small_business" value="{{ price_list.is_small_business }}">
-    <input type="hidden" name="contractor_site" value="{{ price_list.contractor_site }}">
-    <input type="hidden" name="contract_year" value="{{ price_list.contract_year }}">
-    <input type="hidden" name="contract_start" value="{{ price_list.contract_start }}">
-    <input type="hidden" name="contract_end" value="{{ price_list.contract_end }}">
-
+    {% csrf_token %}
     <div class="submit-group">
       <span class="submit-label">
         Submit to approver
       </span>
       <button type="submit" class="button-primary">Next</button>
-
-    </form>
     </div>
+  </form>
   {% endif %}
 </div>
 


### PR DESCRIPTION
This improves [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) by using a `ModelForm` in step 1 of price list upload.

@hbillings does this look ok and make sense to you?  As with `Step2Form`, we're using a `ModelForm` to make things easy and DRY for us, but not actually saving the model until step 4.