### PR TITLE
Rename 'safe mode' to 'compatibility mode', other writing lab fixes

### DIFF
--- a/frontend/templates/frontend/safe_mode/ui.html
+++ b/frontend/templates/frontend/safe_mode/ui.html
@@ -2,19 +2,19 @@
 <aside class="safe-mode safe-mode-disable">
   <form method="post" action="{% url 'safe_mode:disable' %}">
     {% csrf_token %}
-    <button class="button-primary" type="submit">Deactivate Safe Mode</button>
-    This site is currently in <strong>safe mode</strong>. For an enhanced
-    experience, you can try disabling it, but you may experience
-    compatibility issues with your current browser.
+    <button class="button-primary" type="submit">Deactivate compatibility mode</button>
+    This site is currently in <strong>compatibility mode</strong>. For an enhanced
+    experience, you can disable it, but this may cause compatibility issues
+    with your current browser.
   </form>
 </aside>
 {% else %}
 <aside id="safe-mode-enable" class="safe-mode" style="display: none" tabindex="-1" role="alert">
   <form method="post" action="{% url 'safe_mode:enable' %}">
     {% csrf_token %}
-    <button class="button-primary" type="submit">Activate Safe Mode</button>
-    Having problems using this page? We apologize for the inconvenience.
-    Try activating this site's <strong>safe mode</strong> for a better
+    <button class="button-primary" type="submit">Activate compatibility mode</button>
+    Having problems using this page? We're sorry for the inconvenience.
+    Activate this site's <strong>compatibility mode</strong> for a better
     experience.
   </form>
 </aside>


### PR DESCRIPTION
This fixes #854. Note that internally, within the codebase, we're still calling it "safe mode" because it's (A) shorter to type and (B) never exposed to end-users.  Also, it is a huge pain to rename all that stuff. 😉 