### PR TITLE
Fix minor typo ~~Remove focus outline from <alerts-widget>~~

### DIFF
--- a/styleguide/ajaxform_example.py
+++ b/styleguide/ajaxform_example.py
@@ -61,7 +61,7 @@ def view(request):
                     time.sleep(3)
                     return ajaxform.redirect(request, 'styleguide:index')
                 elif choice == CHOICE_500:
-                    raise Exception('Here is the 500 your ordered.')
+                    raise Exception('Here is the 500 you ordered.')
                 else:
                     return HttpResponse('Here is an unexpected response.')
 


### PR DESCRIPTION
Well, I was going to do this real quick, but I am unable to get the `<alerts-widget>` example in the Style Guide (http://app.calc.docker/styleguide/ajaxform) to actually show the alerts widget. Any ideas, @toolness?

And then I noticed that it appears there is already a rule to remove the focus from `alert-widget`: https://github.com/18F/calc/blob/develop/frontend/source/sass/components/_alerts.scss#L40 (added by @hbillings in 82210e35ad247ef28cd52b7e308badee51744ff9).

So, I just corrected a minor typo I found.

Closes #932
