### PR TITLE
Improve selenium testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - 3.4
 addons:
   postgresql: 9.3
+  sauce_connect: true
 matrix:
   fast_finish: true
 services:
@@ -31,6 +32,14 @@ env:
   - PHANTOMJS_TIMEOUT=15
   - DEBUG=yup
   - DATABASE_URL=postgres://postgres@localhost/hourglass
+  - DJANGO_LIVE_TEST_SERVER_ADDRESS=127.0.0.1:8000
+  - WD_TESTING_URL=http://127.0.0.1:8000
+  - WD_TESTING_BROWSER=internet explorer
+  - WD_TESTING_BROWSER_VERSION=11.103
+  - WD_JOB_VISIBILITY=public
+  - WD_SOCKET_TIMEOUT=60
+  - SAUCE_USERNAME=atulvarma
+  - secure: "RbgG35nc1SHgjdxVbGUDlumePeR/+dXq5fMbfTXOW8uFYw5kGh75px2KdFDkL1JIA1vbfxyNFm09x32uXMcHsBKu9fJS7xbpMrRDbJoV2wVy5wd6qtvZ7yFbR87Fqo3/tuGu13jNNDvUgKjpUlrzLZKaL7qvv5Gd7CVhkySUa1o="
 deploy:
   edge: true
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
 - pip install -r requirements-dev.txt
 - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
 - npm install
-- gulp build
 script:
 - phantomjs --version
 - python manage.py ultratest flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ env:
   - PHANTOMJS_TIMEOUT=15
   - DEBUG=yup
   - DATABASE_URL=postgres://postgres@localhost/hourglass
+
+  # These environment variables affect the running of Webdriver/Selenium
+  # tests. Note that if we're not in a trusted environment (e.g. a PR
+  # is being issued from an untrusted fork), we will default to using
+  # PhantomJS locally, rather than a real-world browser via Sauce Labs.
   - DJANGO_LIVE_TEST_SERVER_ADDRESS=127.0.0.1:8000
   - WD_TESTING_BROWSER="internet explorer"
   - WD_TESTING_BROWSER_VERSION=11.103

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
   - DATABASE_URL=postgres://postgres@localhost/hourglass
   - DJANGO_LIVE_TEST_SERVER_ADDRESS=127.0.0.1:8000
   - WD_TESTING_URL=http://127.0.0.1:8000
-  - WD_TESTING_BROWSER=internet explorer
+  - WD_TESTING_BROWSER="internet explorer"
   - WD_TESTING_BROWSER_VERSION=11.103
   - WD_JOB_VISIBILITY=public
   - WD_SOCKET_TIMEOUT=60

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ env:
   - DEBUG=yup
   - DATABASE_URL=postgres://postgres@localhost/hourglass
   - DJANGO_LIVE_TEST_SERVER_ADDRESS=127.0.0.1:8000
-  - WD_TESTING_URL=http://127.0.0.1:8000
   - WD_TESTING_BROWSER="internet explorer"
   - WD_TESTING_BROWSER_VERSION=11.103
   - WD_JOB_VISIBILITY=public

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ py.test
 For more information on running only specific tests, see
 [`py.test` Usage and Invocations][pytest].
 
+### Browser tests via Selenium
+
+By default, CALC's browser-based tests will run via PhantomJS. This
+is nice because it requires no configuration (aside from installing
+PhantomJS, if you're not using the Docker setup).
+
+However, it might also be preferable to run the browser-based tests in
+a real-world browser. This can be done via Selenium/WebDriver. The
+trade-off is that this requires configuration.
+
+For details on how to do this, see [`selenium.md`](selenium.md).
+
 ### Security Scans
 
 We use [bandit](https://github.com/openstack/bandit) for security-related static analysis.

--- a/frontend/tests/test_qunit.py
+++ b/frontend/tests/test_qunit.py
@@ -5,24 +5,53 @@ from django.test import LiveServerTestCase, override_settings
 
 from hourglass.urls import urlpatterns, tests_url
 from .utils import build_static_assets
-
-
-RUNNER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                           'vendor', 'runner.js')
+from .test_selenium import WD_TESTING_BROWSER, SeleniumTestCase
 
 
 urlpatterns += [tests_url]
 
 
-@override_settings(ROOT_URLCONF=__name__)
-class QunitTests(LiveServerTestCase):
+if WD_TESTING_BROWSER == 'phantomjs':
+    RUNNER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               'vendor', 'runner.js')
 
