### PR TITLE
Use <legend> where appropriate

### DIFF
--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -9,6 +9,7 @@ from frontend.radio import UswdsRadioSelect
 
 class Step1Form(forms.ModelForm):
     schedule = forms.ChoiceField(
+        label="Which schedule is associated with this price list?",
         choices=registry.get_choices
     )
 

--- a/data_capture/templates/data_capture/price_list/step_1.html
+++ b/data_capture/templates/data_capture/price_list/step_1.html
@@ -1,4 +1,5 @@
 {% extends 'data_capture/step.html' %}
+{% load frontend %}
 
 {% block subtitle %}Upload price list{% endblock %}
 
@@ -11,24 +12,9 @@
   {% csrf_token %}
   {{ form.non_field_errors }}
 
-  <fieldset{% if form.schedule.errors %} class="fieldset-error"{% endif %}>
-    {{ form.schedule.errors }}
-    <label for="{{ form.schedule.id_for_label }}">Which schedule is associated with this price list?</label>
-    {{ form.schedule }}
-  </fieldset>
-
-  <fieldset{% if form.contract_number.errors %} class="fieldset-error"{% endif %}>
-    {{ form.contract_number.errors }}
-    {{ form.contract_number.label_tag }}
-    {{ form.contract_number }}
-    <p class="helptext">{{ form.contract_number.help_text }}</p>
-  </fieldset>
-
-  <fieldset{% if form.vendor_name.errors %} class="fieldset-error"{% endif %}>
-    {{ form.vendor_name.errors }}
-    {{ form.vendor_name.label_tag }}
-    {{ form.vendor_name }}
-  </fieldset>
+  {% fieldset form.schedule %}
+  {% fieldset form.contract_number %}
+  {% fieldset form.vendor_name %}
 
   <div class="form-button-row clearfix">
     <div class="submit-group">

--- a/data_capture/templates/data_capture/price_list/step_2.html
+++ b/data_capture/templates/data_capture/price_list/step_2.html
@@ -1,4 +1,5 @@
 {% extends 'data_capture/step.html' %}
+{% load frontend %}
 
 {% block subtitle %}Enter contract details{% endblock %}
 
@@ -9,29 +10,14 @@
   {% csrf_token %}
 
   {{ form.non_field_errors }}
-  <fieldset{% if form.is_small_business.errors %} class="fieldset-error"{% endif %}>
-    {{ form.is_small_business.errors }}
-    {{ form.is_small_business.label_tag }}
-    {{ form.is_small_business }}
-  </fieldset>
-  <fieldset{% if form.contractor_site.errors %} class="fieldset-error"{% endif %}>
-    {{ form.contractor_site.errors }}
-    {{ form.contractor_site.label_tag }}
-    {{ form.contractor_site }}
-  </fieldset>
+
+  {% fieldset form.is_small_business %}
+  {% fieldset form.contractor_site %}
 
   <div class="date-range {% if form.contract_start.errors or form.contract_end.errors%}fieldset-error{% endif %}">
-    <fieldset {% if form.contract_start.errors %}class="fieldset-error"{% endif %}>
-      {{ form.contract_start.errors }}
-      {{ form.contract_start.label_tag }}
-      {{ form.contract_start }}
-    </fieldset>
+    {% fieldset form.contract_start %}
     <p>to</p>
-    <fieldset {% if form.contract_end.errors %}class="fieldset-error"{% endif %}>
-      {{ form.contract_end.errors }}
-      {{ form.contract_end.label_tag }}
-      {{ form.contract_end }}
-    </fieldset>
+    {% fieldset form.contract_end %}
   </div>
 
   <div class="form-button-row clearfix">

--- a/data_capture/templates/data_capture/price_list/step_2.html
+++ b/data_capture/templates/data_capture/price_list/step_2.html
@@ -20,14 +20,14 @@
     {{ form.contractor_site }}
   </fieldset>
 
-  <div class="date-range{% if form.contract_start.errors or form.contract_end.errors %} fieldset-error{% endif %}">
-    <fieldset>
+  <div class="date-range {% if form.contract_start.errors or form.contract_end.errors%}fieldset-error{% endif %}">
+    <fieldset {% if form.contract_start.errors %}class="fieldset-error"{% endif %}>
       {{ form.contract_start.errors }}
       {{ form.contract_start.label_tag }}
       {{ form.contract_start }}
     </fieldset>
     <p>to</p>
