### PR TITLE
Show step 1 deets in step 2

### DIFF
--- a/data_capture/templates/data_capture/price_list/step_2.html
+++ b/data_capture/templates/data_capture/price_list/step_2.html
@@ -3,8 +3,9 @@
 {% block subtitle %}Enter contract details{% endblock %}
 
 {% block step_body %}
-<h2>Enter contract details</h2>
+<h2>Price list details for {{ step_1_data.contract_number.value }}</h2>
 <div class="row">
+  <h3><strong>{{ step_1_data.vendor_name.value }}</strong></h3>
   <form method="post" class="columns nine">
   {% csrf_token %}
 

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -117,7 +117,8 @@ def step_2(request, step):
             add_generic_form_error(request, form)
 
     return step.render(request, {
-        'form': form
+        'form': form,
+        'step_1_data': get_step_form_from_session(1, request)
     })
 
 


### PR DESCRIPTION
Closes #737. Note that this doesn't display the schedule, in part because I'm no longer sure if we want to stick with displaying the schedule, or if we think we might want to shift to using SIN numbers a la the micropurchase.
<img width="764" alt="screen shot 2016-09-20 at 3 50 39 pm" src="https://cloud.githubusercontent.com/assets/509309/18688455/2074132e-7f4a-11e6-9204-fd9ce4c9177c.png">
