### PR TITLE
Display preferred schedule during fallback

### DIFF
--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -19,6 +19,13 @@ class Step1Form(forms.ModelForm):
             'vendor_name',
         ]
 
+    def clean(self):
+        cleaned_data = super().clean()
+        schedule = cleaned_data.get('schedule')
+        if schedule:
+            cleaned_data['schedule_class'] = registry.get_class(schedule)
+        return cleaned_data
+
 
 class Step2Form(forms.ModelForm):
     is_small_business = forms.ChoiceField(

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -8,7 +8,7 @@
 {% if not is_preferred_schedule %}
 <p>
   <strong>Note:</strong> You specified that the price list you were
-  uploading was for <em>{{ preferred_schedule.title }}</em>, but it
+  uploading was for <em>{{ preferred_schedule_title }}</em>, but it
   appears to be for <em>{{ gleaned_data.title }}</em>. If this is
   incorrect, please upload a different file.
 </p>

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -146,21 +146,20 @@ def step_3(request):
 @handle_cancel
 def step_4(request, gleaned_data):
     session_pl = request.session['data_capture:price_list']
-    preferred_schedule = registry.get_class(
-        session_pl['step_1_POST']['schedule']
+    step_1_form = forms.Step1Form(
+        session_pl['step_1_POST']
     )
+    if not step_1_form.is_valid():
+        raise AssertionError('invalid step 1 data in session')
+
+    preferred_schedule = step_1_form.cleaned_data['schedule_class']
+
     if request.method == 'POST':
         if not gleaned_data.valid_rows:
             # Our UI never should've let the user issue a request
             # like this.
             return HttpResponseBadRequest()
-        step_1_form = forms.Step1Form(
-            session_pl['step_1_POST']
-        )
-        if not step_1_form.is_valid():
-            raise AssertionError('invalid step 1 data in session')
         price_list = step_1_form.save(commit=False)
-
         step_2_form = forms.Step2Form(
             session_pl['step_2_POST'],
             instance=price_list
@@ -172,6 +171,12 @@ def step_4(request, gleaned_data):
         price_list.submitter = request.user
         price_list.serialized_gleaned_data = json.dumps(
             session_pl['gleaned_data'])
+
+        # We always want to explicitly set the schedule to the
+        # one that the gleaned data is part of, in case we gracefully
+        # fell back to a schedule other than the one the user chose.
+        price_list.schedule = registry.get_classname(gleaned_data)
+
         price_list.save()
         gleaned_data.add_to_price_list(price_list)
 
@@ -183,7 +188,7 @@ def step_4(request, gleaned_data):
         'step_number': 4,
         'gleaned_data': gleaned_data,
         'is_preferred_schedule': isinstance(gleaned_data, preferred_schedule),
-        'preferred_schedule': preferred_schedule,
+        'preferred_schedule_title': preferred_schedule.title,
     })
 
 


### PR DESCRIPTION
This fixes #663.

It also makes `Step1Form` take care of automatically converting the schedule the user chose into a `BasePriceList` subclass, which should help with #737.

I also discovered that even though the fallback logic was working, the actual `schedule` property of the submitted price list was still being set to the user's preferred schedule (rather than the one we fell back to), so I fixed that too.