### PR TITLE
Show highlight animation when section of styleguide is navigated to

### DIFF
--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -108,7 +108,7 @@ kbd {
 
 @keyframes highlight-fade {
   from {
-    background-color: yellow;
+    background-color: #fff0be;
   }
 
   to {

--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -100,3 +100,18 @@ kbd {
   line-height:1.4;
   white-space:nowrap;
 }
+
+:target {
+  animation-duration: 2s;
+  animation-name: highlight-fade;
+}
+
+@keyframes highlight-fade {
+  from {
+    background-color: yellow;
+  }
+
+  to {
+    background-color: inherit;
+  }
+}


### PR DESCRIPTION
This uses the [`:target`](https://developer.mozilla.org/en-US/docs/Web/CSS/:target) CSS pseudo-selector to show the user where the section they just navigated to is.

![target-highlight](https://cloud.githubusercontent.com/assets/124687/18772043/551f7742-8109-11e6-9e08-1bb1dac8b616.gif)
