### PR TITLE
spruce up the Logged Out page

### DIFF
--- a/uaa_client/templates/logged_out.html
+++ b/uaa_client/templates/logged_out.html
@@ -2,6 +2,11 @@
 
 {% block body %}
 <div class="container">
-You are now logged out.
+  <h1>Logged out</h1>
+
+  <div class="alert alert-success">
+    <h3>You have successfully logged out of CALC.</h3>
+    <p>Return to the <a href="/">CALC home page</a>.</p>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
<img width="961" alt="screen shot 2016-10-14 at 10 50 21 am" src="https://cloud.githubusercontent.com/assets/697848/19393877/48458486-91fc-11e6-8006-3ec737dc670c.png">

I guess something that maybe looks not great is that the `.alert` spans the entire page width.

Closes #511 