### PR TITLE
Adjust margin-left of styleguide section headers

### DIFF
--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -14,7 +14,7 @@ h3.styleguide-section {
 .styleguide-section a {
   color: lightgray;
   text-decoration: none;
-  margin-left: -29px;
+  margin-left: -0.8em;
   padding-right: 2px;
   display: inline-block;
   opacity: 0;


### PR DESCRIPTION
This just re-aligns the styleguide section headers. We're now defining them in terms of `em` so hopefully we don't need to adjust them as styles change anymore.