-    def test_qunit(self):
-        subprocess.check_call([
-            'phantomjs', RUNNER_PATH, self.live_server_url + '/tests/'
-        ])
+    @override_settings(ROOT_URLCONF=__name__)
+    class QunitTests(LiveServerTestCase):
+        '''
+        Run QUnit tests directly via phantomjs, bypassing Selenium to
+        simplify the test process and reduce the chance of something
+        weird exploding in our face.
+        '''
 
-    @classmethod
-    def setUpClass(cls):
-        build_static_assets()
-        super(QunitTests, cls).setUpClass()
+        def test_qunit(self):
+            subprocess.check_call([
+                'phantomjs', RUNNER_PATH, self.live_server_url + '/tests/'
+            ])
+
+        @classmethod
+        def setUpClass(cls):
+            build_static_assets()
+            super(QunitTests, cls).setUpClass()
+else:
+    @override_settings(ROOT_URLCONF=__name__)
+    class QunitTests(SeleniumTestCase):
+        '''
+        Run QUnit tests in a real-world browser via Selenium.
+        '''
+
+        def test_qunit(self):
+            self.load('/tests/')
+
+            FAILED = '#qunit-testresult .failed'
+
+            def are_results_loaded():
+                els = self.driver.find_elements_by_css_selector(FAILED)
+
+                return len(els) > 0
+
+            self.wait_for(are_results_loaded)
+
+            failed = self.driver.find_element_by_css_selector(FAILED).text
+
+            if failed != '0':
+                raise Exception("{} qunit test(s) failed".format(failed))

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -36,6 +36,7 @@ WD_HUB_URL = os.environ.get('WD_HUB_URL')
 WD_TESTING_URL = os.environ.get('WD_TESTING_URL')
 WD_TESTING_BROWSER = os.environ.get('WD_TESTING_BROWSER',
                                     'phantomjs')
+WD_SOCKET_TIMEOUT = int(os.environ.get('WD_SOCKET_TIMEOUT', '5'))
 
 PHANTOMJS_TIMEOUT = int(os.environ.get('PHANTOMJS_TIMEOUT', '3'))
 WEBDRIVER_TIMEOUT_LOAD_ATTEMPTS = 10
@@ -76,6 +77,8 @@ class SeleniumTestCase(LiveServerTestCase):
         desired_cap['browserName'] = WD_TESTING_BROWSER
         if 'WD_TESTING_BROWSER_VERSION' in os.environ:
             desired_cap['version'] = os.environ['WD_TESTING_BROWSER_VERSION']
+        if 'WD_JOB_VISIBILITY' in os.environ:
+            desired_cap['public'] = os.environ['WD_JOB_VISIBILITY']
         desired_cap['name'] = 'CALC'
         print('capabilities:', desired_cap)
 
