### PR TITLE
Include Lato in Admin base template

### DIFF
--- a/hourglass/templates/admin/base.html
+++ b/hourglass/templates/admin/base.html
@@ -7,6 +7,7 @@
 <head>
 <title>{% block title %}{% endblock %}</title>
 
+<link href='https://fonts.googleapis.com/css?family=Lato:300,400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" type="text/css" href=" {% static "frontend/built/style/main.min.css" %}">
 <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "frontend/built/style/admin/overrides.min.css" %}{% endblock %}" />
 {% block extrastyle %}{% endblock %}


### PR DESCRIPTION
Fixes the weird issue that looked like a 1px pad underneath the navigation tabs on `/admin` pages.

During a screenhero session with @hbillings, we realized the actual problem was that the Lato custom typeface was not being included in the admin base template.

Before:
<img width="447" alt="screen shot 2016-11-02 at 3 38 13 pm" src="https://cloud.githubusercontent.com/assets/697848/19946614/a81f4d86-a112-11e6-8e65-6ae5378afa91.png">

After:
<img width="420" alt="screen shot 2016-11-02 at 3 38 46 pm" src="https://cloud.githubusercontent.com/assets/697848/19946619/ac7e4e40-a112-11e6-9a98-1b24b0905401.png">
