### PR TITLE
Improve button focus styling

### DIFF
--- a/frontend/source/sass/components/_buttons.scss
+++ b/frontend/source/sass/components/_buttons.scss
@@ -13,7 +13,12 @@ button,
   margin-bottom: 0;
   margin-top: 0;
   font-size: $font-size-button;
+
+  &:focus {
+    box-shadow: $focus-shadow;
+  }
 }
+
 // Need to override Skeleton's default button styling
 .button.button-primary,
 button.button-primary,
@@ -42,7 +47,6 @@ input.button-primary[type="button"] {
   &.button-focus {
     background-color: $color-primary-darker;
     border-color: $color-primary-darker;
-    box-shadow: $focus-shadow;
   }
 
   &:active,
@@ -73,7 +77,6 @@ input.button-secondary[type="button"] {
   &.button-focus {
     background-color: $color-secondary-dark;
     border-color: $color-secondary-dark;
-    box-shadow: $focus-shadow;
   }
 
   &:active,
@@ -116,6 +119,8 @@ input.button-link[type="button"] {
   &:focus,
   &.button-focus {
     color: $color-primary-darker;
+    outline: 1px dotted $color-primary-darker;
+    box-shadow: none;
   }
 
   &:active,
@@ -129,5 +134,15 @@ input.button-link[type="button"] {
   cursor: default;
   &:hover {
     color: $color-gray;
+  }
+}
+
+.button.button-disabled,
+button.button-disabled,
+input.button-disabled[type="submit"],
+input.button-disabled[type="reset"],
+input.button-disabled[type="button"] {
+  &:focus {
+    outline: 1px dotted $color-gray-dark;
   }
 }


### PR DESCRIPTION
Currently, not all of our buttons have great focus styling. Here's me tabbing through all the [buttons in our styleguide](https://calc-dev.apps.cloud.gov/styleguide/#buttons):

> ![before](https://cloud.githubusercontent.com/assets/124687/19352749/ff88492c-912e-11e6-95c3-af452c3b2fc9.gif)

So it's very hard/impossible to tell when default, disabled, gray, and link buttons are in focus, which makes interaction particularly challenging for keyboard users.

This PR changes styling so it's easy to tell when any button is focused:

> ![after](https://cloud.githubusercontent.com/assets/124687/19352825/4630aedc-912f-11e6-957f-39f823fc9e18.gif)
