### PR TITLE
Expand introduction to styleguide

### DIFF
--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -16,11 +16,38 @@
   <h1>CALC Style Guide</h1>
 
   {% guide %}
+
+  {% guide_section "Introduction" %}
+
+  <p>
+    Welcome to the CALC Style Guide!
+  </p>
+
+  <p>
+    CALC's content is structured using 18F's standard voice, which is
+    described in the <a href="https://pages.18f.gov/content-guide/">18F
+    Content Guide</a>.
+  </p>
+
   <p>
     CALC uses <a href="http://getskeleton.com/">Skeleton</a> as the foundation
     for its styles, with alterations based on the
     <a href="https://standards.usa.gov/">U.S. Web Design Standards (USWDS)</a>.
   </p>
+
+  <p>
+    While not all parts of the site adhere to a single unifying
+    philosophy, we try to build new parts in accordance with
+    Aaron Gustafson's <a href="http://adaptivewebdesign.info/1st-edition/read/chapter-4.html#planning-and-restraint">three maxims for progressive enhancement
+    with JavaScript</a>:
+  </p>
+
+  <ol>
+    <li>Make sure all content is accessible and all necessary tasks can be completed without JavaScript turned on.</li>
+    <li>Use JavaScript to generate any additional markup it needs.
+</li>
+    <li>Apply no style before its time.</li>
+  </ol>
 
   {% guide_section "Typography" %}
 


### PR DESCRIPTION
This fixes #923 by expanding the introduction of the style guide to include a link to the 18F Content Guide and information about our progressive enhancement strategy:

> <img width="604" alt="screen shot 2016-10-18 at 10 02 36 am" src="https://cloud.githubusercontent.com/assets/124687/19480867/0616a24a-951a-11e6-88a1-fbebb8f3acbb.png">
