### PR TITLE
Fade-in current step

### DIFF
--- a/frontend/source/sass/components/_steps.scss
+++ b/frontend/source/sass/components/_steps.scss
@@ -1,4 +1,23 @@
 @import '../base/variables';
+
+@keyframes step-fade-in {
+  from {
+    background-color: $color-white;
+    color: $color-primary;
+  }
+
+  to {
+    background-color: $color-primary;
+    color: $color-white;
+  }
+}
+
+ol.steps li + li.current::before {
+  animation-duration: 2s;
+  animation-delay: 0.25s;
+  animation-name: step-fade-in;
+}
+
 ol.steps {
   counter-reset: li;
   font-weight: 300;

--- a/frontend/source/sass/components/_steps.scss
+++ b/frontend/source/sass/components/_steps.scss
@@ -1,21 +1,21 @@
 @import '../base/variables';
 
 @keyframes step-fade-in {
-  from {
-    background-color: $color-white;
-    color: $color-primary;
-  }
-
   to {
     background-color: $color-primary;
     color: $color-white;
   }
 }
 
-ol.steps li + li.current::before {
-  animation-duration: 2s;
-  animation-delay: 0.25s;
-  animation-name: step-fade-in;
+@supports ((animation-name: test) and (animation-fill-mode: forwards)) {
+  ol.steps li + li.current::before {
+    animation-duration: 2s;
+    animation-delay: 0.25s;
+    animation-name: step-fade-in;
+    animation-fill-mode: forwards;
+    background-color: $color-white;
+    color: $color-primary;
+  }
 }
 
 ol.steps {


### PR DESCRIPTION
This salvages the step fade-in from #793 as a CSS animation.

![target-highlight](https://cloud.githubusercontent.com/assets/124687/18791314/d5354a56-8177-11e6-8996-8dcd6dae5138.gif)

If the user's browser doesn't support CSS animations, this PR has no effect (in other words, the current step will still appear "filled-in" from the start, rather than appearing "empty" and never being "filled").