### PR TITLE
Make step-based workflows more accessibility-friendly, consolidate step logic

### DIFF
--- a/data_capture/templates/data_capture/bulk_upload/region_10_step.html
+++ b/data_capture/templates/data_capture/bulk_upload/region_10_step.html
@@ -1,18 +1,18 @@
 {% extends 'data_capture/step.html' %}
 
-{% block title %}Upload Region 10 data / {% block subtitle %}{% endblock %}{% endblock %}
+{% block title %}Upload Region 10 data / {{ step.description|capfirst }}: {% block subtitle %}{% endblock %}{% endblock %}
 
 {% block heading %}Upload Region 10 data{% endblock heading %}
 
 {% block steps %}
-  <ol class="steps">
-    <li {% if step_number == 1 %}class="current"{% endif %}>
+  <ol class="steps" aria-hidden="true">
+    <li {% if step.number == 1 %}class="current"{% endif %}>
       <label>Upload spreadsheet</label>
     </li>
-    <li {% if step_number == 2 %}class="current"{% endif %}>
+    <li {% if step.number == 2 %}class="current"{% endif %}>
       <label>Confirm load</label>
     </li>
-    <li {% if step_number == 3 %}class="current"{% endif %}>
+    <li {% if step.number == 3 %}class="current"{% endif %}>
       <label>Complete</label>
     </li>
   </ol>

--- a/data_capture/templates/data_capture/step.html
+++ b/data_capture/templates/data_capture/step.html
@@ -1,32 +1,32 @@
 {% extends 'data_capture/base.html' %}
 
-{% block title %}Add price data to CALC / Step {{ step_number }} of {{ NUM_STEPS }}: {% block subtitle %}{% endblock %}{% endblock %}
+{% block title %}Add price data to CALC / {{ step.description|capfirst }}: {% block subtitle %}{% endblock %}{% endblock %}
 
 {% block body %}
 <div class="container">
 
 <h1>
   Add price data to CALC
-  <span class="sr-only">step {{ step_number }} of {{ NUM_STEPS }}</span>
+  <span class="sr-only">{{ step.description }}</span>
 </h1>
 
 {% block step_heading %}{% endblock %}
 
 {% block steps %}
   <ol class="steps" aria-hidden="true">
-    <li {% if step_number == 1 %}class="current"{% endif %}>
+    <li {% if step.number == 1 %}class="current"{% endif %}>
       <label>Choose schedule</label>
     </li>
-    <li {% if step_number == 2 %}class="current"{% endif %}>
+    <li {% if step.number == 2 %}class="current"{% endif %}>
       <label>Enter contract details</label>
     </li>
-    <li {% if step_number == 3 %}class="current"{% endif %}>
+    <li {% if step.number == 3 %}class="current"{% endif %}>
       <label>Upload price list</label>
     </li>
-    <li {% if step_number == 4 %}class="current"{% endif %}>
+    <li {% if step.number == 4 %}class="current"{% endif %}>
       <label>Validate data</label>
     </li>
-    <li {% if step_number == 5 %}class="current"{% endif %}>
+    <li {% if step.number == 5 %}class="current"{% endif %}>
       <label>Submit data</label>
     </li>
   </ol>

--- a/data_capture/templates/data_capture/step.html
+++ b/data_capture/templates/data_capture/step.html
@@ -1,16 +1,19 @@
 {% extends 'data_capture/base.html' %}
 
-{% block title %}Add price data to CALC / {% block subtitle %}{% endblock %}{% endblock %}
+{% block title %}Add price data to CALC / Step {{ step_number }} of {{ NUM_STEPS }}: {% block subtitle %}{% endblock %}{% endblock %}
 
 {% block body %}
 <div class="container">
 
-<h1>Add price data to CALC</h1>
+<h1>
+  Add price data to CALC
+  <span class="sr-only">step {{ step_number }} of {{ NUM_STEPS }}</span>
+</h1>
 
 {% block step_heading %}{% endblock %}
 
 {% block steps %}
-  <ol class="steps">
+  <ol class="steps" aria-hidden="true">
     <li {% if step_number == 1 %}class="current"{% endif %}>
       <label>Choose schedule</label>
     </li>

