### PR TITLE
Set max width for paragraphs

### DIFF
--- a/data_capture/templates/data_capture/price_list/step_1.html
+++ b/data_capture/templates/data_capture/price_list/step_1.html
@@ -3,7 +3,7 @@
 {% block subtitle %}Upload price list{% endblock %}
 
 {% block step_heading %}
-<p>Your price lists help make CALC a more robust tool. Uploading them is quick. Once you upload a price list, we’ll make sure we understand your data, ask you for a few details, and send your price list to a CALC admin. The admin will check the data and publish it on CALC for all to use.</p>
+<p>Your price lists help make CALC a more robust tool. Uploading them is quick. Once you upload a price list, we'll make sure we understand your data, ask you for a few details, and send your price list to a CALC admin. The admin will check the data and publish it on CALC for all to use.</p>
 {% endblock %}
 
 {% block step_body %}

--- a/frontend/source/sass/base/_typography.scss
+++ b/frontend/source/sass/base/_typography.scss
@@ -22,6 +22,7 @@ h6 {
 p {
   font-size: $base-font-size;
   line-height: $base-line-height;
+  max-width: 72rem;
 }
 
 .help-text {


### PR DESCRIPTION
Closes #720. This sets a `max-width` of `72rem` on paragraph tags, which is 75% of the container's max width. 
<img width="961" alt="screen shot 2016-09-21 at 10 30 55 am" src="https://cloud.githubusercontent.com/assets/509309/18717738/85b68f0e-7fe6-11e6-8c56-9b6b238b4cd9.png">
