### PR TITLE
Link to Sauce Labs results when selenium tests fail

### DIFF
--- a/frontend/tests/test_qunit.py
+++ b/frontend/tests/test_qunit.py
@@ -10,6 +10,7 @@ from .test_selenium import WD_TESTING_BROWSER, SeleniumTestCase
 
 urlpatterns += [tests_url]
 
+TESTS_URL = '/tests/?hidepassed'
 
 if WD_TESTING_BROWSER == 'phantomjs':
     RUNNER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -25,7 +26,7 @@ if WD_TESTING_BROWSER == 'phantomjs':
 
         def test_qunit(self):
             subprocess.check_call([
-                'phantomjs', RUNNER_PATH, self.live_server_url + '/tests/'
+                'phantomjs', RUNNER_PATH, self.live_server_url + TESTS_URL
             ])
 
         @classmethod
@@ -40,7 +41,7 @@ else:
         '''
 
         def test_qunit(self):
-            self.load('/tests/')
+            self.load(TESTS_URL)
 
             FAILED = '#qunit-testresult .failed'
 

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -32,6 +32,7 @@ from datetime import datetime
 from .utils import build_static_assets
 
 
+WD_IS_USING_SAUCE_LABS = False
 WD_HUB_URL = os.environ.get('WD_HUB_URL')
 WD_TESTING_URL = os.environ.get('WD_TESTING_URL')
 WD_TESTING_BROWSER = os.environ.get('WD_TESTING_BROWSER',
@@ -65,6 +66,7 @@ if WD_TESTING_URL and WD_HUB_URL is None and \
         os.environ['SAUCE_USERNAME'],
         os.environ['SAUCE_ACCESS_KEY']
     )
+    WD_IS_USING_SAUCE_LABS = True
 
 
 def _get_webdriver(name):
@@ -158,6 +160,12 @@ class SeleniumTestCase(LiveServerTestCase):
             self.base_url = WD_TESTING_URL
         self.driver.set_window_size(*self.window_size)
         super().setUp()
+
+    def tearDown(self):
+        if WD_IS_USING_SAUCE_LABS:
+            print("Results: http://saucelabs.com/jobs/{}".format(
+                self.driver.session_id
+            ))
 
     def load(self, uri='/'):
         url = self.base_url + uri


### PR DESCRIPTION
This uses the instructions in [Building links to test results](https://wiki.saucelabs.com/display/DOCS/Building+Links+to+Test+Results) to display a link to sauce labs results that is visible in the `stdout` log when selenium tests fail.

It also hides successful test results in QUnit, so that hopefully information relevant to the failing test(s) is visible in the Sauce Labs screencast.

You can see what this looks like in #896, which adds a trivial failing test to the build:

![travis-log](https://cloud.githubusercontent.com/assets/124687/19188715/9cb6c3a4-8c61-11e6-90bd-e31dcae281ee.png)

I guess it's not super easy to notice, but it's there if you know where to look... Definitely a step up from not having any idea and needing to scour the Sauce Labs logs for clues.

Here's what the QUnit test output looks like when we only show failing tests:

![qunit-output](https://cloud.githubusercontent.com/assets/124687/19188761/e6d6227c-8c61-11e6-8068-7c4c0c2dc03a.png)