--- a/data_capture/templates/data_capture/tests/my_step_1.html
+++ b/data_capture/templates/data_capture/tests/my_step_1.html
@@ -1,0 +1,1 @@
+Hello from {{ step.description }}! foo is {{ foo }}.

--- a/data_capture/urls.py
+++ b/data_capture/urls.py
@@ -4,11 +4,5 @@ from .views import price_list_upload, bulk_upload
 
 urlpatterns = [
     url(r'^step/', include(price_list_upload.steps.urls)),
-
-    url(r'^bulk/region-10/step/1$',
-        bulk_upload.region_10_step_1, name="bulk_region_10_step_1"),
-    url(r'^bulk/region-10/step/2$',
-        bulk_upload.region_10_step_2, name="bulk_region_10_step_2"),
-    url(r'^bulk/region-10/step/3$',
-        bulk_upload.region_10_step_3, name="bulk_region_10_step_3"),
+    url(r'^bulk/region-10/step/', include(bulk_upload.steps.urls)),
 ]

--- a/data_capture/urls.py
+++ b/data_capture/urls.py
@@ -1,13 +1,9 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 
 from .views import price_list_upload, bulk_upload
 
 urlpatterns = [
-    url(r'^step/1$', price_list_upload.step_1, name='step_1'),
-    url(r'^step/2$', price_list_upload.step_2, name='step_2'),
-    url(r'^step/3$', price_list_upload.step_3, name='step_3'),
-    url(r'^step/4$', price_list_upload.step_4, name='step_4'),
-    url(r'^step/5$', price_list_upload.step_5, name='step_5'),
+    url(r'^step/', include(price_list_upload.steps.urls)),
 
     url(r'^bulk/region-10/step/1$',
         bulk_upload.region_10_step_1, name="bulk_region_10_step_1"),

--- a/data_capture/views/bulk_upload.py
+++ b/data_capture/views/bulk_upload.py
@@ -19,7 +19,7 @@ steps = Steps(
 @steps.step
 @staff_login_required
 @require_http_methods(["GET", "POST"])
-def region_10_step_1(request, step):
+def bulk_region_10_step_1(request, step):
     '''
     Start of Region 10 Bulk Upload - Upload the spreadsheet
     '''
@@ -63,7 +63,7 @@ def region_10_step_1(request, step):
 @staff_login_required
 @handle_cancel
 @require_http_methods(["GET", "POST"])
-def region_10_step_2(request, step):
+def bulk_region_10_step_2(request, step):
     '''
     Confirm that the new data should be loaded and load it when the user
     submits
@@ -96,7 +96,7 @@ def region_10_step_2(request, step):
 
 @steps.step
 @staff_login_required
-def region_10_step_3(request, step):
+def bulk_region_10_step_3(request, step):
     '''Show success page'''
 
     return step.render(request, {

--- a/data_capture/views/bulk_upload.py
+++ b/data_capture/views/bulk_upload.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect
 from django.core.files.base import ContentFile
 from django.views.decorators.http import require_http_methods
 from django.conf import settings
@@ -6,14 +6,20 @@ from django.conf import settings
 from .. import forms, jobs
 from ..r10_spreadsheet_converter import Region10SpreadsheetConverter
 from ..decorators import handle_cancel, staff_login_required
-from .common import add_generic_form_error
+from .common import add_generic_form_error, Steps
 from frontend import ajaxform
 from contracts.models import BulkUploadContractSource
 
 
+steps = Steps(
+    template_format='data_capture/bulk_upload/region_10_step_{}.html',
+)
+
+
+@steps.step
 @staff_login_required
 @require_http_methods(["GET", "POST"])
-def region_10_step_1(request):
+def region_10_step_1(request, step):
     '''
     Start of Region 10 Bulk Upload - Upload the spreadsheet
     '''
@@ -44,20 +50,20 @@ def region_10_step_1(request):
 
     return ajaxform.render(
         request,
-        context={
-            'step_number': 1,
+        context=step.context({
             'form': form,
-        },
-        template_name='data_capture/bulk_upload/region_10_step_1.html',
+        }),
+        template_name=step.template_name,
         ajax_template_name='data_capture/bulk_upload/'
                            'region_10_step_1_form.html',
     )
 
 
+@steps.step
 @staff_login_required
 @handle_cancel
 @require_http_methods(["GET", "POST"])
-def region_10_step_2(request):
+def region_10_step_2(request, step):
     '''
     Confirm that the new data should be loaded and load it when the user
     submits
@@ -75,12 +81,9 @@ def region_10_step_2(request):
 
         file_metadata = Region10SpreadsheetConverter(file).get_metadata()
 
-        return render(
-            request,
-            'data_capture/bulk_upload/region_10_step_2.html', {
-                'step_number': 2,
-                'file_metadata': file_metadata,
-            })
+        return step.render(request, {
+            'file_metadata': file_metadata,
+        })
 
     # else 'POST' because of @require_http_methods decorator
     jobs.process_bulk_upload_and_send_email.delay(upload_source_id)
@@ -91,11 +94,11 @@ def region_10_step_2(request):
     return redirect('data_capture:bulk_region_10_step_3')
 
 
+@steps.step
 @staff_login_required
-def region_10_step_3(request):
+def region_10_step_3(request, step):
     '''Show success page'''
 
-    return render(request, 'data_capture/bulk_upload/region_10_step_3.html', {
-        'step_number': 3,
+    return step.render(request, {
         'SEND_TRANSACTIONAL_EMAILS': settings.SEND_TRANSACTIONAL_EMAILS,
     })

--- a/data_capture/views/common.py
+++ b/data_capture/views/common.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.shortcuts import render
 from django.template.defaultfilters import pluralize
 
 
@@ -8,3 +9,36 @@ def add_generic_form_error(request, form):
         'Oops, please correct the error{} below and try again.'
             .format(pluralize(form.errors))
     )
+
+
+class StepBuilder:
+    def __init__(self, template_format, view_format, globs):
+        self._template_format = template_format
+        self._view_format = view_format
+        self._globs = globs
+        self._num_steps = None
+
+    def context(self, step, context=None):
+        final_ctx = {
+            'step_number': step,
+            'NUM_STEPS': self.num_steps
+        }
+        if context:
+            final_ctx.update(context)
+        return final_ctx
+
+    def template_name(self, step):
+        return self._template_format.format(step)
+
+    def render(self, step, request, context=None):
+        return render(request, self.template_name(step),
+                      self.context(step, context))
+
+    @property
+    def num_steps(self):
+        if self._num_steps is None:
+            for i in range(1, 999):
+                if self._view_format.format(i) not in self._globs:
+                    self._num_steps = i - 1
+                    break
+        return self._num_steps

--- a/data_capture/views/common.py
+++ b/data_capture/views/common.py
@@ -13,7 +13,7 @@ def add_generic_form_error(request, form):
     )
 
 
-class StepBuilder:
+class Steps:
     def __init__(self, template_format):
         self.template_format = template_format
         self._views = []

--- a/data_capture/views/common.py
+++ b/data_capture/views/common.py
@@ -35,7 +35,9 @@ class Steps:
         >>> @steps.step
         ... def step_2(request, step): pass
 
-    Note that skipping numbers is not allowed, e.g.:
+    (What's that extra `step` argument?  We'll get to that in a moment!)
+
+    Breaking this ordering, e.g. by skipping numbers, is not allowed:
 
         >>> @steps.step
         ... def step_5(request, step): pass
@@ -55,10 +57,13 @@ class Steps:
         >>> steps.urls
         [<RegexURLPattern step_1 ^1$>, <RegexURLPattern step_2 ^2$>]
 
-    The `step` argument passed into each view function is a `StepRenderer`
-    instance bound to the particular step that the view represents.
+    Now, what's that `step` argument passed into each view function?
 
-    These can also be retrieved manually if needed:
+    It's a `StepRenderer` instance bound to the particular step that the
+    view represents, and it provides some tools that make it easy to
+    render steps.
+
+    `StepRenderer` instances can also be retrieved manually if needed:
 
         >>> step1 = steps.get_step_renderer(1)
 

--- a/data_capture/views/common.py
+++ b/data_capture/views/common.py
@@ -16,7 +16,7 @@ def add_generic_form_error(request, form):
 
 class Steps:
     '''
-    This class makes it easier to consolidate the logic of
+    The `Steps` class makes it easier to consolidate the logic of
     multi-step workflows.
 
     The `Steps` constructor takes a format string representing what

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -7,11 +7,11 @@ from django.http import HttpResponseBadRequest
 from .. import forms
 from ..decorators import handle_cancel
 from ..schedules import registry
-from .common import add_generic_form_error, StepBuilder
+from .common import add_generic_form_error, Steps
 from frontend import ajaxform
 
 
-steps = StepBuilder(
+steps = Steps(
     template_format='data_capture/price_list/step_{}.html',
 )
 

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -137,11 +137,12 @@ def step_3(request, step):
 @contract_officer_perms_required
 @handle_cancel
 def step_4(request, step):
-    gleaned_data = None
-    try:
-        price_list = request.session['data_capture:price_list']
-        gleaned_data = price_list['gleaned_data']
-    except KeyError:
+    gleaned_data = get_nested_item(request.session, (
+        'data_capture:price_list',
+        'gleaned_data',
+    ))
+
+    if gleaned_data is None:
         return redirect('data_capture:step_3')
 
     gleaned_data = registry.deserialize(gleaned_data)

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -12,10 +12,8 @@ from .common import add_generic_form_error, StepBuilder
 from frontend import ajaxform
 
 
-step = StepBuilder(
+steps = StepBuilder(
     template_format='data_capture/price_list/step_{}.html',
-    view_format='step_{}',
-    globs=globals()
 )
 
 
@@ -31,6 +29,7 @@ def gleaned_data_required(f):
     return wrapper
 
 
+@steps.step
 @login_required
 @require_http_methods(["GET", "POST"])
 def step_1(request):
@@ -47,11 +46,12 @@ def step_1(request):
         else:
             add_generic_form_error(request, form)
 
-    return step.render(1, request, {
+    return steps.render(1, request, {
         'form': form,
     })
 
 
+@steps.step
 @handle_cancel
 @login_required
 @require_http_methods(["GET", "POST"])
@@ -77,11 +77,12 @@ def step_2(request):
         else:
             add_generic_form_error(request, form)
 
-    return step.render(2, request, {
+    return steps.render(2, request, {
         'form': form
     })
 
 
+@steps.step
 @handle_cancel
 @login_required
 @require_http_methods(["GET", "POST"])
@@ -111,14 +112,15 @@ def step_3(request):
 
         return ajaxform.render(
             request,
-            context=step.context(3, {
+            context=steps.context(3, {
                 'form': form
             }),
-            template_name=step.template_name(3),
+            template_name=steps.template_name(3),
             ajax_template_name='data_capture/price_list/upload_form.html',
         )
 
 
+@steps.step
 @login_required
 @gleaned_data_required
 @handle_cancel
@@ -157,13 +159,14 @@ def step_4(request, gleaned_data):
 
         return redirect('data_capture:step_5')
 
-    return step.render(4, request, {
+    return steps.render(4, request, {
         'gleaned_data': gleaned_data,
         'is_preferred_schedule': isinstance(gleaned_data, preferred_schedule),
         'preferred_schedule': preferred_schedule,
     })
 
 
+@steps.step
 @login_required
 def step_5(request):
-    return step.render(5, request)
+    return steps.render(5, request)

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -128,7 +128,7 @@ def step_3(request, step):
             context=step.context({
                 'form': form
             }),
-            template_name=step.template_name(),
+            template_name=step.template_name,
             ajax_template_name='data_capture/price_list/upload_form.html',
         )
 

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -152,11 +152,21 @@
   </p>
 
   <p>
-    Use <code>li.steps-done</code> to identify a step as being completed.
+    Use <code>li.current</code> to identify a step as being the current
+    one.
+  </p>
+
+  <p>
+    We recommend adding <code>aria-hidden="true"</code> to the list, as
+    there isn't an easy way to communicate the information to vision-impaired
+    users without being overly verbose (thus annoying the user) or confusing.
+    However, <em>do</em> be sure to repeat the name of the current step
+    elsewhere in a header, so that the user knows what step they're currently
+    on.
   </p>
 
   {% example %}
-  <ol class="steps">
+  <ol class="steps" aria-hidden="true">
     <li>
       <label>Upload price list</label>
     </li>


### PR DESCRIPTION
This supersedes #578 and fixes #413, as it was easier to just start a new PR instead of deal with the merge conflicts.  I'm also taking a slightly different approach that will make it easier to consolidate logic across all step-based workflows (i.e. region 10 bulk upload and price list upload).

Basically I'm doing this through the creation of a new `Steps` class, which encapsulates all the steps in a particular workflow.  Here's the docstring (which contains doctests that are verified during CI 🎉 ):

```
    The `Steps` class makes it easier to consolidate the logic of
    multi-step workflows.

    The `Steps` constructor takes a format string representing what
    the template path for each step looks like:

        >>> steps = Steps('data_capture/tests/my_step_{}.html')

    The `@step` view decorator can be used to "register" steps in the
    workflow.  Each step's function name is expected to end with
    a number, and the steps are expected to be defined in
    ascending order, e.g.:

        >>> @steps.step
        ... def step_1(request, step): pass

        >>> @steps.step
        ... def step_2(request, step): pass

    (What's that extra `step` argument?  We'll get to that in a moment!)

    Breaking this ordering, e.g. by skipping numbers, is not allowed:

        >>> @steps.step
        ... def step_5(request, step): pass
        Traceback (most recent call last):
        ...
        ValueError: Expected "step_5" to end with the number 3

    At this point, our example workflow has two steps:

        >>> steps.num_steps
        2

    URL patterns for our steps are automatically defined, too, and can
    be included via Django's standard `include()` function. The names
    of each view will be identical to their view function's name:

        >>> steps.urls
        [<RegexURLPattern step_1 ^1$>, <RegexURLPattern step_2 ^2$>]

    Now, what's that `step` argument passed into each view function?

    It's a `StepRenderer` instance bound to the particular step that the
    view represents, and it provides some tools that make it easy to
    render steps.

    `StepRenderer` instances can also be retrieved manually if needed:

        >>> step1 = steps.get_step_renderer(1)

    A `StepRenderer` instance can be used to easily access
    commonly-used view logic, e.g.:

        >>> step1.number
        1

        >>> step1.steps.num_steps
        2

        >>> step1.description
        'step 1 of 2'

    Tools for templates and their contexts are also available.

    The `context()` function builds a context dictionary that always
    contains a `step` key referring to the `StepRenderer` instance for
    that step:

        >>> ctx = step1.context({'foo': 'bar'})
        >>> ctx['foo']
        'bar'
        >>> ctx['step']
        <StepRenderer for step 1 of 2>

    The `template_name` property always refers to the template for the step:

        >>> step1.template_name
        'data_capture/tests/my_step_1.html'

    And `render`/`render_to_string` ties everything together:

        >>> step1.render_to_string({'foo': 'bar'})
        'Hello from step 1 of 2! foo is bar.'
```

<!--
Basically I'm doing this through the creation of a new `Steps` class, which encapsulates all the steps in a particular workflow.  Its main two features are:

* `Steps.step`, a view decorator that passes in a `StepRenderer` instance to the view, which simplifies view logic.

  The most unintuitive "feature" of this decorator at present is that it expects the view function's name to end with a number that corresponds to the step it represents, e.g. `step_4`, and it uses this number to determine things like what template to use for rendering.  This may or may not be a bit too "convention over configuration"-y for our tastes, so we can change it to explicitly take in a step number if we want.

* `Steps.urls`, which returns a list of URLs that can be `include`'d in a Django URL config.

    Really this feature was mainly just added as a way to ensure that the `Steps` class was working properly without having to write new unit tests. 😅  (That is, if it wasn't registering the URLs properly, I'd know something was afoot in its core logic!)

-->

The API for the `Steps`/`StepRenderer` classes are inspired by Django's [`Paginator` / `Page`](https://docs.djangoproject.com/en/1.9/topics/pagination/) classes.

If these new classes seem useful, we can build on them more in future PRs to e.g. automatically render the steps widget for us, among other things.  I tried curbing my inner [architecture astronaut](http://www.joelonsoftware.com/articles/fog0000000018.html) to make this PR as small and non-disruptive as possible, but I'm not sure if I succeeded... Any feedback is appreciated!

## To Do

- [x] Add unit tests.
- [x] Add documentation (specifically, docstrings for `Steps` and `StepRenderer`).
- [x] Apply the `Steps` class to Region 10 bulk upload once #694 is merged. (it's currently just applied to price list upload.)
