### PR TITLE
Fix selenium tests and radios in data explorer

### DIFF
--- a/data_explorer/templates/index.html
+++ b/data_explorer/templates/index.html
@@ -59,9 +59,14 @@
           <input id="labor_category" name="q" placeholder="Type a labor category" class="search u-full-width" type="text">
           <label for="labor_category" style="display:none;">Type a labor category</label>
           <div id="query-types">
-            <label><input type="radio" name="query_type" value="match_all" checked> Contains words</label>
-            <label><input type="radio" name="query_type" value="match_phrase"> Contains phrase</label>
-            <label><input type="radio" name="query_type" value="match_exact"> Exact match</label>
+            <input id="query_type_match_all" type="radio" name="query_type" value="match_all" checked>
+            <label for="query_type_match_all">Contains words</label>
+
+            <input id="query_type_match_phrase" type="radio" name="query_type" value="match_phrase">
+            <label for="query_type_match_phrase">Contains phrase</label>
+
+            <input id="query_type_match_exact" type="radio" name="query_type" value="match_exact">
+            <label for="query_type_match_exact">Exact match</label>
           </div>
         </div>
         <div class="six columns">

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -653,6 +653,11 @@ class FunctionalTests(LiveServerTestCase):
         self.assertEqual(results_count, str(
             num), "Results count mismatch: '%s' != %d" % (results_count, num))
 
+    def get_label_for_input(self, input, form):
+        return form.find_element_by_css_selector('label[for="{}"]'.format(
+            input.get_attribute('id')
+        ))
+
     def set_form_value(self, form, key, value):
         fields = form.find_elements_by_name(key)
         field = fields[0]
@@ -663,7 +668,7 @@ class FunctionalTests(LiveServerTestCase):
             if field_type in ('checkbox', 'radio'):
                 for _field in fields:
                     if _field.get_attribute('value') == value:
-                        _field.click()
+                        self.get_label_for_input(_field, form).click()
             else:
                 field.send_keys(str(value))
         return field


### PR DESCRIPTION
This fixes #813. It also makes our radios under the search field in the data explorer visible again:

> ![radios](https://cloud.githubusercontent.com/assets/124687/18893152/a5fc657e-84da-11e6-87bb-9d4189ce5e64.png)