-    <fieldset>
+    <fieldset {% if form.contract_end.errors %}class="fieldset-error"{% endif %}>
       {{ form.contract_end.errors }}
       {{ form.contract_end.label_tag }}
       {{ form.contract_end }}

--- a/frontend/source/sass/components/_forms.scss
+++ b/frontend/source/sass/components/_forms.scss
@@ -39,17 +39,16 @@ form ul {
   list-style-type: none;
 }
 
-fieldset,
-.fieldset-error {
+fieldset {
   max-width: 53rem;
 }
 
 /* Django's default form rendering uses a <ul class="errorlist">
    for errors, and <span class="helptext"> for help text. */
-.fieldset-error {
+fieldset.fieldset-error {
   border-left: 3px solid $color-secondary-dark;
   background-color: #fef5f5;
-  margin: 3rem 0 3rem -10px;
+  margin: 3rem 0 0 -10px;
   padding: 10px;
   ul {
     margin-bottom: 0;
@@ -64,6 +63,10 @@ fieldset,
   textarea {
     border: 3px solid $color-secondary-dark;
   }
+}
+
+form > .fieldset-error {
+  margin-bottom: 3rem;
 }
 
 .errorlist {

--- a/frontend/templates/frontend/fieldset.html
+++ b/frontend/templates/frontend/fieldset.html
@@ -1,6 +1,11 @@
 <fieldset{% if field.errors %} class="fieldset-error"{% endif %}>
   {{ field.errors }}
-  {{ field.label_tag }}
+  {% if use_legend %}
+    {# We're wrapping the <legend> in a <span> for styling: http://stackoverflow.com/a/3973527 #}
+    <span><legend>{{ field.label }}</legend></span>
+  {% else %}
+    {{ field.label_tag }}
+  {% endif %}
   {{ field }}
   {% if field.help_text %}
     <p class="helptext">{{ field.help_text }}</p>

--- a/frontend/templates/frontend/fieldset.html
+++ b/frontend/templates/frontend/fieldset.html
@@ -1,0 +1,8 @@
+<fieldset{% if field.errors %} class="fieldset-error"{% endif %}>
+  {{ field.errors }}
+  {{ field.label_tag }}
+  {{ field }}
+  {% if field.help_text %}
+    <p class="helptext">{{ field.help_text }}</p>
+  {% endif %}
+</fieldset>

--- a/frontend/templatetags/frontend.py
+++ b/frontend/templatetags/frontend.py
@@ -1,7 +1,17 @@
-from django import template
+from django import template, forms
+from .. import date
 
 
 register = template.Library()
+
+
+# These are widget classes that consist of multiple sub-widgets. We'd
+# like to use a <legend> element with these, instead of a <label>, so
+# that screen-readers contextualize them properly.
+LEGEND_WIDGETS = (
+    date.SplitDateWidget,
+    forms.RadioSelect
+)
 
 
 @register.simple_tag(takes_context=True)
@@ -15,4 +25,5 @@ def fieldset(context, field):
 
     return t.render(template.Context({
         'field': field,
+        'use_legend': isinstance(field.field.widget, LEGEND_WIDGETS)
     }))

--- a/frontend/templatetags/frontend.py
+++ b/frontend/templatetags/frontend.py
@@ -1,0 +1,18 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def fieldset(context, field):
+    '''
+    This template tag makes it easy to render form fields as
+    <fieldset> elements.
+    '''
+
+    t = context.template.engine.get_template('frontend/fieldset.html')
+
+    return t.render(template.Context({
+        'field': field,
+    }))


### PR DESCRIPTION
~~**Note: This is a PR against #817, not `develop`.**~~

This attempts to use `<legend>` for date widgets and radio button selects for reasons explained in https://github.com/18F/calc/pull/817#issuecomment-250201585.

The styling remains the same as before, though I had to wrap the `<legend>` in a `<span>` to get there because [bleh](http://stackoverflow.com/a/3973527).