### PR TITLE
Ensure gateway works when testing on sauce labs

### DIFF
--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -161,11 +161,21 @@ class SeleniumTestCase(LiveServerTestCase):
         self.driver.set_window_size(*self.window_size)
         super().setUp()
 
+        if WD_IS_USING_SAUCE_LABS and not hasattr(self, '_gateway_ensured'):
+            self.ensure_gateway_works()
+            self._gateway_ensured = True
+
     def tearDown(self):
         if WD_IS_USING_SAUCE_LABS:
             print("Results: http://saucelabs.com/jobs/{}".format(
                 self.driver.session_id
             ))
+
+    def ensure_gateway_works(self):
+        def about():
+            self.load('/about/')
+            return 'CALC' in self.driver.page_source
+        self.wait_for(about)
 
     def load(self, uri='/'):
         url = self.base_url + uri


### PR DESCRIPTION
This is an attempt to maybe fix #883 via the strategy described in https://github.com/18F/calc/issues/883#issuecomment-252263117.

Basically, before any specific Selenium test cases are run, the test harness repeatedly attempts to load `/about/` for 10 seconds. [Sauce labs output is available here.](https://saucelabs.com/beta/tests/85673f76e2a447f68ab0d59dc8f69872/watch#10)

Thoughts @jseppi?