@@ -90,7 +93,8 @@ class SeleniumTestCase(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        socket.setdefaulttimeout(5)
+        cls._old_socket_timeout = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(WD_SOCKET_TIMEOUT)
         build_static_assets()
         cls.driver = cls.get_driver()
         cls.longMessage = True
@@ -103,6 +107,7 @@ class SeleniumTestCase(LiveServerTestCase):
         cls.driver.quit()
         if cls.connect:
             cls.connect.shutdown_connect()
+        socket.setdefaulttimeout(cls._old_socket_timeout)
         super().tearDownClass()
 
     @classmethod

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -102,6 +102,7 @@ class FunctionalTests(LiveServerTestCase):
         cls.driver.quit()
         if cls.connect:
             cls.connect.shutdown_connect()
+        super().tearDownClass()
 
     @classmethod
     def take_screenshot(cls):

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -13,7 +13,7 @@ test_contract_link
 
 8/25/15 [TS]
 """
-from django.conf import settings
+
 from django.test import LiveServerTestCase
 
 from selenium import webdriver

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -50,8 +50,21 @@ if WD_TESTING_URL and WD_HUB_URL is None and \
     )
 
 
-if 'TRAVIS_JOB_NUMBER' in os.environ and WD_TUNNEL_ID is None:
-    WD_TUNNEL_ID = os.environ['TRAVIS_JOB_NUMBER']
+if os.environ.get('TRAVIS') == 'true':
+    if os.environ.get('TRAVIS_SECURE_ENV_VARS') == 'true':
+        # We're running in a trusted environment, so use Sauce Labs
+        # if it's available.
+        WD_TUNNEL_ID = os.environ['TRAVIS_JOB_NUMBER']
+        WD_TESTING_URL = 'http://{}'.format(
+            os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS']
+        )
+    else:
+        # We're running against an untrusted PR from another repository,
+        # so default to using PhantomJS locally.
+        WD_TESTING_BROWSER = 'phantomjs'
+        WD_TESTING_BROWSER_VERSION = None
+        WD_TESTING_URL = None
+        WD_HUB_URL = None
 
 
 def _get_webdriver(name):

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -511,11 +511,13 @@ class FunctionalTests(LiveServerTestCase):
         header2 = find_column_header(driver, 'labor_category')
 
         header1.click()
+        self.wait_for(lambda: has_class(header1, 'sorted'))
         self.assertTrue(has_class(header1, 'sorted'), "column 1 is not sorted")
         self.assertFalse(has_class(header2, 'sorted'),
                          "column 2 is still sorted (but should not be)")
 
         header2.click()
+        self.wait_for(lambda: has_class(header2, 'sorted'))
         self.assertTrue(has_class(header2, 'sorted'), "column 2 is not sorted")
         self.assertFalse(has_class(header1, 'sorted'),
                          "column 1 is still sorted (but should not be)")

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -14,7 +14,7 @@ test_contract_link
 8/25/15 [TS]
 """
 
-from django.test import LiveServerTestCase
+from django.test import LiveServerTestCase, override_settings
 
 from selenium import webdriver
 from selenium.webdriver.support.ui import Select
@@ -622,6 +622,24 @@ class FunctionalTests(LiveServerTestCase):
             len(cells), 1, 'wrong cell count: %d (expected 1)' % len(cells))
         self.assertEqual(cells[0].text, 'Software Engineer',
                          'bad cell text: "%s"' % cells[0].text)
+
+    @override_settings(ROOT_URLCONF='frontend.tests.test_qunit')
+    def test_qunit(self):
+        self.load('/tests/')
+
+        FAILED_SEL = '#qunit-testresult .failed'
+
+        def are_results_loaded():
+            els = self.driver.find_elements_by_css_selector(FAILED_SEL)
+
+            return len(els) > 0
+
+        self.wait_for(are_results_loaded)
+
+        failed = self.driver.find_element_by_css_selector(FAILED_SEL).text
+
+        if failed != '0':
+            raise Exception("{} qunit test(s) failed".format(failed))
 
     def _test_column_is_sortable(self, driver, colname):
         col_header = find_column_header(driver, colname)

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -90,6 +90,7 @@ class FunctionalTests(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
+        socket.setdefaulttimeout(5)
         build_static_assets()
         cls.driver = cls.get_driver()
         cls.longMessage = True

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -178,6 +178,15 @@ class FunctionalTests(LiveServerTestCase):
         # XXX oh my god why do we have to do this???
         self.driver.execute_script('$("[name=q]").blur()')
 
+    def search_for_query_type(self, query, query_type):
+        # Important: We want to click the radio before entering the
+        # text, otherwise the radio may be obscured by the autocomplete
+        # suggestions (that's the working theory, at least).
+
+        form = self.get_form()
+        self.set_form_values(form, query_type=query_type)
+        self.search_for(query)
+
     def data_is_loaded(self):
         form = self.get_form()
         if has_class(form, 'error'):
@@ -590,9 +599,7 @@ class FunctionalTests(LiveServerTestCase):
             ['Systems Engineer I', 'Software Engineer II', 'Consultant II']))
         driver = self.load()
         self.wait_for(self.data_is_loaded)
