### PR TITLE
Enforce uniqueness of user email, simplify user add form.

### DIFF
--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -49,6 +49,13 @@ class CustomUserCreationForm(forms.ModelForm, UniqueEmailFormMixin):
         fields = ('email',)
 
     def generate_username(self, email, max_attempts=100):
+        '''
+        Generate a unique username based on the given email address
+        by slugifying the first several characters of the username
+        part of the email. If needed, a number is added at the end
+        to avoid conflicts with existing usernames.
+        '''
+
         basename = slugify(email.split('@')[0])[:15]
         for i in range(max_attempts):
             if i == 0:

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -48,7 +48,7 @@ class CustomUserCreationForm(forms.ModelForm, UniqueEmailFormMixin):
         model = User
         fields = ('email',)
 
-    def find_username(self, email, max_attempts=100):
+    def generate_username(self, email, max_attempts=100):
         basename = slugify(email.split('@')[0])[:15]
         for i in range(max_attempts):
             if i == 0:
@@ -58,7 +58,7 @@ class CustomUserCreationForm(forms.ModelForm, UniqueEmailFormMixin):
             if not User.objects.filter(username=username).exists():
                 return username
         raise Exception(
-            'unable to find username for {} after {} attempts'.format(
+            'unable to generate username for {} after {} attempts'.format(
                 email,
                 max_attempts
             )
@@ -68,7 +68,7 @@ class CustomUserCreationForm(forms.ModelForm, UniqueEmailFormMixin):
         email = self.cleaned_data.get('email')
 
         if email:
-            self.cleaned_data['username'] = self.find_username(email)
+            self.cleaned_data['username'] = self.generate_username(email)
 
         return self.cleaned_data
 

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -49,9 +49,12 @@ class CustomUserCreationForm(forms.ModelForm, UniqueEmailFormMixin):
         fields = ('email',)
 
     def find_username(self, email, max_attempts=100):
-        basename = slugify(email)[:15]
+        basename = slugify(email.split('@')[0])[:15]
         for i in range(max_attempts):
-            username = '{}_{}'.format(basename, i)
+            if i == 0:
+                username = basename
+            else:
+                username = '{}{}'.format(basename, i)
             if not User.objects.filter(username=username).exists():
                 return username
         raise Exception(

--- a/data_capture/templates/admin/data_capture/add_user_form.html
+++ b/data_capture/templates/admin/data_capture/add_user_form.html
@@ -1,0 +1,12 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{# This file is based on https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/auth/user/add_form.html. #}
+
+{% block form_top %}
+  {% if not is_popup %}
+    <p>First, enter an email address. Then, you'll be able to edit more user options.</p>
+  {% else %}
+    <p>Enter an email address.</p>
+  {% endif %}
+{% endblock %}

--- a/data_capture/tests/test_admin.py
+++ b/data_capture/tests/test_admin.py
@@ -3,7 +3,8 @@ import unittest.mock as mock
 from django.conf import settings
 from django.core.management import call_command
 from django.contrib import messages
-from django.test import override_settings
+from django.contrib.auth.models import User
+from django.test import override_settings, TestCase
 
 from .. import admin, models, email
 from .common import FAKE_SCHEDULE
@@ -48,6 +49,44 @@ class DebugAdminTestCase(AdminTestCase):
     pass
 
 
+class CustomUserCreationFormTests(TestCase):
+    def test_checks_uniqueness_of_email(self):
+        User.objects.create_user(username='blerg', email='foo@gsa.gov')
+        form = admin.CustomUserCreationForm({'email': 'foo@gsa.gov'})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {
+            'email': ['That email address is already in use.']
+        })
+
+    def test_find_username_works(self):
+        form = admin.CustomUserCreationForm()
+        self.assertEqual(form.find_username('boop.jones@gsa.gov'),
+                         'boopjones')
+
+    def test_find_username_appends_number_when_needed(self):
+        User.objects.create_user(username='boopjones')
+        form = admin.CustomUserCreationForm()
+        self.assertEqual(form.find_username('boop.jones@gsa.gov'),
+                         'boopjones1')
+
+    def test_find_username_raises_exception_when_attempts_maxed_out(self):
+        User.objects.create_user(username='boopjones')
+        User.objects.create_user(username='boopjones1')
+        form = admin.CustomUserCreationForm()
+        with self.assertRaisesRegexp(
+            Exception,
+            'unable to find username for boop.jones@gsa.gov after 2 attempts'
+        ):
+            form.find_username('boop.jones@gsa.gov', max_attempts=2)
+
+    def test_save_sets_username(self):
+        form = admin.CustomUserCreationForm({'email': 'foo@gsa.gov'})
+        self.assertTrue(form.is_valid())
+        user = form.save()
+        self.assertEqual(user.username, 'foo')
+        self.assertEqual(user.email, 'foo@gsa.gov')
+
+
 class SuperuserViewTests(DebugAdminTestCase):
     def setup_user(self):
         self.user = self.login(is_superuser=True)
@@ -65,6 +104,11 @@ class SuperuserViewTests(DebugAdminTestCase):
 
 
 class NonSuperuserViewTests(DebugAdminTestCase):
+    def test_user_add_returns_200(self):
+        res = self.client.get('/admin/auth/user/add/')
+        self.assertContains(res, 'First, enter an email address',
+                            status_code=200)
+
     def test_cannot_set_superuser(self):
         res = self.client.get('/admin/auth/user/{}/'.format(self.user.id))
         self.assertNotContains(res, 'Superuser')

--- a/data_capture/tests/test_admin.py
+++ b/data_capture/tests/test_admin.py
@@ -58,26 +58,27 @@ class CustomUserCreationFormTests(TestCase):
             'email': ['That email address is already in use.']
         })
 
-    def test_find_username_works(self):
+    def test_generate_username_works(self):
         form = admin.CustomUserCreationForm()
-        self.assertEqual(form.find_username('boop.jones@gsa.gov'),
+        self.assertEqual(form.generate_username('boop.jones@gsa.gov'),
                          'boopjones')
 
-    def test_find_username_appends_number_when_needed(self):
+    def test_generate_username_appends_number_when_needed(self):
         User.objects.create_user(username='boopjones')
         form = admin.CustomUserCreationForm()
-        self.assertEqual(form.find_username('boop.jones@gsa.gov'),
+        self.assertEqual(form.generate_username('boop.jones@gsa.gov'),
                          'boopjones1')
 
-    def test_find_username_raises_exception_when_attempts_maxed_out(self):
+    def test_generate_username_raises_exception_when_attempts_maxed_out(self):
         User.objects.create_user(username='boopjones')
         User.objects.create_user(username='boopjones1')
         form = admin.CustomUserCreationForm()
         with self.assertRaisesRegexp(
             Exception,
-            'unable to find username for boop.jones@gsa.gov after 2 attempts'
+            'unable to generate username for '
+            'boop.jones@gsa.gov after 2 attempts'
         ):
-            form.find_username('boop.jones@gsa.gov', max_attempts=2)
+            form.generate_username('boop.jones@gsa.gov', max_attempts=2)
 
     def test_save_sets_username(self):
         form = admin.CustomUserCreationForm({'email': 'foo@gsa.gov'})


### PR DESCRIPTION
This simplifies the "add user" form:

> ![add-user](https://cloud.githubusercontent.com/assets/124687/18854420/512fe91a-8419-11e6-86f4-2a23c2399d97.png)

When submitted, the uniqueness of the email is checked; if a user already exists with the email, an error message with the text "That email address is already in use." is displayed.

If the email is unique, then a username is automatically generated by [slugifying](https://docs.djangoproject.com/en/1.10/ref/utils/#django.utils.text.slugify) the first several characters of the username part of the email address, and adding a number at the end if needed for uniqueness.  This should be OK since users never see their usernames, and admins will only ever see the usernames in the admin UI.

The "change user" form has also been modified to ensure that the email is unique.

This fixes #752. Well, login *will* still explode if two users with the same email address exist, but these changes to the admin UI make it extremely unlikely for that to happen (the users w/ the same email address will need to have been created/modified via a `manage.py` command, basically).

## To do

- [x] Verify w/ Kelly that this behavior is decent.
- [x] Add tests.
