### PR TITLE
Document compatibility/safe mode in style guide

### DIFF
--- a/frontend/source/sass/components/_safemode.scss
+++ b/frontend/source/sass/components/_safemode.scss
@@ -6,6 +6,7 @@ aside.safe-mode {
   left: 0;
   right: 0;
   padding: 1em;
+  z-index: 10000;
 
   form {
     margin-bottom: 0;

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -642,6 +642,47 @@
 
   <p>When JavaScript is not available, the activator element will do whatever it previously did before being modified to open a dialog.</p>
 
+  {% guide_section "Compatibility Mode" %}
+
+  <p>
+    Because we're designing the new parts of CALC to be progressively enhanced,
+    they can actually work without JavaScript. One advantage of this approach
+    is that in the rare case that the site doesn't work, a user can disable
+    JavaScript in their browser and reload the page&mdash;it can potentially
+    fix things.
+  </p>
+
+  <p>
+    However, there's a few problems with this:
+  </p>
+
+  <ol>
+    <li>Most users don't know what JavaScript is, much less how to disable it.</li>
+    <li>Even if a user knows what JavaScript is and how to disable it in their
+    browser, they have no idea when a JavaScript error has actually occurred.</li>
+  </ol>
+
+  <p>
+    Fortunately, it <em>is</em> possible to use JavaScript to detect when a
+    JavaScript error has occurred, so we do this on progressively
+    enhanced CALC pages. Whenever a JS error occurs, a warning appears
+    that allows users to opt-in to <em>compatibility mode</em>. If the
+    user opts-in, the server will stop sending JS to the client, ensuring
+    a baseline experience.
+  </p>
+
+  {% if not is_safe_mode_enabled %}
+  <p>
+    To see what this looks like in action, you can forcibly trigger a JS error
+    on this page via the button below.
+  </p>
+
+  <button class="button-secondary"
+          onclick="throw new Error('I am an intentional error')">
+    Trigger JavaScript Error
+  </button>
+  {% endif %}
+
   {% endguide %}
 </div>
 {% if not is_safe_mode_enabled %}


### PR DESCRIPTION
This documents the compatibility/safe mode in the style guide.

Most of the copy was taken from the description of https://github.com/18F/writing-lab/issues/197.