### PR TITLE
Improvements to #751 (form input restyling)

### DIFF
--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -39,11 +39,7 @@ class Step2Form(forms.ModelForm):
     )
     contractor_site = forms.ChoiceField(
         label='Worksite',
-        choices=[
-            ('Customer', 'Customer/Offsite'),
-            ('Contractor', 'Contractor/Onsite'),
-            ('Both', 'Both'),
-        ],
+        choices=SubmittedPriceList.CONTRACTOR_SITE_CHOICES,
         widget=UswdsRadioSelect,
     )
     contract_start = SplitDateField(required=False)

--- a/data_capture/models.py
+++ b/data_capture/models.py
@@ -5,6 +5,12 @@ from contracts.models import Contract, EDUCATION_CHOICES
 
 
 class SubmittedPriceList(models.Model):
+    CONTRACTOR_SITE_CHOICES = [
+        ('Customer', 'Customer/Offsite'),
+        ('Contractor', 'Contractor/Onsite'),
+        ('Both', 'Both'),
+    ]
+
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -20,11 +26,7 @@ class SubmittedPriceList(models.Model):
     is_small_business = models.BooleanField()
     contractor_site = models.CharField(
         verbose_name='Worksite',
-        choices=[
-            ('Customer', 'Customer/Offsite'),
-            ('Contractor', 'Contractor/Onsite'),
-            ('Both', 'Both'),
-        ],
+        choices=CONTRACTOR_SITE_CHOICES,
         max_length=128
     )
     contract_year = models.IntegerField(null=True, blank=True)

--- a/data_capture/templates/data_capture/price_list/step_1.html
+++ b/data_capture/templates/data_capture/price_list/step_1.html
@@ -17,8 +17,8 @@
 
   <label>{{ form.contract_number.label }}</label>
   {{ form.contract_number.errors }}
-  <p class="helptext">{{ form.contract_number.help_text }}</p>
   {{ form.contract_number }}
+  <p class="helptext">{{ form.contract_number.help_text }}</p>
 
   <label>{{ form.vendor_name.label }}</label>
   {{ form.vendor_name.errors }}

--- a/data_capture/templates/data_capture/price_list/step_2.html
+++ b/data_capture/templates/data_capture/price_list/step_2.html
@@ -12,26 +12,12 @@
   <fieldset>
     <legend>{{ form.is_small_business.label }}</legend>
     {{ form.is_small_business.errors }}
-    <ul>
-      {% for radio in form.is_small_business %}
-      <li>
-        {{ radio.tag }}
-        <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-      </li>
-      {% endfor %}
-    </ul>
+    {{ form.is_small_business }}
   </fieldset>
   <fieldset>
     <legend>{{ form.contractor_site.label }}</legend>
     {{ form.contractor_site.errors }}
-    <ul>
-      {% for radio in form.contractor_site %}
-      <li>
-        {{ radio.tag }}
-        <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-      </li>
-      {% endfor %}
-    </ul>
+    {{ form.contractor_site }}
   </fieldset>
 
   <div class="date-range">

--- a/data_capture/templates/data_capture/price_list/step_2.html
+++ b/data_capture/templates/data_capture/price_list/step_2.html
@@ -34,6 +34,12 @@
     </fieldset>
   </div>
 
+  <fieldset>
+    <legend>{{ form.contract_year.label }}</legend>
+    {{ form.contract_year.errors }}
+    {{ form.contract_year }}
+  </fieldset>
+
   <div class="form-button-row clearfix">
     <a href="{% url 'data_capture:step_1' %}" class="button button-outline button-previous">Previous</a>
 


### PR DESCRIPTION
**Note: This is a PR against #751, not `develop`.**

This addresses @jseppi's comments at https://github.com/18F/calc/pull/751#issuecomment-247641856 and a few other things.

It resolves the help text margins by moving the help text back below the `<input>` field, which is where it was before the great rejiggering of #583. Here the bottom margin on `<p>` elements works to distance the help text from the next field, rather than from the input:

> <img width="474" alt="screen shot 2016-09-16 at 1 46 45 pm" src="https://cloud.githubusercontent.com/assets/124687/18595741/09a164be-7c14-11e6-823c-9a03a4bb03ee.png">

But I'm not sure if the move of the help text to be above the input in #583 was a deliberate decision, or just an accidental effect of the rejiggering.  Regardless, it's really easy to undo.