### PR TITLE
Fix step 4 form-button-row markup

### DIFF
--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -58,20 +58,22 @@
 
 {% endif %}
 
-<div class="form-button-row clearfix">
-  <a href="{% url 'data_capture:step_3' %}" class="button button-previous">Previous</a>
+<form method="post">
+  <div class="form-button-row clearfix">
+    <a href="{% url 'data_capture:step_3' %}" class="button button-previous">Previous</a>
 
-  {% if gleaned_data.valid_rows %}
-  <form method="post" class="submit-group">
-    {% csrf_token %}
-    <button type="submit" class="button-primary">Next</button>
-    <span class="submit-label">
-      Submit to approver
-    </span>
+    {% if gleaned_data.valid_rows %}
+      <div class="submit-group">
+        {% csrf_token %}
+        <button type="submit" class="button-primary">Next</button>
+        <span class="submit-label">
+          Submit to approver
+        </span>
+      </div>
+    {% endif %}
 
     <button type="submit" class="button-link" name="cancel" formnovalidate>Cancel</button>
-  </form>
-  {% endif %}
-</div>
+  </div>
+</form>
 
 {% endblock %}


### PR DESCRIPTION
Fixes #768

Also moves the `cancel` button to outside of the `{% if %}` block so that the price list submission can still be canceled when no valid rows are present in the selected file.