### PR TITLE
Add link to 18F/calc-analysis in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CALC (formerly known as "Hourglass"), which stands for Contracts Awarded Labor C
 ## Related repositories
 
 * [18F/calc-analysis](https://github.com/18F/calc-analysis) contains
-  data science experiments and other analysis that uses CALC
+  data science experiments and other analyses that use CALC
   data.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 CALC (formerly known as "Hourglass"), which stands for Contracts Awarded Labor Category, is a tool to help contracting personnel estimate their per-hour labor costs for a contract, based on historical pricing information. The tool is live at [https://calc.gsa.gov](https://calc.gsa.gov). You can track our progress on our [trello board](https://trello.com/b/LjXJaVbZ/prices) or file an issue on this repo.
 
+## Related repositories
+
+* [18F/calc-analysis](https://github.com/18F/calc-analysis) contains
+  data science experiments and other analysis that uses CALC
+  data.
+
 ## Setup
 
 To install the requirements, use:


### PR DESCRIPTION
This just adds a **Related repositories** section at the top of the README that currently only contains one item, a link to https://github.com/18F/calc-analysis.

I figured I'd put it at the top of the README since it's probably useful to non-technical audiences, while the vast majority of the rest of the README is specific to technical audiences... So I didn't want it to get buried in all the technical mumbo-jumbo.
