### PR TITLE
Pass schedule into price_list.Step3Form constructor

### DIFF
--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -48,6 +48,14 @@ class Step3Form(forms.Form):
     file = forms.FileField(widget=UploadWidget())
 
     def __init__(self, *args, **kwargs):
+        '''
+        This constructor requires `schedule` to be passed in as a
+        keyword argument. It should be a string referring to the
+        fully-qualified class name for an entry in the schedule
+        registry, e.g.
+        "data_capture.schedules.fake_schedule.FakeSchedulePriceList".
+        '''
+
         self.schedule = kwargs.pop('schedule')
         super().__init__(*args, **kwargs)
 

--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -45,22 +45,19 @@ class Step2Form(forms.ModelForm):
 
 
 class Step3Form(forms.Form):
-    # TODO: We should figure out a way of getting rid of this field, since
-    # we're not actually asking the user for it anymore.
-
-    schedule = forms.ChoiceField(
-        choices=registry.get_choices
-    )
-
     file = forms.FileField(widget=UploadWidget())
+
+    def __init__(self, *args, **kwargs):
+        self.schedule = kwargs.pop('schedule')
+        super().__init__(*args, **kwargs)
 
     def clean(self):
         cleaned_data = super().clean()
-        schedule = cleaned_data.get('schedule')
         file = cleaned_data.get('file')
 
-        if schedule and file:
-            gleaned_data = registry.smart_load_from_upload(schedule, file)
+        if file:
+            gleaned_data = registry.smart_load_from_upload(self.schedule,
+                                                           file)
 
             if gleaned_data.is_empty():
                 raise forms.ValidationError(

--- a/data_capture/tests/test_forms.py
+++ b/data_capture/tests/test_forms.py
@@ -12,16 +12,14 @@ class Step3FormTests(TestCase):
         registry._init()
 
     def test_invalid_when_file_is_missing(self):
-        form = Step3Form({})
+        form = Step3Form({}, schedule=FAKE_SCHEDULE)
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors['file'][0], 'This field is required.')
 
     def test_invalid_when_file_cannot_be_gleaned(self):
-        form = Step3Form({
-            'schedule': FAKE_SCHEDULE,
-        }, {
+        form = Step3Form({}, {
             'file': uploaded_csv_file(b'i cannot be gleaned')
-        })
+        }, schedule=FAKE_SCHEDULE)
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors, {
             '__all__': [
@@ -31,11 +29,9 @@ class Step3FormTests(TestCase):
         })
 
     def test_clean_sets_gleaned_data(self):
-        form = Step3Form({
-            'schedule': FAKE_SCHEDULE,
-        }, {
+        form = Step3Form({}, {
             'file': uploaded_csv_file()
-        })
+        }, schedule=FAKE_SCHEDULE)
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data['gleaned_data'].title,
                          FakeSchedulePriceList.title)

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -111,14 +111,16 @@ def step_3(request):
                                                 {}):
         return redirect('data_capture:step_2')
     else:
+        session_pl = request.session['data_capture:price_list']
+        schedule = session_pl['step_1_POST']['schedule']
         if request.method == 'GET':
-            form = forms.Step3Form()
+            form = forms.Step3Form(schedule=schedule)
         else:
-            session_pl = request.session['data_capture:price_list']
-            posted_data = dict(
+            form = forms.Step3Form(
                 request.POST,
-                schedule=session_pl['step_1_POST']['schedule'])
-            form = forms.Step3Form(posted_data, request.FILES)
+                request.FILES,
+                schedule=schedule
+            )
 
             if form.is_valid():
                 session_pl['gleaned_data'] = \


### PR DESCRIPTION
`price_list.Step3Form` used to have `schedule` as a user-facing field but we removed it in [the great form rejiggering of 2016](https://github.com/18F/calc/pull/583).  However, the field was still kept around in the actual form class.  This removes it as a field and instead expects the schedule to be passed-in to the form constructor.

Aside from making the code a bit more understandable, this will also help with #538, as it'll be easier to dynamically set the upload widget properties (accepted file types and help text) based on the schedule.