### PR TITLE
Find Labor Categories start row index instead of hardcoding it

### DIFF
--- a/data_capture/schedules/s70.py
+++ b/data_capture/schedules/s70.py
@@ -83,6 +83,19 @@ def safe_cell_str_value(sheet, rownum, colnum, coercer=None):
     return str(val)
 
 
+def find_header_row(sheet):
+    CHECK_THRESHOLD = 50
+
+    first_col_heading = EXAMPLE_SHEET_ROWS[0][0]
+    row_limit = min(sheet.nrows, CHECK_THRESHOLD)
+
+    for rx in range(row_limit):
+        if sheet.cell_value(rx, 0) == first_col_heading:
+            return rx
+
+    raise ValidationError('Could not find Labor Categories price table.')
+
+
 def glean_labor_categories_from_file(f, sheet_name=DEFAULT_SHEET_NAME):
     # TODO: I'm not sure how big these uploaded files can get. While
     # the labor categories price lists don't get that long, according to
@@ -103,7 +116,8 @@ def glean_labor_categories_from_file(f, sheet_name=DEFAULT_SHEET_NAME):
 
     sheet = book.sheet_by_name(sheet_name)
 
-    rownum = 3
+    rownum = find_header_row(sheet) + 1  # add 1 to start on first data row
+
     cats = []
 
     while True:

--- a/data_capture/schedules/s70.py
+++ b/data_capture/schedules/s70.py
@@ -83,11 +83,9 @@ def safe_cell_str_value(sheet, rownum, colnum, coercer=None):
     return str(val)
 
 
-def find_header_row(sheet):
-    CHECK_THRESHOLD = 50
-
+def find_header_row(sheet, row_threshold=50):
     first_col_heading = EXAMPLE_SHEET_ROWS[0][0]
-    row_limit = min(sheet.nrows, CHECK_THRESHOLD)
+    row_limit = min(sheet.nrows, row_threshold)
 
     for rx in range(row_limit):
         if sheet.cell_value(rx, 0) == first_col_heading:

--- a/data_capture/tests/test_s70.py
+++ b/data_capture/tests/test_s70.py
@@ -60,6 +60,30 @@ class SafeCellStrValueTests(TestCase):
         self.assertEqual(s70.safe_cell_str_value(s, 1, 1, int), '5')
 
 
+class FindHeaderRowTests(TestCase):
+
+    def return_heading_on_row_4(self, row, col):
+        if row is 4:
+            return s70.EXAMPLE_SHEET_ROWS[0][0]
+        return 'boop'
+
+    def test_find_header_row_works(self):
+        sheet_mock = MagicMock(nrows=10)
+        sheet_mock.cell_value.side_effect = self.return_heading_on_row_4
+        self.assertEqual(s70.find_header_row(sheet_mock), 4)
+
+    def test_raises_validation_error_if_table_not_found(self):
+        sheet_mock = MagicMock(nrows=10)
+        with self.assertRaises(ValidationError):
+            s70.find_header_row(sheet_mock)
+
+    def test_raises_validation_error_when_threshold_is_reached(self):
+        sheet_mock = MagicMock(nrows=10)
+        sheet_mock.cell_value.side_effect = self.return_heading_on_row_4
+        with self.assertRaises(ValidationError):
+            s70.find_header_row(sheet_mock, row_threshold=3)
+
+
 class GleanLaborCategoriesTests(TestCase):
     def test_rows_are_returned(self):
         rows = s70.glean_labor_categories_from_file(uploaded_xlsx_file())


### PR DESCRIPTION
Small change to find the start row of the labor categories table instead of hardcoding `rownum = 3`. The new `find_header_row` works pretty naively by just returning the row index for the row that contains the first expected column heading (`"SIN(s) PROPOSED"`) in column 0.

To Do:
- [x] add test ~~and fixture~~ (used MagicMocks instead)

