### PR TITLE
Fix #705, #711, simplify price list form logic.

### DIFF
--- a/data_capture/forms/__init__.py
+++ b/data_capture/forms/__init__.py
@@ -1,6 +1,6 @@
 
-from .price_list import Step1Form, Step2Form, Step3Form, Step4Form
+from .price_list import Step1Form, Step2Form, Step3Form
 from .bulk_upload import Region10BulkUploadForm
 
-__all__ = ['Step1Form', 'Step2Form', 'Step3Form', 'Step4Form',
+__all__ = ['Step1Form', 'Step2Form', 'Step3Form',
            'Region10BulkUploadForm']

--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -71,33 +71,3 @@ class Step3Form(forms.Form):
             cleaned_data['gleaned_data'] = gleaned_data
 
         return cleaned_data
-
-
-class Step4Form(forms.ModelForm):
-    class Meta:
-        model = SubmittedPriceList
-        fields = [
-            'contract_number',
-            'vendor_name',
-            'schedule',
-            'is_small_business',
-            'contractor_site',
-            'contract_start',
-            'contract_end',
-            'contract_year',
-        ]
-
-        # TODO: It'd be nice if we could actually get rid of all these
-        # hidden inputs, since all this data is already stored in our request
-        # session.
-
-        widgets = {
-            'contract_number': forms.HiddenInput(),
-            'vendor_name': forms.HiddenInput(),
-            'schedule': forms.HiddenInput(),
-            'is_small_business': forms.HiddenInput(),
-            'contractor_site': forms.HiddenInput(),
-            'contract_year': forms.HiddenInput(),
-            'contract_start': forms.HiddenInput(),
-            'contract_end': forms.HiddenInput()
-        }

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -65,24 +65,14 @@
 
   {% if gleaned_data.valid_rows %}
   <form method="post">
-  {% csrf_token %}
-    <input type="hidden" name="contract_number" value="{{ price_list.contract_number }}">
-    <input type="hidden" name="vendor_name" value="{{ price_list.vendor_name }}">
-    <input type="hidden" name="schedule" value="{{ price_list.schedule }}">
-    <input type="hidden" name="is_small_business" value="{{ price_list.is_small_business }}">
-    <input type="hidden" name="contractor_site" value="{{ price_list.contractor_site }}">
-    <input type="hidden" name="contract_year" value="{{ price_list.contract_year }}">
-    <input type="hidden" name="contract_start" value="{{ price_list.contract_start }}">
-    <input type="hidden" name="contract_end" value="{{ price_list.contract_end }}">
-
+    {% csrf_token %}
     <div class="submit-group">
       <span class="submit-label">
         Submit to approver
       </span>
       <button type="submit" class="button-primary">Next</button>
-
-    </form>
     </div>
+  </form>
   {% endif %}
 </div>
 


### PR DESCRIPTION
**Note: This builds upon #707.**

This simplifies our price list form logic by storing the raw POST data from earlier steps in the session, rather than storing the same data in the session using a potentially error-prone custom serialization mechanism.

This also allows us to "resurrect" the actual `ModelForm`s for earlier steps when the user submits their data in step 4 and call their `save()` methods, saving us from having to assign data to the new model ourselves.

This new way of doing things also happens to fix #705.

I also fixed #711 because it was easy to fix along the way.

@hbillings can you take a look at this?  Does it make sense?