### PR TITLE
Bulk upload visual tweaks

### DIFF
--- a/data_capture/templates/data_capture/bulk_upload/region_10_step.html
+++ b/data_capture/templates/data_capture/bulk_upload/region_10_step.html
@@ -1,19 +1,19 @@
 {% extends 'data_capture/step.html' %}
 
-{% block title %}Upload Region 10 Data / {% block subtitle %}{% endblock %}{% endblock %}
+{% block title %}Upload Region 10 data / {% block subtitle %}{% endblock %}{% endblock %}
 
-{% block heading %}Upload Region 10 Data{% endblock heading %}
+{% block heading %}Upload Region 10 data{% endblock heading %}
 
 {% block steps %}
   <ol class="steps">
     <li {% if step_number == 1 %}class="current"{% endif %}>
-      <label>Upload Export Spreadsheet</label>
+      <label>Upload spreadsheet</label>
     </li>
     <li {% if step_number == 2 %}class="current"{% endif %}>
-      <label>Confirm Load</label>
+      <label>Confirm load</label>
     </li>
     <li {% if step_number == 3 %}class="current"{% endif %}>
-      <label>Completed</label>
+      <label>Complete</label>
     </li>
   </ol>
 {% endblock steps %}

--- a/data_capture/templates/data_capture/bulk_upload/region_10_step_1.html
+++ b/data_capture/templates/data_capture/bulk_upload/region_10_step_1.html
@@ -1,13 +1,14 @@
 {% extends 'data_capture/bulk_upload/region_10_step.html' %}
 
-{% block subtitle %}Select File{% endblock %}
+{% block subtitle %}Select file{% endblock %}
 
 {% block step_heading %}
-<p>Upload an exported Region 10 Pricing Database spreadsheet into CALC.</p>
-<p>Please be patient during this process as it may take several minutes to load large data files.</p>
+<h3>Choose file to upload</h3>
 {% endblock step_heading %}
 
 {% block step_body %}
+  <p>Upload an exported Region 10 pricing database spreadsheet into CALC. <strong>This will delete and replace all of the existing Region 10 data in CALC!</strong></p>
+  <p>Please be patient during this process as it may take several minutes to load large data files.</p>
   {% include 'data_capture/bulk_upload/region_10_step_1_form.html' %}
 
   {% if show_debug_ui %}

--- a/data_capture/templates/data_capture/bulk_upload/region_10_step_1_form.html
+++ b/data_capture/templates/data_capture/bulk_upload/region_10_step_1_form.html
@@ -17,9 +17,9 @@
   <div class="form-button-row clearfix">
     <div class="submit-group">
       <span class="submit-label">
-        Upload and review results
+        Confirm you want to replace existing data
       </span>
-      <button type="submit" class="button-primary">Submit</button>
+      <button type="submit" class="button-primary">Next</button>
     </div>
   </div>
 </form>

--- a/data_capture/templates/data_capture/bulk_upload/region_10_step_2.html
+++ b/data_capture/templates/data_capture/bulk_upload/region_10_step_2.html
@@ -1,14 +1,13 @@
 {% extends 'data_capture/bulk_upload/region_10_step.html' %}
 {% load humanize %}
 
-{% block subtitle %}Confirm Load{% endblock subtitle %}
+{% block subtitle %}Confirm load{% endblock subtitle %}
 
 {% block step_body %}
   {% with total=file_metadata.num_rows %}
     {% if total %}
-      <p>{{ total|intcomma }} row{{ total|pluralize }} were found in the uploaded spreadsheet.</p>
-
-      <p>This will delete all existing Region 10 data and replace it with the new data.</p>
+      <h3>{{ total|intcomma }} row{{ total|pluralize }} ready to add to CALC</h3>
+      <p>Are you ready to <strong>delete all existing Region 10 data</strong> and replace it with the {{ total|intcomma }} new row{{ total|pluralize }} of data you just uploaded?</p>
     {% else %}
       <p>No valid rows were found in the uploaded spreadsheet. Please check your file and <a href="{% url 'data_capture:bulk_region_10_step_1' %}">try again</a>.</p>
     {% endif %}
@@ -16,16 +15,11 @@
     <form method="post" action="{% url 'data_capture:bulk_region_10_step_3' %}">
       {% csrf_token %}
       <div class="form-button-row clearfix">
-        <a href="{% url 'data_capture:bulk_region_10_step_1' %}" class="button button-previous">Previous</a>
-
-        <button type="submit" class="button-secondary" name="cancel">Cancel</button>
+        <button type="submit" class="button-secondary" name="cancel">No, keep the existing data</button>
 
         {% if total %}
           <div class="submit-group">
-            <span class="submit-label">
-              Load data and view results
-            </span>
-            <button type="submit" class="button-primary" name="submit">Confirm</button>
+            <button type="submit" class="button-primary" name="submit">Yes, replace existing data with my file</button>
           </div>
         {% endif %}
       </div>

--- a/frontend/source/sass/components/_steps.scss
+++ b/frontend/source/sass/components/_steps.scss
@@ -6,6 +6,7 @@ ol.steps {
   list-style-type: none;
   list-style-position: inside;
   display: flex;
+  margin-top: 3rem;
 
   li {
     list-style: none;
@@ -44,6 +45,7 @@ ol.steps {
     label {
       font-weight: 100;
       margin-top: 0.2rem;
+      max-width: 100px;
     }
   }
 }


### PR DESCRIPTION
Closes #596. Some copy and visual changes to the R10 uploader. (Ignore the incorrect steps bar; that should be fixed by a separate PR.)
<img width="1010" alt="screen shot 2016-09-09 at 4 50 36 pm" src="https://cloud.githubusercontent.com/assets/509309/18404032/c62a0bfc-76ad-11e6-8a28-d4897b910716.png">
<img width="1032" alt="screen shot 2016-09-09 at 4 50 52 pm" src="https://cloud.githubusercontent.com/assets/509309/18404034/c96c9302-76ad-11e6-9913-20128d51ca12.png">
