### PR TITLE
Allow schedules to provide upload examples and help text

### DIFF
--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -64,7 +64,13 @@ class Step3Form(forms.Form):
         '''
 
         self.schedule = kwargs.pop('schedule')
+        self.schedule_class = registry.get_class(self.schedule)
+
         super().__init__(*args, **kwargs)
+
+        extra = self.schedule_class.upload_widget_extra_instructions
+        if extra is not None:
+            self.fields['file'].widget.extra_instructions = extra
 
     def clean(self):
         cleaned_data = super().clean()

--- a/data_capture/schedules/base.py
+++ b/data_capture/schedules/base.py
@@ -1,3 +1,6 @@
+from django.template.loader import render_to_string
+
+
 class BasePriceList:
     '''
     Abstract base class for price lists being imported into CALC.
@@ -6,6 +9,13 @@ class BasePriceList:
     # Human-readable name of the schedule to which the price list
     # belongs. Subclasses should override this.
     title = 'Unknown Schedule'
+
+    # Path to the template used for presenting an example of
+    # what to upload.
+    upload_example_template = None
+
+    # Extra instructions text to use for the upload widget.
+    upload_widget_extra_instructions = None
 
     def __init__(self):
         # This is a list of Django Form objects representing
@@ -54,6 +64,20 @@ class BasePriceList:
         '''
 
         return NotImplementedError()
+
+    @classmethod
+    def render_upload_example(cls):
+        '''
+        Returns the HTML containing an example of what the schedule
+        expects the user to upload, along with any other pertinent
+        information.
+
+        If the schedule has no example, returns an empty string.
+        '''
+
+        if cls.upload_example_template is not None:
+            return render_to_string(cls.upload_example_template)
+        return ''
 
     @classmethod
     def deserialize(cls, obj):

--- a/data_capture/schedules/fake_schedule.py
+++ b/data_capture/schedules/fake_schedule.py
@@ -43,6 +43,9 @@ class FakeScheduleRow(forms.Form):
 class FakeSchedulePriceList(BasePriceList):
     title = 'Fake Schedule (for dev/debugging only)'
     table_template = 'data_capture/price_list/tables/fake_schedule.html'
+    upload_example_template = ('data_capture/price_list/upload_examples/'
+                               'fake_schedule.html')
+    upload_widget_extra_instructions = 'CSV format, please.'
 
     def __init__(self, rows):
         super().__init__()

--- a/data_capture/schedules/s70.py
+++ b/data_capture/schedules/s70.py
@@ -132,6 +132,8 @@ class Schedule70PriceList(BasePriceList):
     title = 'IT Schedule 70'
     table_template = 'data_capture/price_list/tables/schedule_70.html'
 
+    upload_widget_extra_instructions = 'XLS or XLSX format, please.'
+
     def __init__(self, rows):
         super().__init__()
 

--- a/data_capture/templates/data_capture/price_list/step_3.html
+++ b/data_capture/templates/data_capture/price_list/step_3.html
@@ -7,13 +7,13 @@
 {% endblock %}
 
 {% block step_body %}
+{% if upload_example %}
+<expandable-area>
+  <p><strong>I don't know what to upload.</strong></p>
+  <div>
+    {{ upload_example }}
+  </div>
+</expandable-area>
+{% endif %}
 {% include 'data_capture/price_list/upload_form.html' %}
 {% endblock %}
-{% if show_debug_ui %}
-{% load static %}
-<p class="dev-note">
-  <strong>Developers:</strong>
-  Download <a href="{% static 'data_capture/fake_schedule_example.csv' %}"><code>fake_schedule_example.csv</code></a>
-  and choose "Fake Schedule" from the drop-down to get started.
-</p>
-{% endif %}

--- a/data_capture/templates/data_capture/price_list/upload_examples/fake_schedule.html
+++ b/data_capture/templates/data_capture/price_list/upload_examples/fake_schedule.html
@@ -1,0 +1,6 @@
+{% load static %}
+
+<p>
+  Download <a href="{% static 'data_capture/fake_schedule_example.csv' %}"><code>fake_schedule_example.csv</code></a>
+to get started.
+</p>

--- a/data_capture/tests/test_base_price_list.py
+++ b/data_capture/tests/test_base_price_list.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+from unittest import TestCase
+
+from ..schedules import base
+from ..schedules.base import BasePriceList
+
+
+class BasePriceListTests(TestCase):
+    def test_is_empty_returns_true_when_empty(self):
+        pl = BasePriceList()
+        self.assertTrue(pl.is_empty())
+
+    def test_is_empty_returns_false_when_valid_rows_exist(self):
+        pl = BasePriceList()
+        pl.valid_rows = ['blah']
+        self.assertFalse(pl.is_empty())
+
+    def test_is_empty_returns_false_when_invalid_rows_exist(self):
+        pl = BasePriceList()
+        pl.invalid_rows = ['blah']
+        self.assertFalse(pl.is_empty())
+
+    def test_render_upload_example_returns_empty_string_by_default(self):
+        self.assertEqual(BasePriceList.render_upload_example(), '')
+
+    @patch.object(base, 'render_to_string')
+    def test_render_upload_example_calls_render_to_string(self, r):
+        class FunkyPriceList(BasePriceList):
+            upload_example_template = 'foo/bar.html'
+
+        r.return_value = 'blah'
+
+        self.assertEqual(FunkyPriceList.render_upload_example(), 'blah')
+
+        r.assert_called_once_with('foo/bar.html')

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -36,6 +36,29 @@ def get_nested_item(obj, keys, default=None):
     return obj[key]
 
 
+def get_step_form_from_session(step_number, request, **kwargs):
+    '''
+    Bring back the given Form instance for a step from the
+    request session.  Returns None if the step hasn't been completed yet.
+
+    Any keyword arguments are passed on to the Form constructor.
+    '''
+
+    cls = getattr(forms, 'Step{}Form'.format(step_number))
+    post_data = get_nested_item(request.session, (
+        'data_capture:price_list',
+        'step_{}_POST'.format(step_number)
+    ))
+    if post_data is None:
+        return None
+    form = cls(post_data, **kwargs)
+    if not form.is_valid():
+        raise AssertionError(
+            'invalid step {} data in session'.format(step_number)
+        )
+    return form
+
+
 @steps.step
 @contract_officer_perms_required
 @require_http_methods(["GET", "POST"])
@@ -67,8 +90,7 @@ def step_1(request, step):
 @handle_cancel
 def step_2(request, step):
     # Redirect back to step 1 if we don't have data
-    if 'step_1_POST' not in request.session.get('data_capture:price_list',
-                                                {}):
+    if get_step_form_from_session(1, request) is None:
         return redirect('data_capture:step_1')
 
     if request.method == 'GET':
@@ -100,19 +122,20 @@ def step_2(request, step):
 @require_http_methods(["GET", "POST"])
 @handle_cancel
 def step_3(request, step):
-    if 'step_2_POST' not in request.session.get('data_capture:price_list',
-                                                {}):
+    if get_step_form_from_session(2, request) is None:
         return redirect('data_capture:step_2')
     else:
         session_pl = request.session['data_capture:price_list']
-        schedule = session_pl['step_1_POST']['schedule']
+        step_1_data = get_step_form_from_session(1, request).cleaned_data
+        schedule_class = step_1_data['schedule_class']
+
         if request.method == 'GET':
-            form = forms.Step3Form(schedule=schedule)
+            form = forms.Step3Form(schedule=step_1_data['schedule'])
         else:
             form = forms.Step3Form(
                 request.POST,
                 request.FILES,
-                schedule=schedule
+                schedule=step_1_data['schedule']
             )
 
             if form.is_valid():
@@ -128,7 +151,8 @@ def step_3(request, step):
         return ajaxform.render(
             request,
             context=step.context({
-                'form': form
+                'form': form,
+                'upload_example': schedule_class.render_upload_example()
             }),
             template_name=step.template_name,
             ajax_template_name='data_capture/price_list/upload_form.html',
@@ -150,11 +174,7 @@ def step_4(request, step):
     gleaned_data = registry.deserialize(gleaned_data)
 
     session_pl = request.session['data_capture:price_list']
-    step_1_form = forms.Step1Form(
-        session_pl['step_1_POST']
-    )
-    if not step_1_form.is_valid():
-        raise AssertionError('invalid step 1 data in session')
+    step_1_form = get_step_form_from_session(1, request)
 
     preferred_schedule = step_1_form.cleaned_data['schedule_class']
 
@@ -164,12 +184,8 @@ def step_4(request, step):
             # like this.
             return HttpResponseBadRequest()
         price_list = step_1_form.save(commit=False)
-        step_2_form = forms.Step2Form(
-            session_pl['step_2_POST'],
-            instance=price_list
-        )
-        if not step_2_form.is_valid():
-            raise AssertionError('invalid step 2 data in session')
+        step_2_form = get_step_form_from_session(2, request,
+                                                 instance=price_list)
         step_2_form.save(commit=False)
 
         price_list.submitter = request.user


### PR DESCRIPTION
This fixes #538 by adding a `upload_widget_extra_instructions` property to `BasePriceList`.

It also lays a foundation for fixing #727 by adding an `upload_example_template` property and `render_upload_example()` method.  It doesn't actually provide the actual *content* for Schedule 70, though--we'll address that in a future PR.  (And it's fine to merge this now b/c the "I'm not sure what to upload" expander only appears if there's upload example content to fill it with.)

While I didn't add upload example content for schedule 70 (this is addressed in #754), I did add some for the fake schedule, which is only ever shown to developers:

> <img width="728" alt="screen shot 2016-09-15 at 9 58 13 am" src="https://cloud.githubusercontent.com/assets/124687/18552615/1f7083f4-7b2b-11e6-8a50-793ac7e685b2.png">


Aside from that, it also makes a few refactorings to the price list views, by adding a `get_step_form_from_session()` helper function, which simplifies some things.

It also adds a new test suite for `BasePriceList` since we never had one.