### PR TITLE
surround Add Price Data link with perm check

### DIFF
--- a/data_explorer/templates/base.html
+++ b/data_explorer/templates/base.html
@@ -52,7 +52,9 @@
                     {% if user.is_staff %}
                     <li><a href="{% url 'admin:index' %}">Site admin</a></li>
                     {% endif %}
+                    {% if perms.data_capture.add_submittedpricelist %}
                     <li><a href="{% url 'data_capture:step_1' %}">Add price data</a></li>
+                    {% endif %}
                     <li><a href="{% url 'about' %}">About this tool</a></li>
                   </ul>
                 </li>


### PR DESCRIPTION
Closes #788

As @hbillings pointed out in #788, we don't really have a use case for users without the `add_submittedpricelist` permission. However, this check is slightly helpful to us because it is an easy visual queue during dev and test/staging deployments to show whether we've initialized the test user accounts with proper permissions.