### PR TITLE
Embed upload form in /data-capture/step/3/errors

### DIFF
--- a/data_capture/templates/data_capture/price_list/step_3_errors.html
+++ b/data_capture/templates/data_capture/price_list/step_3_errors.html
@@ -13,8 +13,7 @@
           <h3>No valid rows found!</h3>
           <p>
             Your uploaded price list contains no valid rows. Please fix the errors
-            shown above in the original file and
-            <a href="{% url 'data_capture:step_3' %}">try uploading it again</a>.
+            shown below in the original file and try uploading it again.
           </p>
         {% else %}
           <h3>{{ total }} row{{ total|pluralize:" has,s have" }} errors</h3>
@@ -23,7 +22,7 @@
             invalid and <strong>will be discarded</strong> when you upload your
             price list.
             If you'd like, you may correct {{ total|pluralize:"this row,these rows" }}
-            in your original spreadsheet and <a href="{% url 'data_capture:step_3' %}">try uploading it again</a>.
+            in your original spreadsheet and try uploading it again.
           </p>
         {% endif %}
 
@@ -41,13 +40,28 @@
       {{ gleaned_data.to_error_table|safe }}
     {% endwith %}
 
+  <h2>Want to try that again?</h2>
 
-  <form method="post">
+  <p>
+    If you'd like to fix the errors above in your spreadsheet,
+    you can try uploading it again here.
+    {% if gleaned_data.valid_rows %}
+      Otherwise, we'll discard the rows with problems when we upload
+      your original spreadsheet.
+    {% endif %}
+  </p>
+
+  <form enctype="multipart/form-data" method="post"
+        is="ajax-form"
+        action="{% url 'data_capture:step_3' %}">
     {% csrf_token %}
+
+    {{ form.file }}
+
     <div class="form-button-row clearfix">
-      <a href="{% url 'data_capture:step_3' %}" class="button button-primary">
+      <button type="submit" class="button-primary">
         Upload revised price list
-      </a>
+      </button>
 
       {% if gleaned_data.valid_rows %}
         <a href="{% url 'data_capture:step_4' %}" class="button button-secondary">

--- a/data_capture/tests/test_price_list_views.py
+++ b/data_capture/tests/test_price_list_views.py
@@ -299,7 +299,7 @@ class Step3Tests(PriceListStepTestCase, HandleCancelMixin):
 
 
 class Step3ErrorTests(PriceListStepTestCase,
-                      HandleCancelMixin, RequireGleanedDataMixin):
+                      RequireGleanedDataMixin):
     url = '/data-capture/step/3/errors'
 
     rows = [{

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -173,8 +173,7 @@ def step_3(request, step):
 
 @login_required
 @permission_required(PRICE_LIST_UPLOAD_PERMISSION, raise_exception=True)
-@require_http_methods(["GET", "POST"])
-@handle_cancel
+@require_http_methods(["GET"])
 def step_3_errors(request):
     step = steps.get_step_renderer(3)
     gleaned_data = get_nested_item(request.session, (
@@ -191,9 +190,12 @@ def step_3_errors(request):
 
     preferred_schedule = step_1_form.cleaned_data['schedule_class']
 
+    form = forms.Step3Form(schedule=step_1_form.cleaned_data['schedule'])
+
     return render(request,
                   'data_capture/price_list/step_3_errors.html',
                   step.context({
+                    'form': form,
                     'gleaned_data': gleaned_data,
                     'is_preferred_schedule': isinstance(gleaned_data,
                                                         preferred_schedule),


### PR DESCRIPTION
This fixes #804.

I basically implemented the mockup @hbillings described in https://github.com/18F/calc/issues/804#issuecomment-250782942:

<img width="1096" alt="screen shot 2016-09-30 at 10 57 44 am" src="https://cloud.githubusercontent.com/assets/509309/18998125/da95cd56-86fc-11e6-8678-6e58818eb8f2.png">

Additional notes/caveats/adjustments:

* The error alerts no longer hyperlink the phrase "try uploading it again" to step 3.  An alternative might be to leave them hyperlinked, but change the behavior so that the page scrolls down to the upload form and gives it a temporary visual highlight to attract the user's attention to it.

* If no valid rows were found, we don't display the text "Otherwise, we'll discard the rows with problems when we upload your original spreadsheet", since continuing without fixing the errors isn't an option. An alternative might be to display entirely different text if the user *must* upload a fixed form to continue--for instance, rather than "Want to try that again?" we could have "You need to try that again."  Although that might not sound very friendly, which is why I altered the copy as little as possible. 😁 

* The form now `POST`s to `/data-capture/step/3`, *not* to `/data-capture/step/3/errors`.  It is also now an ajaxform, since it needs to be in order to support the upload widget. This was by far the simplest way to embed an upload form in the errors page.

  However, this does come with a few drawbacks. In particular, it means that in the unusual case where the form is invalid--e.g. if the user uploads an empty file--the re-injected ajax form will actually be *the form from step 3*, which has different buttons at the bottom. I tried this out and I don't find it disorienting, but if users do (or if y'all think users will) then we can fix it, it'll just take more code and testing.


