### PR TITLE
Fix ajaxform interop w/ back-forward cache

### DIFF
--- a/frontend/source/js/data-capture/ajaxform.js
+++ b/frontend/source/js/data-capture/ajaxform.js
@@ -17,7 +17,17 @@ class Delegate {
   }
 
   redirect(url) {
-    // http://stackoverflow.com/a/13123626
+    // Some browsers will actually cache the state of our page, including
+    // its DOM and JS, when the user navigates away from it, so that if/when
+    // the user navigates back, the cached version is shown.
+    //
+    // In the case of ajaxform, this ultimately means that the user could
+    // be shown the page in a state that we never expected it to be in, so
+    // we'll use the 'pageshow' event, which is triggered in such situations,
+    // to reload the page if this ever happens.
+    //
+    // For more details, see: http://stackoverflow.com/a/13123626
+
     this.window.onpageshow = e => {
       if (e.persisted) {
         this.window.location.reload();

--- a/frontend/source/js/data-capture/ajaxform.js
+++ b/frontend/source/js/data-capture/ajaxform.js
@@ -11,16 +11,28 @@ const $ = jQuery;
 const MISC_ERROR = 'Sorry, we’re having trouble. ' +
                    'Please try again later or refresh your browser.';
 
-// This abstracts various actions for test suites to hook into.
-let delegate = {
+class Delegate {
+  constructor(window) {
+    this.window = window;
+  }
+
   redirect(url) {
-    window.location = url;
-  },
+    // http://stackoverflow.com/a/13123626
+    this.window.onpageshow = e => {
+      if (e.persisted) {
+        this.window.location.reload();
+      }
+    };
+    this.window.location = url;
+  }
+
   alert(msg) {
     // TODO: Be more user-friendly here.
-    window.alert(msg);   // eslint-disable-line no-alert
-  },
-};
+    this.window.alert(msg);
+  }
+}
+
+let delegate = new Delegate(window);
 
 exports.setDelegate = newDelegate => {
   delegate = newDelegate;
@@ -146,3 +158,4 @@ document.registerElement('ajax-form', {
 });
 
 exports.AjaxForm = AjaxForm;
+exports.Delegate = Delegate;

--- a/frontend/source/js/tests/ajaxform_tests.js
+++ b/frontend/source/js/tests/ajaxform_tests.js
@@ -133,6 +133,27 @@ formTest('degraded form does not cancel form submission', {
   $(s.ajaxform).submit();
 });
 
+test('Delegate.redirect() works', assert => {
+  const fakeWindow = {};
+  const delegate = new ajaxform.Delegate(fakeWindow);
+  let reloadCalled = false;
+
+  delegate.redirect('http://boop');
+  assert.equal(fakeWindow.location, 'http://boop');
+  fakeWindow.location = { reload: () => { reloadCalled = true; } };
+  fakeWindow.onpageshow({ persisted: true });
+  assert.ok(reloadCalled);
+});
+
+test('Delegate.alert() works', assert => {
+  const messages = [];
+  const fakeWindow = { alert(msg) { messages.push(msg); } };
+  const delegate = new ajaxform.Delegate(fakeWindow);
+
+  delegate.alert('boop');
+  assert.deepEqual(messages, ['boop']);
+});
+
 test('populateFormData() works w/ non-upgraded file inputs', assert => {
   const formData = ajaxform.AjaxForm.prototype.populateFormData.call({
     elements: [{


### PR DESCRIPTION
This fixes ajaxform's interoperability with the browser's [back-forward cache](https://developer.mozilla.org/en-US/Firefox/Releases/1.5/Using_Firefox_1.5_caching), whereby on some browsers a page containing an ajaxform is shown in its post-redirect state when the user clicks their browser's "back" button.

Solution gleaned from [stack overflow](http://stackoverflow.com/a/13123626).

To reproduce the bug this is fixing, do the following on Safari (probably in IE as well, according to yesterday's user research session):

1. Visit any ajaxform, e.g. `/styleguide/ajaxform`.
2. Fill the form out properly and click submit.
3. Click the back button.

You should see the ajaxform in its "loading" (i.e. faded out) state.