### PR TITLE
Improve google analytics tracking

### DIFF
--- a/data_explorer/templates/base.html
+++ b/data_explorer/templates/base.html
@@ -11,6 +11,30 @@
     <script src="{% static 'frontend/js/vendor/history.min.js' %}"></script>
     <![endif]-->
 
+    <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        // anonymize user IPs (chops off the last IP triplet)
+        ga('set', 'anonymizeIp', true);
+
+        // forces SSL even if the page were somehow loaded over http://
+        ga('set', 'forceSSL', true);
+
+        {% if user.is_authenticated %}
+        ga('set', 'dimension1', '{{ user.id }}');
+        {% endif %}
+
+        {% if is_safe_mode_enabled %}
+        ga('set', 'dimension2', 'safe mode enabled');
+        {% endif %}
+
+        ga('create', 'UA-48605964-21', 'auto');
+        ga('send', 'pageview');
+    </script>
+
     {% include 'frontend/safe_mode/script_tag.html' %}
     <link rel="stylesheet" href="{% static 'frontend/built/style/main.min.css' %}"/>
 
@@ -113,25 +137,6 @@
     </footer>
 
     {% if not is_safe_mode_enabled %}
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-        // anonymize user IPs (chops off the last IP triplet)
-        ga('set', 'anonymizeIp', true);
-
-        // forces SSL even if the page were somehow loaded over http://
-        ga('set', 'forceSSL', true);
-
-{% if user.is_authenticated %}
-        ga('set', 'dimension1', '{{ user.id }}');
-{% endif %}
-        ga('create', 'UA-48605964-21', 'auto');
-        ga('send', 'pageview');
-    </script>
-
     <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
 

--- a/data_explorer/templates/base.html
+++ b/data_explorer/templates/base.html
@@ -125,6 +125,9 @@
         // forces SSL even if the page were somehow loaded over http://
         ga('set', 'forceSSL', true);
 
+{% if user.is_authenticated %}
+        ga('set', 'dimension1', '{{ user.id }}');
+{% endif %}
         ga('create', 'UA-48605964-21', 'auto');
         ga('send', 'pageview');
     </script>

--- a/frontend/source/js/common/ga.js
+++ b/frontend/source/js/common/ga.js
@@ -1,0 +1,11 @@
+/* global window */
+
+/**
+ * This is just a wrapper around Google Analytics' ga() function, which
+ * should be included inline at the top of the page. If it wasn't included
+ * at the top of the page, however, we'll just provide a no-op function
+ * so that code which calls it still works, allowing GA to be an optional
+ * dependency.
+ */
+
+module.exports = typeof window.ga === 'function' ? window.ga : () => {};

--- a/frontend/source/js/data-capture/expandable-area.js
+++ b/frontend/source/js/data-capture/expandable-area.js
@@ -4,6 +4,8 @@ import 'document-register-element';
 
 import * as supports from './feature-detection';
 
+import ga from '../common/ga';
+
 import { dispatchBubbly } from './custom-event';
 
 const KEY_SPACE = 32;
@@ -50,6 +52,8 @@ class ExpandableArea extends window.HTMLElement {
     const newVal = this.expander.getAttribute('aria-expanded') === 'true'
                    ? 'false' : 'true';
     this.expander.setAttribute('aria-expanded', newVal);
+    ga('send', 'event', 'expandable area',
+       newVal === 'true' ? 'expand' : 'collapse');
   }
 }
 

--- a/frontend/source/js/data-capture/expandable-area.js
+++ b/frontend/source/js/data-capture/expandable-area.js
@@ -53,7 +53,8 @@ class ExpandableArea extends window.HTMLElement {
                    ? 'false' : 'true';
     this.expander.setAttribute('aria-expanded', newVal);
     ga('send', 'event', 'expandable area',
-       newVal === 'true' ? 'expand' : 'collapse');
+       newVal === 'true' ? 'expand' : 'collapse',
+       this.expander.textContent);
   }
 }
 

--- a/frontend/templates/frontend/safe_mode/script.js
+++ b/frontend/templates/frontend/safe_mode/script.js
@@ -8,6 +8,9 @@ function showEnableSafeModeUI() {
   if (el && el.hasAttribute('style')) {
     el.removeAttribute('style');
     el.focus();
+    if (typeof ga === 'function') {
+      ga('send', 'event', 'safe mode', 'show');
+    }
   }
 }
 


### PR DESCRIPTION
This addresses some of the user stories outlined in #839:

* It defines [custom dimension](https://support.google.com/analytics/answer/2709828?hl=en#configuration) index 1 to be the user ID of the currently logged-in user.  This isn't PII by itself so we should be fine storing it in google analytics.

* It defines custom dimension index 2 to be `safe mode enabled` if safe mode is enabled.

* Whenever the user is shown the safe mode opt-in, an [event](https://support.google.com/analytics/answer/1033068?hl=en) of category `safe mode` and action `show` is triggered.

* Whenever the user expands or collapses an `<expandable-area>`, a custom event of category `expandable area` and action `expand` or `collapse` and the label of the expander (i.e. the text the user clicked on) is triggered.

* Moves the google analytics script to the `<head>`.  This is the recommended best practice since the GA script loads asynchronously and users might technically navigate to a different page before GA kicks in, if we load it at the bottom of the page.  Also, this way our code bundles can access `ga` for custom events at any point in their execution (the events will just be queued up if the analytics script hasn't been loaded yet).

* Adds a `common/ga` module that wraps the `ga()` global function, providing a no-op if GA is disabled (e.g. for unit tests, or if we eventually make `ga` optional for deploys).

**Note that all custom dimensions must be registered via the Google Analytics administrative UI too, or else they won't have any effect.**

I think this is enough for one PR, but I'll file separate issues for more things we ought to be tracking, such as ajaxform events and such.