-        form = self.get_form()
-        self.search_for('software engineer')
-        self.set_form_values(form, query_type='match_phrase')
+        self.search_for_query_type('software engineer', 'match_phrase')
         self.submit_form_and_wait()
         cells = driver.find_elements_by_css_selector(
             'table.results tbody .column-labor_category')
@@ -607,9 +614,7 @@ class FunctionalTests(LiveServerTestCase):
              'Senior Software Engineer']))
         driver = self.load()
         self.wait_for(self.data_is_loaded)
-        form = self.get_form()
-        self.search_for('software engineer')
-        self.set_form_values(form, query_type='match_exact')
+        self.search_for_query_type('software engineer', 'match_exact')
         self.submit_form_and_wait()
         cells = driver.find_elements_by_css_selector(
             'table.results tbody .column-labor_category')

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -42,14 +42,6 @@ PHANTOMJS_TIMEOUT = int(os.environ.get('PHANTOMJS_TIMEOUT', '3'))
 WEBDRIVER_TIMEOUT_LOAD_ATTEMPTS = 10
 
 
-if WD_TESTING_URL and WD_HUB_URL is None and \
-   'SAUCE_USERNAME' in os.environ and 'SAUCE_ACCESS_KEY' in os.environ:
-    WD_HUB_URL = 'http://{}:{}@ondemand.saucelabs.com/wd/hub'.format(
-        os.environ['SAUCE_USERNAME'],
-        os.environ['SAUCE_ACCESS_KEY']
-    )
-
-
 if os.environ.get('TRAVIS') == 'true':
     if os.environ.get('TRAVIS_SECURE_ENV_VARS') == 'true':
         # We're running in a trusted environment, so use Sauce Labs
@@ -65,6 +57,14 @@ if os.environ.get('TRAVIS') == 'true':
         WD_TESTING_BROWSER_VERSION = None
         WD_TESTING_URL = None
         WD_HUB_URL = None
+
+
+if WD_TESTING_URL and WD_HUB_URL is None and \
+   'SAUCE_USERNAME' in os.environ and 'SAUCE_ACCESS_KEY' in os.environ:
+    WD_HUB_URL = 'http://{}:{}@ondemand.saucelabs.com/wd/hub'.format(
+        os.environ['SAUCE_USERNAME'],
+        os.environ['SAUCE_ACCESS_KEY']
+    )
 
 
 def _get_webdriver(name):

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -36,10 +36,22 @@ WD_HUB_URL = os.environ.get('WD_HUB_URL')
 WD_TESTING_URL = os.environ.get('WD_TESTING_URL')
 WD_TESTING_BROWSER = os.environ.get('WD_TESTING_BROWSER',
                                     'phantomjs')
+WD_TUNNEL_ID = os.environ.get('WD_TUNNEL_ID')
 WD_SOCKET_TIMEOUT = int(os.environ.get('WD_SOCKET_TIMEOUT', '5'))
-
 PHANTOMJS_TIMEOUT = int(os.environ.get('PHANTOMJS_TIMEOUT', '3'))
 WEBDRIVER_TIMEOUT_LOAD_ATTEMPTS = 10
