### PR TITLE
re-ignore selenium tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
 - python manage.py ultratest flake8
 - echo "For details on why we're ignoring selenium tests, see https://github.com/18F/calc/issues/330"
 - bandit -r .
-- py.test --ignore=selenium_tests --cov
+- py.test --ignore=frontend/tests/test_selenium.py --cov
 env:
   global:
   - TRAVIS_NODE_VERSION=5.10.0


### PR DESCRIPTION
We were ignoring selenium tests as of #331 during Travis builds because they often time out, per #330. However, when all the frontend-related code and tests were moved to `frontend/` I neglected to update the `--ignore` argument to `py.test` in our `.travis.yml`. This PR re-ignores selenium tests on Travis.