### PR TITLE
Use defusedxml and ensure xlrd is using it

### DIFF
--- a/data_capture/__init__.py
+++ b/data_capture/__init__.py
@@ -1,0 +1,3 @@
+import defusedxml
+
+defusedxml.defuse_stdlib()

--- a/data_capture/tests/test_xlsx_security.py
+++ b/data_capture/tests/test_xlsx_security.py
@@ -1,0 +1,33 @@
+import io
+import xlrd.xlsx
+from django.test import TestCase
+from defusedxml.common import EntitiesForbidden
+
+
+# https://en.wikipedia.org/wiki/Billion_laughs
+BILLION_LAUGHS_XML = """\
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+ <!ENTITY lol "lol">
+ <!ELEMENT lolz (#PCDATA)>
+ <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+ <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+ <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+ <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+ <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+ <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+ <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<lolz>&lol9;</lolz>"""
+
+
+class XlsxSecurityTests(TestCase):
+    def test_billion_laughs_fails(self):
+        if xlrd.xlsx.ET is None:
+            xlrd.xlsx.ensure_elementtree_imported(verbosity=False,
+                                                  logfile=None)
+
+        with self.assertRaises(EntitiesForbidden):
+            xlrd.xlsx.ET.parse(io.StringIO(BILLION_LAUGHS_XML))

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ requests==2.11.0
 python-dotenv==0.5.1
 httmock==1.2.5
 xlrd==1.0.0
+defusedxml==0.4.1
 django-debug-toolbar==1.5
 rq==0.6.0
 django-rq==0.9.2


### PR DESCRIPTION
This is an alternate approach to fixing #749. It just calls `defusedxml.defuse_stdlib()` whenever `data_capture` is imported, and adds a test to verify that `xlrd` is using it, and that we aren't vulnerable to the [Billion Laughs](https://en.wikipedia.org/wiki/Billion_laughs) exploit.

This means that `xlrd.open_workbook()` can now throw a `defusedxml.common.EntitiesForbidden` exception, but that should be fine since our schedule 70 gleaner catches *any* exceptions thrown from `xlrd.open_workbook()`.

To do:

- [x] Actually call `open_workbook()` with a billion-laughs XLSX file and ensure it throws an `EntitiesForbidden` error.