+
+
+if WD_TESTING_URL and WD_HUB_URL is None and \
+   'SAUCE_USERNAME' in os.environ and 'SAUCE_ACCESS_KEY' in os.environ:
+    WD_HUB_URL = 'http://{}:{}@ondemand.saucelabs.com/wd/hub'.format(
+        os.environ['SAUCE_USERNAME'],
+        os.environ['SAUCE_ACCESS_KEY']
+    )
+
+
+if 'TRAVIS_JOB_NUMBER' in os.environ and WD_TUNNEL_ID is None:
+    WD_TUNNEL_ID = os.environ['TRAVIS_JOB_NUMBER']
 
 
 def _get_webdriver(name):
@@ -79,6 +91,9 @@ class SeleniumTestCase(LiveServerTestCase):
             desired_cap['version'] = os.environ['WD_TESTING_BROWSER_VERSION']
         if 'WD_JOB_VISIBILITY' in os.environ:
             desired_cap['public'] = os.environ['WD_JOB_VISIBILITY']
+        if WD_TUNNEL_ID:
+            desired_cap['tunnel-identifier'] = WD_TUNNEL_ID
+
         desired_cap['name'] = 'CALC'
         print('capabilities:', desired_cap)
 

--- a/frontend/tests/utils.py
+++ b/frontend/tests/utils.py
@@ -1,11 +1,12 @@
+import os
 from django.conf import settings
 from django.core import management
 
 import subprocess
 
 
-_static_assets_built = False
-_static_asset_prereqs_built = False
+_static_assets_built = _static_asset_prereqs_built = \
+    'SKIP_STATIC_ASSET_BUILDING' in os.environ
 
 
 def build_static_asset_prerequisites():

--- a/selenium.md
+++ b/selenium.md
@@ -19,7 +19,7 @@ define the following environment variables (unless otherwise noted):
   Examples include `chrome`, `firefox`, `internet explorer`, `android`,
   `chrome`, `iPhone`, `iPad`, `opera`, and `safari`.
 
-## Example: Docker + your machine's desktop browser
+## Example: Docker + your machine's Chrome browser
 
 If you're using Docker, configuration may not be straightforward due
 to the fact that CALC is running in its own Docker container with its
@@ -41,7 +41,7 @@ default `DOCKER_EXPOSED_PORT` of `8000`.
 
    ```
    DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8000
-   WD_TESTING_URL=http://localhost:8000
+   WD_TESTING_URL=http://127.0.0.1:8000
    WD_TESTING_BROWSER=chrome
    ```
 
@@ -80,6 +80,32 @@ default `DOCKER_EXPOSED_PORT` of `8000`.
    front-end code between runs, set `SKIP_STATIC_ASSET_BUILDING=yup` in
    your `.env` to make things run faster.
 
+
+### Running Selenium and a headless Chrome browser in Docker
+
+We can modify the earlier setup to use a [Selenium Docker image][] that
+runs the Selenium hub server and a headless Chrome browser in a Docker
+container.  The advantage is that you don't need to have Java, Selenium hub,
+Chrome, and ChromeDriver on your local system; the downside is that you won't
+be able to see what's happening except via screenshots taken by the test
+suite.
+
+In a separate terminal, run:
+
+```
+docker run -it --rm -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:2.53.1
+```
+
+Your `WD_HUB_URL` should remain unchanged, since the same port on your
+machine is hosting the Selenium server (it's just forwarding all requests to
+the container now).
+
+However, you will need to change the IP address of your `WD_TESTING_URL`,
+as the browser is no longer running on your machine, but inside a Docker
+container. You'll probably want to give it the same IP that `WD_HUB_URL`
+uses.
+
 [Selenium hub]: https://seleniumhq.github.io/docs/grid.html#what_is_a_hub_and_node
 [Selenium Standalone Server]: http://www.seleniumhq.org/download/
 [ChromeDriver]: https://sites.google.com/a/chromium.org/chromedriver/
+[Selenium Docker image]: https://github.com/SeleniumHQ/docker-selenium

