### PR TITLE
Make <upload-widget> work w/ funky upgrade timings.

### DIFF
--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -20,9 +20,12 @@ const HAS_BROWSER_SUPPORT = supports.dragAndDrop() && supports.formData() &&
  */
 
 class UploadInput extends window.HTMLInputElement {
-  attachedCallback() {
+  createdCallback() {
     this.isUpgraded = false;
     this._upgradedValue = null;
+  }
+
+  attachedCallback() {
     if (this.getAttribute('type') !== 'file') {
       throw new Error('<input is="upload-input"> must have type "file".');
     }

--- a/frontend/source/js/tests/upload_tests.js
+++ b/frontend/source/js/tests/upload_tests.js
@@ -25,8 +25,14 @@ import { UploadWidget } from '../data-capture/upload';
       input = upload.find('input');
       cb();
     });
-    document.body.appendChild(div);
+
+    // On browsers with native support for custom elements, this
+    // could synchronously upgrade the elements.
     div.innerHTML = UPLOAD_HTML;
+
+    // This will cause the attached/connected callbacks (depending on
+    // version of custom elements spec) to be triggered.
+    document.body.appendChild(div);
   }
 
   function degradedTest(name, cb) {


### PR DESCRIPTION
This fixes #710.

#710 was not caused by any kind of regression in #583--I think it may be a regression introduced way back in 1f04e7ff0295844900148d47d4e48b30252234f4 (part of #582) that we didn't discover until today.

I also discovered that #710 also only exhibits itself on Chrome, which is the only browser with native support for Custom Elements.

Basically, when dynamically injecting the HTML of an ajaxform into the page, we're first creating the DOM for the new form and then attaching it to the document tree.  In Chrome's case, this means that the web components in the HTML are upgraded *before* being attached to the document tree.  Once attached to the document tree, the `attachedCallback`s on custom elements are called in **tree order** (preorder, depth-first traversal), which basically means that `<upload-widget>`'s is always called before `<input is="upload-input">`'s.

Ultimately this means that the `upgrade()` method of the `UploadInput` was being called after it was upgraded but *before* its `attachedCallback` was called.  Because of the implementation, this meant that once the `attachedCallback` was eventually called, the `isUpgraded` property of the custom element was overwritten to be `false`, which completely messed up the state of the whole ajax form. :disappointed: 

This fixes things so that our `UploadInput` works with unusual upgrade timings, and also changes the way tests are run to force those unusual upgrade timings to happen on Chrome (it makes no difference on other browsers that don't natively support custom elements).