### PR TITLE
check price_list_rows instead of gleaned_data.valid_rows

### DIFF
--- a/data_capture/templates/price_lists/details.html
+++ b/data_capture/templates/price_lists/details.html
@@ -37,7 +37,7 @@
       </div>
     </div>
     <div class="row">
-      {% if gleaned_data.valid_rows %}
+      {% if price_list_rows %}
         <div class="columns twelve">
           <h3>Valid price list rows</h3>
           <table>


### PR DESCRIPTION
Relatively minor fix. The `if` statement in the details template was checking the wrong condition for showing the table of existing price list rows.