### PR TITLE
Make <legend>s work on NVDA

### DIFF
--- a/frontend/templates/frontend/fieldset.html
+++ b/frontend/templates/frontend/fieldset.html
@@ -1,8 +1,9 @@
 <fieldset{% if field.errors %} class="fieldset-error"{% endif %}>
   {{ field.errors }}
   {% if use_legend %}
-    {# We're wrapping the <legend> in a <span> for styling: http://stackoverflow.com/a/3973527 #}
-    <span><legend>{{ field.label }}</legend></span>
+    {# <legend>s are difficult/impossible to style but are great for screen readers, so we'll make them invisible to sighted users. #}
+    <legend class="sr-only">{{ field.label }}</legend>
+    <label aria-hidden="true">{{ field.label }}</label>
   {% else %}
     {{ field.label_tag }}
   {% endif %}


### PR DESCRIPTION
Arg, NVDA (and possibly other screen readers) *do* work with `<legend>` elements, but only if they're direct descendants of `<fieldset>`s, i.e. not wrapped in `<span>`s so we can style them.  So this adds a `<legend class="sr-only">` for the screenreaders and an `<label aria-hidden="true">` for the sighted folks.

😞 