--- a/selenium.md
+++ b/selenium.md
@@ -47,10 +47,12 @@ default `DOCKER_EXPOSED_PORT` of `8000`.
 
    You will also want to define `WD_HUB_URL` in a way that allows your
    docker container to make a request to the Selenium server running on
-   your machine.  You should be able to get this by running the following:
+   your machine.  One way to do this is by using the IP address of your
+   machine on your LAN; on OS X, for instance, you should be able to
+   use the output of the following command:
 
    ```
-   echo "http://`ip route | awk '/docker0/ { print $NF }'`:4444/wd/hub"
+   echo "http://`ipconfig getifaddr en0`:4444/wd/hub"
    ```
 
    Supposing the above command produced the output

--- a/selenium.md
+++ b/selenium.md
@@ -1,0 +1,75 @@
+# Browser tests via Selenium
+
+To run CALC's browser-based tests via Selenium/WebDriver, you'll need to
+define the following environment variables (unless otherwise noted):
+
+* `DJANGO_LIVE_TEST_SERVER_ADDRESS` is the IP and port that CALC
+  will bind itself to from the perspective of the machine (or
+  Docker container) running the tests, e.g. `0.0.0.0:8000`.
+
+* `WD_HUB_URL` is the URL at which the [Selenium hub][] server resides
+  from the perspective of the machine (or Docker container) running
+  the tests, e.g. `http://localhost:4444/wd/hub`.
+
+* `WD_TESTING_URL` is the URL from which the automated browser will be able
+  to access CALC, e.g. `http://localhost:8000`. (This will literally be
+  the base URL that appears in the automated browser's address bar.)
+
+* `WD_TESTING_BROWSER` is the browser used to perform the automated tests.
+  Examples include `chrome`, `firefox`, `internet explorer`, `android`,
+  `chrome`, `iPhone`, `iPad`, `opera`, and `safari`.
+
+## Example: Docker + your machine's desktop browser
+
+If you're using Docker, configuration may not be straightforward due
+to the fact that CALC is running in its own Docker container with its
+own network.
+
+Below is an example configuration for running tests in your
+host machine's Chrome browser; they assume that you're using a native
+version of Docker that exposes CALC through `localhost` at the
+default `DOCKER_EXPOSED_PORT` of `8000`.
+
+1. Download [Selenium Standalone Server][].  To run it, you will need to
+   install Java too. Start it up with `java -jar` followed by the
+   name of the `.jar` file you downloaded.
+
+2. Download [ChromeDriver][], decompress its executable and put it in the
+   same directory as Selenium Standalone Server.
+
+3. Set the following environment variables in your `.env` file:
+
+       DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8000
+       WD_TESTING_URL=http://localhost:8000
+       WD_TESTING_BROWSER=chrome
+
+   You will also want to define `WD_HUB_URL` in a way that allows your
+   docker container to make a request to the Selenium server running on
+   your machine.  You should be able to get this by running the following:
+
+       echo "http://`ip route | awk '/docker0/ { print $NF }'`:4444/wd/hub"
+
+   Supposing the above command produced the output
+   `http://192.168.1.5:4444/wd/hub`, you can test connectivity from CALC's
+   docker container by running:
+
+       docker-compose run app curl -I http://192.168.1.5:4444/wd/hub
+
+   This command should result in a 302 if it's able to connect to your
+   Selenium server.
+
+4. If you're running `docker-compose up` in a separate terminal,
+   shut it down now, because the test server is going to be exposing
+   itself on the same port as that development server.
+
+5. Run the following:
+
+       docker-compose run --service-ports app python manage.py test frontend
+
+   If you need to run this multiple times but aren't changing any
+   front-end code between runs, set `SKIP_STATIC_ASSET_BUILDING=yup` in
+   your `.env` to make things run faster.
+
+[Selenium hub]: https://seleniumhq.github.io/docs/grid.html#what_is_a_hub_and_node
+[Selenium Standalone Server]: http://www.seleniumhq.org/download/
+[ChromeDriver]: https://sites.google.com/a/chromium.org/chromedriver/

--- a/selenium.md
+++ b/selenium.md
@@ -19,45 +19,43 @@ define the following environment variables (unless otherwise noted):
   Examples include `chrome`, `firefox`, `internet explorer`, `android`,
   `chrome`, `iPhone`, `iPad`, `opera`, and `safari`.
 
-## Example: Docker + your machine's Chrome browser
+## Example: Docker on OS X
 
 If you're using Docker, configuration may not be straightforward due
 to the fact that CALC is running in its own Docker container with its
 own network.
 
-Below is an example configuration for running tests in your
-host machine's Chrome browser; they assume that you're using a native
-version of Docker that exposes CALC through `localhost` at the
-default `DOCKER_EXPOSED_PORT` of `8000`.
+The hardest part of this setup is figuring out an IP address that
+docker containers can reach your machine through. 
 
-1. Download [Selenium Standalone Server][].  To run it, you will need to
-   install Java too. Start it up with `java -jar` followed by the
-   name of the `.jar` file you downloaded.
+One way to do this is by using the IP address of your
+machine on your LAN; on OS X, for instance, you should be able to
+use the output of the following command:
 
-2. Download [ChromeDriver][], decompress its executable and put it in the
-   same directory as Selenium Standalone Server.
+```
+ipconfig getifaddr en0
+```
 
-3. Set the following environment variables in your `.env` file:
+The following instructions assume this command output `192.168.1.5`;
+your situation will likely differ, so substitute your own machine's IP
+as needed.
 
-   ```
-   DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8000
-   WD_TESTING_URL=http://127.0.0.1:8000
-   WD_TESTING_BROWSER=chrome
-   ```
+Below is an example configuration for running tests in a
+[Selenium Docker image][]--specifically, a headless Chrome browser. They
+assume that you're using a native version of Docker that exposes CALC
+through the default `DOCKER_EXPOSED_PORT` of `8000`.
 
-   You will also want to define `WD_HUB_URL` in a way that allows your
-   docker container to make a request to the Selenium server running on
-   your machine.  One way to do this is by using the IP address of your
-   machine on your LAN; on OS X, for instance, you should be able to
-   use the output of the following command:
+1. In a separate terminal, run:
 
    ```
-   echo "http://`ipconfig getifaddr en0`:4444/wd/hub"
+   docker run -it --rm -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:2.53.1
    ```
 
-   Supposing the above command produced the output
-   `http://192.168.1.5:4444/wd/hub`, you can test connectivity from CALC's
-   docker container by running:
+   This will start up the Selenium hub server connected to a headless
+   Chrome in a docker container.
+
+2. **This step is optional.** To make sure your Selenium server is
+   reachable from CALC, you may want to run the following:
 
    ```
    docker-compose run app curl -I http://192.168.1.5:4444/wd/hub
@@ -65,6 +63,15 @@ default `DOCKER_EXPOSED_PORT` of `8000`.
 
    This command should result in a 302 if it's able to connect to your
    Selenium server.
+
+3. Set the following environment variables in your `.env` file:
+
+   ```
+   DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8000
+   WD_TESTING_URL=http://192.168.1.5:8000
+   WD_HUB_URL=http://192.168.1.5:4444/wd/hub
+   WD_TESTING_BROWSER=chrome
+   ```
 
 4. If you're running `docker-compose up` in a separate terminal,
    shut it down now, because the test server is going to be exposing
@@ -81,29 +88,27 @@ default `DOCKER_EXPOSED_PORT` of `8000`.
    your `.env` to make things run faster.
 
 
-### Running Selenium and a headless Chrome browser in Docker
+### Running the tests on your machine's Chrome browser
 
-We can modify the earlier setup to use a [Selenium Docker image][] that
-runs the Selenium hub server and a headless Chrome browser in a Docker
-container.  The advantage is that you don't need to have Java, Selenium hub,
-Chrome, and ChromeDriver on your local system; the downside is that you won't
-be able to see what's happening except via screenshots taken by the test
-suite.
+One disadvantage of running Chrome headless is that you can't easily
+see what's going on. You can get around this by running the Selenium
+tests using your own machine's Chrome browser, but it takes some
+extra configuration:
 
-In a separate terminal, run:
+1. Download [Selenium Standalone Server][].  To run it, you will need to
+   install Java too. Start it up with `java -jar` followed by the
+   name of the `.jar` file you downloaded.
 
-```
-docker run -it --rm -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:2.53.1
-```
+   Alternatively, if you use Homebrew, you should be able to install
+   it via `brew install selenium-standalone-server`.
 
-Your `WD_HUB_URL` should remain unchanged, since the same port on your
-machine is hosting the Selenium server (it's just forwarding all requests to
-the container now).
+2. Download [ChromeDriver][], decompress its executable and put it in the
+   same directory as Selenium Standalone Server.
 
-However, you will need to change the IP address of your `WD_TESTING_URL`,
-as the browser is no longer running on your machine, but inside a Docker
-container. You'll probably want to give it the same IP that `WD_HUB_URL`
-uses.
+   Alternatively, if you use Homebrew, `brew install chromedriver` should
+   work.
+
+Now, follow the earlier example's instructions from step (2) onward.
 
 [Selenium hub]: https://seleniumhq.github.io/docs/grid.html#what_is_a_hub_and_node
 [Selenium Standalone Server]: http://www.seleniumhq.org/download/

--- a/selenium.md
+++ b/selenium.md
@@ -39,21 +39,27 @@ default `DOCKER_EXPOSED_PORT` of `8000`.
 
 3. Set the following environment variables in your `.env` file:
 
-       DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8000
-       WD_TESTING_URL=http://localhost:8000
-       WD_TESTING_BROWSER=chrome
+   ```
+   DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8000
+   WD_TESTING_URL=http://localhost:8000
+   WD_TESTING_BROWSER=chrome
+   ```
 
    You will also want to define `WD_HUB_URL` in a way that allows your
    docker container to make a request to the Selenium server running on
    your machine.  You should be able to get this by running the following:
 
-       echo "http://`ip route | awk '/docker0/ { print $NF }'`:4444/wd/hub"
+   ```
+   echo "http://`ip route | awk '/docker0/ { print $NF }'`:4444/wd/hub"
+   ```
 
    Supposing the above command produced the output
    `http://192.168.1.5:4444/wd/hub`, you can test connectivity from CALC's
    docker container by running:
 
-       docker-compose run app curl -I http://192.168.1.5:4444/wd/hub
+   ```
+   docker-compose run app curl -I http://192.168.1.5:4444/wd/hub
+   ```
 
    This command should result in a 302 if it's able to connect to your
    Selenium server.
@@ -64,7 +70,9 @@ default `DOCKER_EXPOSED_PORT` of `8000`.
 
 5. Run the following:
 
-       docker-compose run --service-ports app python manage.py test frontend
+   ```
+   docker-compose run --service-ports app python manage.py test frontend
+   ```
 
    If you need to run this multiple times but aren't changing any
    front-end code between runs, set `SKIP_STATIC_ASSET_BUILDING=yup` in


### PR DESCRIPTION
## What this does

- [x] Makes the tests run more consistently across a wider variety of browsers.
- [x] If `WD_TESTING_BROWSER` is undefined, or if it's defined to be something other than `phantomjs`, runs the QUnit tests via Selenium.
- [x] Integrates with Travis and Sauce Labs so that our ~~selenium~~ QUnit tests are run under IE11 on CI.
- [x] Adds a `selenium.md` that explains how to set up selenium testing using various configurations, and is linked-to by `README.md`.
