### PR TITLE
[WIP] Make separate staging and development deploys

### DIFF
--- a/deploy-travis.sh
+++ b/deploy-travis.sh
@@ -4,7 +4,7 @@ API="https://api.cloud.gov"
 ORG="oasis"
 SPACE="calc-dev"
 APP_NAME="calc-dev"
-MANIFEST="manifests/manifest-staging.yml"
+MANIFEST="manifests/manifest-dev.yml"
 
 # CF_USER and CF_PASSWORD are defined as private Environment Variables
 # in the Travis web UI: https://travis-ci.org/18F/calc/settings

--- a/deploy.md
+++ b/deploy.md
@@ -67,8 +67,6 @@ for `<APP_INSTANCE>`) to create the user-provided service:
 
 ```sh
 cf cups calc-env -p credentials-staging.json
-cf bind-service <APP_INSTANCE> calc-env
-cf restage <APP_INSTANCE>
 ```
 
 You can update the user-provided service with the following commands:
@@ -84,8 +82,9 @@ CALC uses PostgreSQL for its database.
 
 ```sh
 cf create-service aws-rds <SERVICE_PLAN> calc-db
-cf bind-service <APP_INSTANCE> calc-db
 ```
+
+(Don't know what `<SERVICE_PLAN>` to use? Try `cf marketplace`.)
 
 ### Redis Service
 
@@ -94,7 +93,6 @@ asynchronous tasks.
 
 ```sh
 cf create-service redis28-swarm standard calc-redis
-cf bind-service <APP_INSTANCE> calc-redis
 ```
 
 ## New Relic Environment Variables

--- a/deploy.md
+++ b/deploy.md
@@ -134,6 +134,13 @@ To deploy, first make sure you are targeting the prod space:
 cf target -o oasis -s calc-prod
 ```
 
+Now, if you don't already have the autopilot plugin, you can install it
+by running:
+
+```sh
+cf install-plugin autopilot -f -r CF-Community
+```
+
 Then use the autopilot plugin's `zero-downtime-push` command to deploy:
 
 ```sh

--- a/manifests/manifest-dev.yml
+++ b/manifests/manifest-dev.yml
@@ -4,20 +4,20 @@ services:
 - calc-env
 - calc-redis
 applications:
-- name: calc-staging
+- name: calc-dev
   instances: 1
   memory: 1G
   disk_quota: 1024M
-  host: calc-staging
+  host: calc-dev
   domain: apps.cloud.gov
   buildpack: python_buildpack
   command: bash cf.sh
   stack: cflinuxfs2
   timeout: 180
   env:
-    NEW_RELIC_APP_NAME: "CALC (staging)"
+    NEW_RELIC_APP_NAME: "CALC (dev)"
     NEW_RELIC_CONFIG_FILE: "newrelic.ini"
-    NEW_RELIC_ENV: "staging"
+    NEW_RELIC_ENV: "dev"
     NEW_RELIC_LOG: "stdout"
 - name: calc-rqworker
   no-route: true


### PR DESCRIPTION
Until now, we've used the terms "dev" and "staging" interchangeably to mean "the deployment that has the latest changes on the `develop` branch."

This changes now.

Once this PR is merged, [calc-dev.apps.cloud.gov](https://calc-dev.apps.cloud.gov/) will contain the latest `develop` branch, while [calc-staging.apps.cloud.gov](https://calc-staging.apps.cloud.gov/) will contain whatever we're about to push to production. Right now that means the version (and deployment configuration) of CALC that is up for ATO review.

Non-repository related TODOs:
- [ ] Set up a new cloud.gov UAA for calc-staging.apps.cloud.gov.
- [ ] Get the current "calc-staging" UAA renamed to "calc-dev". This will likely involve cycling a new UAA secret key to the calc-dev CF space.
- [ ] Either set up a new API host at [api.data.gov](https://api.data.gov/admin) that points https://api.data.gov/dev/gsa/calc/ to calc-dev.apps.cloud.gov, _or_ tell calc-dev.apps.cloud.gov to not use api.data.gov as its `API_HOST`.
- [ ] Update `deploy.md` and any other ATO-related documentation to describe the new environments.
- [ ] Add Noah and other infrastructure superuser accounts to new calc-staging instance.
- [ ] Update the [CALC ATO issue](https://github.com/18F/Infrastructure/issues/649) to mention the new calc-staging.apps.cloud.gov.
- [ ] Make sure New Relic works on all three environments.
- [ ] [Update Compliance Viewer](https://github.com/18F/concourse-compliance-testing#adding-a-project) to do its automated scans against the new calc-staging.apps.cloud.gov
- [ ] Probably more stuff I'm not remembering right now.
