### PR TITLE
Support multiple submit buttons in ajaxform

### DIFF
--- a/frontend/source/js/data-capture/ajaxform.js
+++ b/frontend/source/js/data-capture/ajaxform.js
@@ -77,6 +77,14 @@ class AjaxForm extends window.HTMLFormElement {
         for (let j = 0; j < el.files.length; j++) {
           formData.append(el.name, el.files[j]);
         }
+      } else if (el.type === 'submit') {
+        // This logic is used to support multiple submit buttons.
+        // However, it's assumed that the "default" submit button, which
+        // is triggered in browsers by being the first in the DOM tree,
+        // has no 'name' value associated with it.
+        if (document.activeElement === el) {
+          formData.append(el.name, el.value);
+        }
       } else {
         formData.append(el.name, el.value);
       }

--- a/frontend/source/js/tests/ajaxform_tests.js
+++ b/frontend/source/js/tests/ajaxform_tests.js
@@ -149,6 +149,23 @@ advancedTest('upgraded form has falsy .isDegraded', (assert, s) => {
   assert.ok(!s.ajaxform.isDegraded);
 });
 
+advancedTest('custom submit btn info only included when ' +
+             'in active focus', (assert, s) => {
+  $(s.ajaxform).on('submit', () => {
+    const formData = server.requests[0].requestBody;
+
+    // Ugh, only newer browsers support FormData.prototype.get().
+    if (typeof formData.get === 'function') {
+      assert.ok(formData.has('cancel'));
+    } else {
+      assert.ok(true);
+    }
+  });
+  $parentDiv.show();
+  $('button[name="cancel"]', s.ajaxform).focus();
+  $(s.ajaxform).submit();
+});
+
 advancedTest('submit triggers ajax w/ form data', (assert, s) => {
   $(s.ajaxform).on('submit', e => {
     assert.ok(e.isDefaultPrevented());
@@ -164,6 +181,7 @@ advancedTest('submit triggers ajax w/ form data', (assert, s) => {
     if (typeof formData.get === 'function') {
       assert.equal(formData.get('foo'), 'bar');
       assert.equal(formData.get('file').size, 'hello there'.length);
+      assert.ok(!formData.has('cancel'));
     }
   });
 

--- a/frontend/templatetags/qunit_fixture_data.py
+++ b/frontend/templatetags/qunit_fixture_data.py
@@ -28,6 +28,7 @@ class AjaxformTestsForm(forms.Form):
             ' action="/post-stuff">',
             '  %s' % str(self.as_ul()),
             '  <button type="submit">submit</button>',
+            '  <button type="submit" name="cancel">cancel</button>',
             '</form>'
         ])
 

--- a/styleguide/ajaxform_example.py
+++ b/styleguide/ajaxform_example.py
@@ -47,22 +47,28 @@ def view(request):
     form = None
 
     if request.method == 'POST':
-        form = ExampleForm(request.POST, request.FILES)
+        if 'cancel' in request.POST:
+            messages.add_message(
+                request, messages.INFO,
+                'Form submission cancelled.'
+            )
+        else:
+            form = ExampleForm(request.POST, request.FILES)
 
-        if form.is_valid():
-            choice = form.cleaned_data['on_valid_submit']
-            if choice == CHOICE_REDIRECT:
-                time.sleep(3)
-                return ajaxform.redirect(request, 'styleguide:index')
-            elif choice == CHOICE_500:
-                raise Exception('Here is the 500 your ordered.')
-            else:
-                return HttpResponse('Here is an unexpected response.')
+            if form.is_valid():
+                choice = form.cleaned_data['on_valid_submit']
+                if choice == CHOICE_REDIRECT:
+                    time.sleep(3)
+                    return ajaxform.redirect(request, 'styleguide:index')
+                elif choice == CHOICE_500:
+                    raise Exception('Here is the 500 your ordered.')
+                else:
+                    return HttpResponse('Here is an unexpected response.')
 
-        messages.add_message(
-            request, messages.ERROR,
-            'Uh oh. Please correct the error(s) below and try again.'
-        )
+            messages.add_message(
+                request, messages.ERROR,
+                'Uh oh. Please correct the error(s) below and try again.'
+            )
 
     return ajaxform.render(
         request,

--- a/styleguide/templates/styleguide_ajaxform_example.html
+++ b/styleguide/templates/styleguide_ajaxform_example.html
@@ -24,5 +24,7 @@
     {{ form.file }}
   {% endwith %}
 
-  <button type="submit" class="button-primary">Submit</button>
+  <button type="submit" class="button-primary" style="display: inline-block">Submit</button>
+
+  <button type="submit" class="button-secondary" name="cancel" formnovalidate style="display: inline-block">Cancel</button>
 </form>


### PR DESCRIPTION
This fixes the main remaining issue mentioned in https://github.com/18F/calc/issues/700#issuecomment-246176550 by having `ajaxform` check to see if a button/input with `type="submit"` is the currently focused element on the page before adding its name and value to a `FormData` instance.

The functionality can be manually tested through the ajax form in the style guide. I tried it on IE11, Chrome, Firefox, and Edge, and it works on all of them!  🎉 
