### PR TITLE
[NEEDS DESIGN WORK] Add SubmittedPriceList.get_absolute_url()

### DIFF
--- a/data_capture/models.py
+++ b/data_capture/models.py
@@ -1,4 +1,4 @@
-
+from django.core.urlresolvers import reverse
 from django.db import models
 from django.contrib.auth.models import User
 from django.core.validators import MinValueValidator, MaxValueValidator
@@ -148,6 +148,11 @@ class SubmittedPriceList(models.Model):
     def reject(self, user):
         self._change_status(self.STATUS_REJECTED, user)
         self.save()
+
+    def get_absolute_url(self):
+        return reverse('data_capture:price_list_details', kwargs={
+            'id': str(self.id)
+        })
 
     def __str__(self):
         return "Price List for {}".format(self.contract_number)

--- a/data_capture/tests/test_models.py
+++ b/data_capture/tests/test_models.py
@@ -52,6 +52,14 @@ class ModelTestCase(BaseLoginTestCase):
 
 @override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE])
 class ModelsTests(ModelTestCase):
+    def test_get_absolute_url_works(self):
+        p = self.create_price_list()
+        p.save()
+        self.assertEqual(
+            p.get_absolute_url(),
+            '/data-capture/price-lists/{}'.format(p.id)
+        )
+
     def test_add_row_works(self):
         p = self.create_price_list()
         p.save()


### PR DESCRIPTION
This fixes #995.

However, it might actually be a bit confusing for users, the way it's currently displayed in the admin:

> <img width="371" alt="screen shot 2016-11-08 at 3 48 45 pm" src="https://cloud.githubusercontent.com/assets/124687/20116601/de668aaa-a5ca-11e6-884a-3c2a2ea65041.png">

Because the admin UI now looks like the rest of the site, the phrase "View on site" might actually be confusing to admins.  I'm not sure what a better wording might be, though; nor do I know how hard it might be to alter the admin UI to display that wording.

We might also want to change the styling to make "History" and "View on site" appear on the same line, with some kind of delimiter between them.

Thoughts on any of the above, @hbillings?

To do:

- [x] Add a test for `get_absolute_url()`.
