### PR TITLE
Get rid of html.js / html.no-js classes

### DIFF
--- a/data_explorer/templates/base.html
+++ b/data_explorer/templates/base.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="en">
   <head>
     <title>CALC / {% block title %}Home{% endblock %}</title>
     <meta charset="utf-8">
@@ -10,7 +10,6 @@
     <script src="{% static 'frontend/js/vendor/aight.v2.min.js' %}"></script>
     <script src="{% static 'frontend/js/vendor/history.min.js' %}"></script>
     <![endif]-->
-    <script>(function(e,t,n){var r=e.querySelectorAll("html")[0];r.className=r.className.replace(/(^|\s)no-js(\s|$)/,"$1js$2")})(document,window,0);</script>
     <link rel="stylesheet" href="{% static 'frontend/built/style/main.min.css' %}"/>
 
     <![if gt IE 8]>

--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -199,7 +199,6 @@ class UploadWidget extends window.HTMLElement {
 
     if (!this._checkForAjaxFormParent() || !HAS_BROWSER_SUPPORT ||
         supports.isForciblyDegraded(this)) {
-      $el.addClass('degraded');
       this.isDegraded = true;
       return finishInitialization();
     }
@@ -209,6 +208,8 @@ class UploadWidget extends window.HTMLElement {
 
     // The content of the upload widget will change when the user chooses
     // a file, so let's make sure screen readers let users know about it.
+    // Note that this is also used by CSS rules to determine whether or
+    // not the widget has actually been upgraded by JS.
     $el.attr('aria-live', 'polite');
 
     $el.on('dragenter', e => {

--- a/frontend/source/js/tests/upload_tests.js
+++ b/frontend/source/js/tests/upload_tests.js
@@ -127,7 +127,6 @@ import { UploadWidget } from '../data-capture/upload';
   });
 
   degradedTest('degraded upload sets attributes properly', (assert) => {
-    assert.ok(upload.hasClass('degraded'));
     assert.ok(!upload[0].hasAttribute('aria-live'));
   });
 

--- a/frontend/source/sass/components/_upload.scss
+++ b/frontend/source/sass/components/_upload.scss
@@ -53,7 +53,8 @@ upload-widget {
   }
 }
 
-.js upload-widget:not(.degraded) {
+// Rules specific to JS-upgraded widgets.
+upload-widget[aria-live] {
   input {
     width: 0.1px;
     height: 0.1px;
@@ -64,8 +65,8 @@ upload-widget {
   }
 }
 
-.no-js upload-widget,
-.js upload-widget.degraded {
+// Rules specific to non-JS-upgraded widgets.
+upload-widget:not([aria-live]) {
   font-size: 1.3rem;
   display: block;
   border: none;


### PR DESCRIPTION
As mentioned in https://github.com/18F/calc/pull/654#r79152047, the `js` and `no-js` classes applied to `<html>` a la Modernizr actually violate the [Apply no style before its time](http://adaptivewebdesign.info/1st-edition/read/chapter-4.html) maxim of progressive enhancement.  In particular, it could be the case that this JS executes and applies the `js` style to the page, yet the data capture bundle fails to be retrieved for some reason, thus resulting in a broken page.

Beyond that, though, removing these classes, and our upload widget's reliance on them, actually *simplifies* our CSS and reduces the possibility of our site appearing to be broken.

Fortunately, removing the need for these classes was also easy, since the only component that relies on them is the upload widget.
