### PR TITLE
Skip GA_TRACKING_ID test if defined in env

### DIFF
--- a/hourglass/tests/tests.py
+++ b/hourglass/tests/tests.py
@@ -1,5 +1,7 @@
+import os
 import unittest
 import json
+from unittest import SkipTest
 from unittest.mock import patch
 from django.test import TestCase as DjangoTestCase
 from django.test import override_settings
@@ -309,6 +311,10 @@ class ContextProcessorTests(DjangoTestCase):
         self.assertEquals(res.context['GA_TRACKING_ID'], 'boop')
 
     def test_ga_tracking_id_defaults_to_empty_string(self):
+        if 'GA_TRACKING_ID' in os.environ:
+            # Oof, GA_TRACKING_ID is defined in our outside environment,
+            # so we can't actually test this.
+            raise SkipTest()
         res = self.client.get('/')
         self.assertIn('GA_TRACKING_ID', res.context)
         self.assertEquals(res.context['GA_TRACKING_ID'], '')


### PR DESCRIPTION
One of our tests is to ensure that the default value of `settings.GA_TRACKING_ID` is an empty string when it's not defined already in the OS environment.  However, if it *is* already defined in the OS environment (which is the case on my dev system right now), there's actually no way for us to test this, so we'll skip it.