### PR TITLE
Set GA location, send pageview on search

### DIFF
--- a/frontend/source/js/data-explorer/explorer.js
+++ b/frontend/source/js/data-explorer/explorer.js
@@ -1,3 +1,5 @@
+import ga from '../common/ga';
+
 const hourglass = require('../common/hourglass');
 
 /* eslint-disable */
@@ -275,7 +277,7 @@ const hourglass = require('../common/hourglass');
 
       history.pushState(null, null, href);
 
-      if (didSearchChange && typeof(ga) === 'function') {
+      if (didSearchChange) {
         ga('set', 'location', window.location.href);
         ga('send', 'pageview');
       }

--- a/frontend/source/js/data-explorer/explorer.js
+++ b/frontend/source/js/data-explorer/explorer.js
@@ -278,7 +278,8 @@ const hourglass = require('../common/hourglass');
       history.pushState(null, null, href);
 
       if (didSearchChange) {
-        ga('set', 'location', window.location.href);
+        ga('set', 'page', window.location.pathname +
+                          window.location.search);
         ga('send', 'pageview');
       }
     }

--- a/frontend/source/js/data-explorer/explorer.js
+++ b/frontend/source/js/data-explorer/explorer.js
@@ -271,7 +271,14 @@ const hourglass = require('../common/hourglass');
 
     if (pushState) {
       var href = "?" + hourglass.qs.format(data);
+      var didSearchChange = window.location.search !== href;
+
       history.pushState(null, null, href);
+
+      if (didSearchChange && typeof(ga) === 'function') {
+        ga('set', 'location', window.location.href);
+        ga('send', 'pageview');
+      }
     }
 
     updateExcluded();


### PR DESCRIPTION
This is an attempt to fix #924 by setting the [GA `location` field](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#location) and issuing a `pageview`.

## Notes

* The **GA Single Page Application Tracking guide** specifically advises us to [not update the document location](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications#do_not_update_the_document_location), but this seems weird to me because that's all we're changing, and we really *want* those new querystring arguments to be tracked by GA. And since we're not using GA's campaign fields (e.g. `utm_source`, `utm_campaign`, etc) I don't *think* it should break its session tracking...

* As with the ajaxform improvements in #869, the way this is currently written, it will *only* report the pageview to 18F GA's account, *not* to DAP.  We could report it to both by fixing #940.

## To do

- [x] Import `../common/ga` instead of using the global.
