### PR TITLE
Make AlertsWidget extend HTMLElement

### DIFF
--- a/frontend/source/js/data-capture/alerts.js
+++ b/frontend/source/js/data-capture/alerts.js
@@ -11,7 +11,7 @@ import { dispatchBubbly } from './custom-event';
  * readers to announce the content of the widget immediately.
  */
 
-class AlertsWidget extends window.HTMLInputElement {
+class AlertsWidget extends window.HTMLElement {
   attachedCallback() {
     this.setAttribute('tabindex', '-1');
     this.focus();


### PR DESCRIPTION
This fixes #967. For an explanation, see https://github.com/18F/calc/issues/967#issuecomment-256464907.