### PR TITLE
Use {% fieldset %} in ajaxform example

### DIFF
--- a/styleguide/templates/styleguide_ajaxform_example.html
+++ b/styleguide/templates/styleguide_ajaxform_example.html
@@ -7,6 +7,7 @@
 
       action="{% url 'styleguide:ajaxform' %}">
   {% csrf_token %}
+  {% load frontend %}
 
   {% if request.is_ajax %}
   {% include 'data_capture/messages.html' %}
@@ -14,12 +15,8 @@
 
   {% with form=ajaxform_form %}
     {{ form.non_field_errors }}
-    {{ form.question.errors }}
-    {{ form.question.label_tag }}
-    {{ form.question }}
-    {{ form.on_valid_submit.errors }}
-    {{ form.on_valid_submit.label_tag }}
-    {{ form.on_valid_submit }}
+    {% fieldset form.question %}
+    {% fieldset form.on_valid_submit %}
     {{ form.file.errors }}
     {{ form.file }}
   {% endwith %}


### PR DESCRIPTION
This fixes #968 so that the example ajaxform uses fieldsets and errors look better:

> ![2016-10-26_14-44-19](https://cloud.githubusercontent.com/assets/124687/19739913/bafe62ee-9b8a-11e6-8f2e-3073c3f1af6c.png)
