### PR TITLE
add <uswds-date> custom element that focuses on next widget on "/" key

### DIFF
--- a/frontend/source/js/data-capture/date.js
+++ b/frontend/source/js/data-capture/date.js
@@ -1,0 +1,46 @@
+/* global window, document */
+
+import 'document-register-element';
+
+const KEY_DASH = 189;
+const KEY_PERIOD = 190;
+const KEY_SLASH = 191;
+
+class UswdsDate extends window.HTMLElement {
+  _getNextInput(currentInput) {
+    const inputs = this.querySelectorAll('input');
+    let useNext = false;
+
+    for (let i = 0; i < inputs.length; i++) {
+      if (useNext) {
+        return inputs[i];
+      } else if (inputs[i] === currentInput) {
+        useNext = true;
+      }
+    }
+
+    return null;
+  }
+  _onKeyDown(e) {
+    if (e.keyCode === KEY_DASH || e.keyCode === KEY_PERIOD ||
+        e.keyCode === KEY_SLASH) {
+      const nextInput = this._getNextInput(e.target);
+
+      if (nextInput) {
+        e.preventDefault();
+        nextInput.focus();
+      }
+    }
+  }
+  createdCallback() {
+    this.addEventListener('keydown', this._onKeyDown.bind(this), true);
+  }
+}
+
+UswdsDate.prototype.SOURCE_FILENAME = __filename;
+
+document.registerElement('uswds-date', {
+  prototype: UswdsDate.prototype,
+});
+
+module.exports = UswdsDate;

--- a/frontend/source/js/data-capture/date.js
+++ b/frontend/source/js/data-capture/date.js
@@ -21,7 +21,7 @@ class UswdsDate extends window.HTMLElement {
 
     return null;
   }
-  _onKeyDown(e) {
+  handleKeyDown(e) {
     if (e.keyCode === KEY_DASH || e.keyCode === KEY_PERIOD ||
         e.keyCode === KEY_SLASH) {
       const nextInput = this._getNextInput(e.target);
@@ -33,7 +33,7 @@ class UswdsDate extends window.HTMLElement {
     }
   }
   createdCallback() {
-    this.addEventListener('keydown', this._onKeyDown.bind(this), true);
+    this.addEventListener('keydown', this.handleKeyDown.bind(this), true);
   }
 }
 

--- a/frontend/source/js/data-capture/index.js
+++ b/frontend/source/js/data-capture/index.js
@@ -10,3 +10,4 @@ require('./upload');
 require('./ajaxform');
 require('./alerts');
 require('./expandable-area');
+require('./date');

--- a/frontend/source/js/tests/date_tests.js
+++ b/frontend/source/js/tests/date_tests.js
@@ -1,0 +1,46 @@
+/* global QUnit document */
+
+QUnit.module('uswds-date');
+
+function makeDate() {
+  const date = document.createElement('uswds-date');
+  const input1 = document.createElement('input');
+  const input2 = document.createElement('input');
+
+  date.appendChild(input1);
+  date.appendChild(input2);
+
+  return { date, input1, input2 };
+}
+
+QUnit.test('input focus changed on "/"', assert => {
+  const { date, input1, input2 } = makeDate();
+  let defaultPrevented = false;
+
+  input2.focus = () => {
+    assert.ok(defaultPrevented);
+  };
+
+  date.handleKeyDown({
+    keyCode: 191,
+    target: input1,
+    preventDefault: () => { defaultPrevented = true; },
+  });
+});
+
+QUnit.test('input focus not changed when on last input', assert => {
+  const { date, input1, input2 } = makeDate();
+  let defaultPrevented = false;
+
+  input1.focus = () => {
+    throw new Error('I should not be called!');
+  };
+
+  date.handleKeyDown({
+    keyCode: 191,
+    target: input2,
+    preventDefault: () => { defaultPrevented = true; },
+  });
+
+  assert.ok(!defaultPrevented);
+});

--- a/frontend/source/js/tests/index.js
+++ b/frontend/source/js/tests/index.js
@@ -4,3 +4,4 @@ require('./ajaxform_tests');
 require('./upload_tests');
 require('./expandable-area_tests');
 require('./alerts_tests');
+require('./date_tests');

--- a/frontend/source/sass/components/_date.scss
+++ b/frontend/source/sass/components/_date.scss
@@ -1,0 +1,3 @@
+uswds-date {
+  display: block;
+}

--- a/frontend/source/sass/main.scss
+++ b/frontend/source/sass/main.scss
@@ -19,3 +19,4 @@
 @import 'components/page';
 @import 'components/safemode';
 @import 'components/expandablearea';
+@import 'components/date';

--- a/frontend/templates/frontend/date.html
+++ b/frontend/templates/frontend/date.html
@@ -1,6 +1,6 @@
 <span class="form-hint" id="{{ hint_id }}">For example: 04 28 1986</span>
 
-<div class="date-mm-dd-yy">
+<uswds-date class="date-mm-dd-yy">
   <div class="form-group form-group-month">
     <label for="{{ month.id }}">Month</label>
 
@@ -14,4 +14,4 @@
     <label for="{{ year.id }}">Year</label>
     <input class="input-inline" aria-describedby="{{ hint_id }}" id="{{ year.id }}" name="{{ year.name }}" pattern="[0-9]{4}" type="number" min="1900" max="9999" value="{{ year.value }}">
   </div>
-</div>
+</uswds-date>

--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -79,3 +79,24 @@ code > a {
 code > a:hover {
   text-decoration: underline;
 }
+
+/* http://www.jimmyscode.com/css-styling-for-kbd-tags/ */
+kbd {
+  padding:0.1em 0.6em;
+  border:1px solid #ccc;
+  font-size:11px;
+  font-family:Arial,Helvetica,sans-serif;
+  background-color:#f7f7f7;
+  color:#333;
+  -moz-box-shadow:0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+  -webkit-box-shadow:0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+  box-shadow:0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+  -moz-border-radius:3px;
+  -webkit-border-radius:3px;
+  border-radius:3px;
+  display:inline-block;
+  margin:0 0.1em;
+  text-shadow:0 1px 0 #fff;
+  line-height:1.4;
+  white-space:nowrap;
+}

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -488,7 +488,8 @@
   <p>
     We use a {% webcomponent '<uswds-date>' %} to provide some optional
     dynamic functionality, such as automatically advancing focus to the
-    next input field in the date whenever <code>/</code> is pressed.
+    next input field in the date whenever <kbd>/</kbd>,
+    <kbd>.</kbd>, or <kbd>-</kbd> is pressed.
   </p>
   <p>
     For a simple code example, see

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -484,6 +484,12 @@
     {% pyobjname 'frontend.date.SplitDateField' %} is a custom Django form
     field and widget that offers three separate text fields for users to enter
     dates, as per the <a href="https://standards.usa.gov/form-controls/#date-input">USWDS section on date input</a>.
+  </p>
+  <p>
+    We use a {% webcomponent '<uswds-date>' %} to provide some optional
+    dynamic functionality, such as automatically advancing focus to the
+    next input field in the date whenever <code>/</code> is pressed.
+  </p>
   <p>
     For a simple code example, see
     {% pathname 'styleguide/date_example.py' %} and


### PR DESCRIPTION
During user testing today someone tried typing `4/28/1986` into a date widget, but was confused when it didn't work.  This PR adds a `<uswds-date>` custom element which detects if the user presses `/`, `-`, or `.` and, if so, advances to the next field if applicable.

To do:

- [x] Add tests.
- [x] Add documentation.
