### PR TITLE
Add tests for radio.py

### DIFF
--- a/frontend/radio.py
+++ b/frontend/radio.py
@@ -17,7 +17,7 @@ class UswdsRadioChoiceInput(forms.widgets.RadioChoiceInput):
         if self.id_for_label:
             label_for = format_html(' for="{}"', self.id_for_label)
         else:
-            label_for = ''
+            raise ValueError('USWDS-style radios must have "id" attributes')
         attrs = dict(self.attrs, **attrs) if attrs else self.attrs
         return format_html(
             '{}<label{}>{}</label>', self.tag(attrs), label_for,

--- a/frontend/tests/test_radio.py
+++ b/frontend/tests/test_radio.py
@@ -1,0 +1,34 @@
+from django.test import SimpleTestCase
+
+from .. import radio
+
+
+class RadioTests(SimpleTestCase):
+    def test_it_raises_error_when_id_is_not_present(self):
+        rad = radio.UswdsRadioSelect(choices=[('1', 'foo')])
+        with self.assertRaisesRegexp(
+            ValueError,
+            'USWDS-style radios must have "id" attributes'
+        ):
+            rad.render('my-radios', '1')
+
+    def test_it_renders(self):
+        rad = radio.UswdsRadioSelect(
+            {'id': 'baz'},
+            choices=[('1', 'foo'), ('2', 'bar')]
+        )
+        self.assertHTMLEqual(
+            rad.render('my-radios', '1'),
+            ('<ul id="baz">'
+             '  <li>'
+             '    <input checked="checked" id="baz_0" name="my-radios" '
+             '     type="radio" value="1" />'
+             '    <label for="baz_0">foo</label>'
+             '  </li>'
+             '  <li>'
+             '    <input id="baz_1" name="my-radios" type="radio" '
+             '     value="2" />'
+             '    <label for="baz_1">bar</label>'
+             '  </li>'
+             '</ul>')
+        )


### PR DESCRIPTION
**Note: This is a PR against #751, not `develop`.**

This adds a test suite for `frontend/radio.py`.

It also slightly changes the implementation of `radio.py` to raise an error if the radio doesn't have an `id`: because of the fact that USWDS-style radios have labels as sibling elements instead of parents, the radio *needs* an `id` or else the browser won't be able to associate the label with it.  So now the radio widget raises an exception if it isn't given an `id`, instead of staying silent about it and generating broken markup.