### PR TITLE
In 'common/ga', always proxy to window.ga() instead of permanently caching it

### DIFF
--- a/frontend/source/js/common/ga.js
+++ b/frontend/source/js/common/ga.js
@@ -3,9 +3,16 @@
 /**
  * This is just a wrapper around Google Analytics' ga() function, which
  * should be included inline at the top of the page. If it wasn't included
- * at the top of the page, however, we'll just provide a no-op function
+ * at the top of the page, however, we'll just no-op
  * so that code which calls it still works, allowing GA to be an optional
  * dependency.
  */
 
-module.exports = typeof window.ga === 'function' ? window.ga : () => {};
+function ga(...args) {
+  if (typeof window.ga === 'function') {
+    return window.ga.apply(this, args);
+  }
+  return undefined;
+}
+
+module.exports = ga;

--- a/frontend/source/js/tests/ga_tests.js
+++ b/frontend/source/js/tests/ga_tests.js
@@ -1,0 +1,24 @@
+/* global QUnit window */
+
+import ga from '../common/ga';
+
+QUnit.module('ga', {
+  beforeEach() {
+    delete window.ga;
+  },
+  afterEach() {
+    delete window.ga;
+  },
+});
+
+QUnit.test('ga does not throw when window.ga is undefined', assert => {
+  ga();
+  assert.ok(true, 'calling ga() does not throw');
+});
+
+QUnit.test('ga calls window.ga when it is a function', assert => {
+  window.ga = (...args) => {
+    assert.deepEqual(args, [1, 2, 3]);
+  };
+  ga(1, 2, 3);
+});

--- a/frontend/source/js/tests/index.js
+++ b/frontend/source/js/tests/index.js
@@ -5,3 +5,4 @@ require('./upload_tests');
 require('./expandable-area_tests');
 require('./alerts_tests');
 require('./date_tests');
+require('./ga_tests');


### PR DESCRIPTION
From [how analytics.js works](https://developers.google.com/analytics/devguides/collection/analyticsjs/how-analyticsjs-works):

> The JavaScript tracking snippet defines a global `ga` function known as the "command queue". It's called the command queue because rather than executing the commands it receives immediately, it adds them to a queue that delays execution until the analytics.js library is fully loaded.

The same page later states:

> Once the analytics.js library is loaded, it inspects the contents of the `ga.q` array and executes each command in order. After that, **the `ga()` function is redefined**, so all subsequent calls execute immediately.

(Emphasis mine.)

The fact that `ga` is *redefined* means that we shouldn't be caching it in our `common/ga` module, because if `ga` fails to load before the bundle is loaded, `common/ga`'s exported function will always be the "command queue" version, rather than the newly-redefined one.

This PR just makes `common/ga` export a "wrapper" around `window.ga` so that the current `window.ga` is always proxied-to.
