### PR TITLE
make <expandable-area> work in print, add CSS transition.

### DIFF
--- a/frontend/source/sass/components/_expandablearea.scss
+++ b/frontend/source/sass/components/_expandablearea.scss
@@ -1,23 +1,44 @@
 @import '../base/variables';
 
-expandable-area > *[role="button"][aria-expanded="false"]:before {
-  content: '\25B6';
-  padding-right: 4px;
-  display: inline-block;
+@keyframes expandable-area-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
-expandable-area > *[role="button"][aria-expanded="true"]:before {
-  content: '\25BC';
-  padding-right: 4px;
-  display: inline-block;
-}
+@media screen {
+  expandable-area > *[role="button"] {
+    cursor: pointer;
+    color: $color-primary;
+    text-decoration: underline;
 
-expandable-area > *[role="button"] {
-  cursor: pointer;
-  color: $color-primary;
-  text-decoration: underline;
-}
+    &[aria-expanded="false"] {
+      &:before {
+        content: '\25B6';
+        padding-right: 4px;
+        display: inline-block;
+      }
 
-expandable-area > *[role="button"][aria-expanded="false"] ~ * {
-  display: none;
+      ~ * {
+        display: none;
+      }
+    }
+
+    &[aria-expanded="true"] {
+      &:before {
+        content: '\25BC';
+        padding-right: 4px;
+        display: inline-block;
+      }
+
+      ~ * {
+        animation-duration: 1s;
+        animation-name: expandable-area-fade-in;
+      }
+    }
+  }
 }


### PR DESCRIPTION
This fixes #797 and adds a dinky "fade in" CSS transition when expanding so that users can distinguish what's just been added from the rest of the document.  (Ideally this would be a slide but I dunno how to do that without some fancy JS, and we've got bigger fish to fry anyhow.)

![expandable-area](https://cloud.githubusercontent.com/assets/124687/18838974/5dc08000-83d7-11e6-8a11-a493b4781720.gif)

Browsers without support for CSS animations will just see the content appear instantly (i.e., the current behavior).

This PR also refactors the SASS to use nesting.