### PR TITLE
raise exception instead of returning it

### DIFF
--- a/data_capture/schedules/base.py
+++ b/data_capture/schedules/base.py
@@ -79,7 +79,7 @@ class BasePriceList:
         rows of the price list
         '''
 
-        return NotImplementedError()
+        raise NotImplementedError()
 
     @classmethod
     def get_upload_example_context(cls):


### PR DESCRIPTION
Very minor correction: `raise NotImplementedError()` instead of `return NotImplementedError()`