### PR TITLE
Add a USWDS radio widget

### DIFF
--- a/frontend/radio.py
+++ b/frontend/radio.py
@@ -1,0 +1,33 @@
+from django import forms
+from django.utils.html import format_html
+
+
+class UswdsRadioChoiceInput(forms.widgets.RadioChoiceInput):
+    '''
+    A widget for a USWDS-style radio input.
+
+    This is basically just like Django's standard radio input, except
+    the <label> is a sibling of its <input>, rather than its parent.
+    '''
+
+    def render(self, name=None, value=None, attrs=None):
+        # This is mostly just a copy-paste of our superclass method, it
+        # just tweaks the HTML structure to be USWDS-friendly.
+
+        if self.id_for_label:
+            label_for = format_html(' for="{}"', self.id_for_label)
+        else:
+            label_for = ''
+        attrs = dict(self.attrs, **attrs) if attrs else self.attrs
+        return format_html(
+            '{}<label{}>{}</label>', self.tag(attrs), label_for,
+            self.choice_label,
+        )
+
+
+class UswdsRadioFieldRenderer(forms.widgets.ChoiceFieldRenderer):
+    choice_input_class = UswdsRadioChoiceInput
+
+
+class UswdsRadioSelect(forms.widgets.RadioSelect):
+    renderer = UswdsRadioFieldRenderer

--- a/styleguide/radio_example.py
+++ b/styleguide/radio_example.py
@@ -1,0 +1,46 @@
+from django import forms
+from django.shortcuts import render
+from django.contrib import messages
+
+from frontend.radio import UswdsRadioSelect
+
+
+class ExampleForm(forms.Form):
+    choices = forms.ChoiceField(
+        widget=UswdsRadioSelect,
+        choices=(
+            ('1', 'First'),
+            ('2', 'Second'),
+        )
+    )
+
+
+def create_template_context(radio_form=None):
+    if radio_form is None:
+        radio_form = ExampleForm()
+
+    return {'radio_form': radio_form}
+
+
+def view(request):
+    form = None
+
+    if request.method == 'POST':
+        form = ExampleForm(request.POST)
+
+        if form.is_valid():
+            messages.add_message(
+                request, messages.SUCCESS,
+                "You chose option #{}!".format(form.cleaned_data['choices'])
+            )
+        else:
+            messages.add_message(
+                request, messages.ERROR,
+                'Uh oh. Please correct the error(s) below and try again.'
+            )
+
+    return render(
+        request,
+        'styleguide_radio.html',
+        create_template_context(radio_form=form),
+    )

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -440,6 +440,27 @@
   </select>
   {% endexample %}
 
+  {% guide_section "Radio Buttons" %}
+
+  <p>
+    Because USWDS uses a slightly different HTML structure for
+    radio buttons than Django, we need to use a custom
+    {% pyobjname 'frontend.radio.UswdsRadioSelect' %} widget.
+  </p>
+
+  <p>
+    For a simple code example, see
+    {% pathname 'styleguide/radio_example.py' %} and
+    {% pathname 'styleguide/templates/styleguide_radio_example.html' %}.
+  </p>
+
+  <div class="styleguide-example">
+    <div class="rendering">
+      <h3 class="example-heading">Example</h3>
+      {% include "styleguide_radio_example.html" %}
+    </div>
+  </div>
+
   {% guide_section "Dates" %}
 
   <p>

--- a/styleguide/templates/styleguide_radio.html
+++ b/styleguide/templates/styleguide_radio.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block body %}
+<div class="container">
+  <h1>Radio Widget Example</h1>
+
+  {% include 'data_capture/messages.html' %}
+
+  {% include "styleguide_radio_example.html" %}
+</div>
+
+<script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
+{% endblock %}

--- a/styleguide/templates/styleguide_radio_example.html
+++ b/styleguide/templates/styleguide_radio_example.html
@@ -1,0 +1,14 @@
+<form method="post"
+      action="{% url 'styleguide:radio' %}">
+  {% csrf_token %}
+
+  {% with form=radio_form %}
+    <fieldset>
+      <legend>{{ form.choices.label }}</legend>
+      {{ form.choices.errors }}
+      {{ form.choices }}
+    </fieldset>
+  {% endwith %}
+
+  <button type="submit" class="button-primary">Submit</button>
+</form>

--- a/styleguide/tests.py
+++ b/styleguide/tests.py
@@ -14,3 +14,7 @@ class StyleguideTests(TestCase):
     def test_styleguide_date_returns_200(self):
         response = self.client.get('/styleguide/date')
         self.assertEqual(response.status_code, 200)
+
+    def test_styleguide_radio_returns_200(self):
+        response = self.client.get('/styleguide/radio')
+        self.assertEqual(response.status_code, 200)

--- a/styleguide/urls.py
+++ b/styleguide/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import url
 
-from . import views, ajaxform_example, date_example
+from . import views, ajaxform_example, date_example, radio_example
 
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^ajaxform$', ajaxform_example.view, name='ajaxform'),
     url(r'^date$', date_example.view, name='date'),
+    url(r'^radio$', radio_example.view, name='radio'),
 ]

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -2,7 +2,7 @@ from django import forms
 from django.shortcuts import render
 
 from frontend.upload import UploadWidget
-from . import ajaxform_example, date_example
+from . import ajaxform_example, date_example, radio_example
 
 
 def get_degraded_upload_widget():
@@ -18,5 +18,6 @@ def index(request):
     }
     ctx.update(ajaxform_example.create_template_context())
     ctx.update(date_example.create_template_context())
+    ctx.update(radio_example.create_template_context())
 
     return render(request, 'styleguide.html', ctx)


### PR DESCRIPTION
**Note: This is a PR against #751, not `develop`.**

This adds a USWDS-style radio widget.

> <img width="729" alt="screen shot 2016-09-15 at 2 38 59 pm" src="https://cloud.githubusercontent.com/assets/124687/18562558/37aae01e-7b52-11e6-9952-a758808816bf.png">

I wanted to add the pop-out link to the styleguide form as per #744 but it looks like #751 hasn't merged those changes in, so I left out the pop-out link.

Note that this just adds the widget and an example use of it in the style guide--it doesn't actually change #751 to use it.