### PR TITLE
Improve price list views tests

### DIFF
--- a/data_capture/tests/test_price_list_views.py
+++ b/data_capture/tests/test_price_list_views.py
@@ -17,6 +17,11 @@ class PriceListStepTestCase(StepTestCase):
             registry.serialize(pricelist)
         session.save()
 
+    def delete_price_list_from_session(self):
+        session = self.client.session
+        del session['data_capture:price_list']
+        session.save()
+
     def setUp(self):
         registry._init()
 
@@ -94,6 +99,12 @@ class Step2Tests(PriceListStepTestCase):
         res = self.client.get(self.url)
         self.assertEqual(res.status_code, 200)
 
+    def test_redirects_to_step_1_if_not_completed(self):
+        self.login()
+        self.delete_price_list_from_session()
+        res = self.client.get(self.url)
+        self.assertRedirects(res, Step1Tests.url)
+
     def test_valid_post_updates_session_data(self):
         self.login()
         self.client.post(self.url, self.valid_form)
@@ -161,6 +172,12 @@ class Step3Tests(PriceListStepTestCase):
         self.login()
         res = self.client.get(self.url)
         self.assertEqual(res.status_code, 200)
+
+    def test_redirects_to_step_2_if_not_completed(self):
+        self.login()
+        self.delete_price_list_from_session()
+        res = self.client.get(self.url)
+        self.assertRedirects(res, Step2Tests.url)
 
     def test_valid_post_updates_session_data(self):
         self.login()

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -145,6 +145,8 @@ def step_4(request, gleaned_data):
         price_list.save()
         gleaned_data.add_to_price_list(price_list)
 
+        del request.session['data_capture:price_list']
+
         return redirect('data_capture:step_5')
 
     return render(request, 'data_capture/price_list/step_4.html', {
@@ -156,15 +158,7 @@ def step_4(request, gleaned_data):
 
 
 @login_required
-@gleaned_data_required
-def step_5(request, gleaned_data):
-    if gleaned_data.valid_rows:
-        del request.session['data_capture:price_list']
-    else:
-        # The user may have manually changed the URL or something to
-        # get here. Push them back to the last step.
-        return redirect('data_capture:step_4')
-
+def step_5(request):
     return render(request, 'data_capture/price_list/step_5.html', {
         'step_number': 5
     })

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -1,5 +1,6 @@
 import json
 from functools import wraps
+from django.views.decorators.http import require_http_methods
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseBadRequest
@@ -24,10 +25,11 @@ def gleaned_data_required(f):
 
 
 @login_required
+@require_http_methods(["GET", "POST"])
 def step_1(request):
     if request.method == 'GET':
         form = forms.Step1Form()
-    elif request.method == 'POST':
+    else:
         form = forms.Step1Form(request.POST)
         if form.is_valid():
             request.session['data_capture:price_list'] = {
@@ -46,6 +48,7 @@ def step_1(request):
 
 @handle_cancel
 @login_required
+@require_http_methods(["GET", "POST"])
 def step_2(request):
     # Redirect back to step 1 if we don't have data
     if 'step_1_POST' not in request.session.get('data_capture:price_list',
@@ -54,7 +57,7 @@ def step_2(request):
 
     if request.method == 'GET':
         form = forms.Step2Form()
-    elif request.method == 'POST':
+    else:
         form = forms.Step2Form(request.POST)
         if form.is_valid():
             session_data = request.session['data_capture:price_list']
@@ -76,6 +79,7 @@ def step_2(request):
 
 @handle_cancel
 @login_required
+@require_http_methods(["GET", "POST"])
 def step_3(request):
     if 'step_2_POST' not in request.session.get('data_capture:price_list',
                                                 {}):
@@ -83,7 +87,7 @@ def step_3(request):
     else:
         if request.method == 'GET':
             form = forms.Step3Form()
-        elif request.method == 'POST':
+        else:
             session_pl = request.session['data_capture:price_list']
             posted_data = dict(
                 request.POST,

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -30,10 +30,6 @@ def step_1(request):
     elif request.method == 'POST':
         form = forms.Step1Form(request.POST)
         if form.is_valid():
-            # Clear out request.session if it previously existed
-            if 'data_capture:price_list' in request.session:
-                del request.session['data_capture:price_list']
-
             request.session['data_capture:price_list'] = {
                 'step_1_POST': request.POST,
             }


### PR DESCRIPTION
This simplifies `data_capture.views.price_list_upload` a bit and improves its test coverage to 100%.

To see the test coverage for this file, you can run:

```
docker-compose run app py.test -k price_list_views --cov-report term-missing | grep data_capture/views/price_list_upload.py
```

Notes:

* I made `step_5` not require any kind of session information: all we're doing here is presenting the user with some information, so it's OK if they randomly decide to visit that URL.  It also moves the deletion of the price list from the session to step 4, which IMO makes the whole transaction a bit more atomic--and anyways, a GET request to `step/5` shouldn't change server state.

* Steps 1-3 will only accept `GET` or `POST` requests now.  Previously, other HTTP methods could potentially cause 500s because our branching logic didn't anticipate them.
