### PR TITLE
improve cloud deployment YAML config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ environment variables:
 app:
   environment:
     - DEBUG=yup
+rq_worker:
+  environment:
+    - DEBUG=yup
+rq_scheduler:
+  environment:
+    - DEBUG=yup
 ```
 
 You'll also want to tell Docker Compose what port to listen on,


### PR DESCRIPTION
Blerg.

The cloud deploy doesn't copy the `.env` file over, but the downside is that it means that we need to separately configure every container, which is a bit annoying, especially for environment variables like `DEBUG` that are shared across containers.