### PR TITLE
Add edit button on step 4 of price list upload

### DIFF
--- a/data_capture/forms/__init__.py
+++ b/data_capture/forms/__init__.py
@@ -1,6 +1,6 @@
 
-from .price_list import Step1Form, Step2Form, Step3Form
+from .price_list import Step1Form, Step2Form, Step3Form, Step4Form
 from .bulk_upload import Region10BulkUploadForm
 
-__all__ = ['Step1Form', 'Step2Form', 'Step3Form',
+__all__ = ['Step1Form', 'Step2Form', 'Step3Form', 'Step4Form',
            'Region10BulkUploadForm']

--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -8,6 +8,14 @@ from frontend.widgets import UswdsRadioSelect
 from contracts.models import MIN_ESCALATION_RATE, MAX_ESCALATION_RATE
 
 
+def ensure_contract_start_is_before_end(form, cleaned_data):
+    start = cleaned_data.get('contract_start')
+    end = cleaned_data.get('contract_end')
+    if start and end and start > end:
+        form.add_error('contract_start',
+                       'Start date must be before end date.')
+
+
 class EscalationRateField(forms.FloatField):
     def __init__(self):
         return super().__init__(
@@ -74,11 +82,7 @@ class Step2Form(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        start = cleaned_data.get('contract_start')
-        end = cleaned_data.get('contract_end')
-        if start and end and start > end:
-            self.add_error('contract_start',
-                           'Start date must be before end date.')
+        ensure_contract_start_is_before_end(self, cleaned_data)
         return cleaned_data
 
     class Meta:
@@ -170,11 +174,7 @@ class Step4Form(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        start = cleaned_data.get('contract_start')
-        end = cleaned_data.get('contract_end')
-        if start and end and start > end:
-            self.add_error('contract_start',
-                           'Start date must be before end date.')
+        ensure_contract_start_is_before_end(self, cleaned_data)
         return cleaned_data
 
     class Meta:

--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -8,6 +8,26 @@ from frontend.widgets import UswdsRadioSelect
 from contracts.models import MIN_ESCALATION_RATE, MAX_ESCALATION_RATE
 
 
+class EscalationRateField(forms.FloatField):
+    def __init__(self):
+        return super().__init__(
+            label="Escalation rate (%)",
+            help_text='CALC uses the escalation rate (as a percentage) '
+                      'to calculate out-year pricing. '
+                      'Leave this field blank or enter 0 if this contract '
+                      'does not have a fixed escalation rate.',
+            min_value=MIN_ESCALATION_RATE,
+            max_value=MAX_ESCALATION_RATE,
+            required=False
+        )
+
+    def clean(self, value):
+        value = super().clean(value)
+        if value is None:
+            value = 0
+        return value
+
+
 class Step1Form(forms.ModelForm):
     schedule = forms.ChoiceField(
         label="Which schedule is associated with this price list?",
@@ -50,16 +70,7 @@ class Step2Form(forms.ModelForm):
     contract_end = SplitDateField(
         label='Contract or current option period end'
     )
-    escalation_rate = forms.FloatField(
-        label="Escalation rate (%)",
-        help_text='CALC uses the escalation rate (as a percentage) '
-                  'to calculate out-year pricing. '
-                  'Leave this field blank or enter 0 if this contract does '
-                  'not have a fixed escalation rate.',
-        min_value=MIN_ESCALATION_RATE,
-        max_value=MAX_ESCALATION_RATE,
-        required=False,
-    )
+    escalation_rate = EscalationRateField()
 
     def clean(self):
         cleaned_data = super().clean()
@@ -69,12 +80,6 @@ class Step2Form(forms.ModelForm):
             self.add_error('contract_start',
                            'Start date must be before end date.')
         return cleaned_data
-
-    def clean_escalation_rate(self):
-        value = self.cleaned_data['escalation_rate']
-        if value is None:
-            value = 0
-        return value
 
     class Meta:
         model = SubmittedPriceList
@@ -161,16 +166,7 @@ class Step4Form(forms.ModelForm):
     contract_end = SplitDateField(
         label='Contract or current option period end'
     )
-    escalation_rate = forms.FloatField(
-        label="Escalation rate (%)",
-        help_text='CALC uses the escalation rate (as a percentage) '
-                  'to calculate out-year pricing. '
-                  'Leave this field blank or enter 0 if this contract does '
-                  'not have a fixed escalation rate.',
-        min_value=MIN_ESCALATION_RATE,
-        max_value=MAX_ESCALATION_RATE,
-        required=False,
-    )
+    escalation_rate = EscalationRateField()
 
     def clean(self):
         cleaned_data = super().clean()
@@ -180,12 +176,6 @@ class Step4Form(forms.ModelForm):
             self.add_error('contract_start',
                            'Start date must be before end date.')
         return cleaned_data
-
-    def clean_escalation_rate(self):
-        value = self.cleaned_data['escalation_rate']
-        if value is None:
-            value = 0
-        return value
 
     class Meta:
         model = SubmittedPriceList

--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -135,3 +135,65 @@ class Step3Form(forms.Form):
             cleaned_data['gleaned_data'] = gleaned_data
 
         return cleaned_data
+
+
+class Step4Form(forms.ModelForm):
+    schedule = forms.ChoiceField(
+        choices=registry.get_choices,
+        widget=forms.HiddenInput()
+    )
+    is_small_business = forms.ChoiceField(
+        label='Business size',
+        choices=[
+            (True, 'This is a small business.'),
+            (False, 'This is not a small business.'),
+        ],
+        widget=UswdsRadioSelect,
+    )
+    contractor_site = forms.ChoiceField(
+        label='Worksite',
+        choices=SubmittedPriceList.CONTRACTOR_SITE_CHOICES,
+        widget=UswdsRadioSelect,
+    )
+    contract_start = SplitDateField(
+        label='Contract or current option period start'
+    )
+    contract_end = SplitDateField(
+        label='Contract or current option period end'
+    )
+    escalation_rate = forms.FloatField(
+        label="Escalation rate (%)",
+        help_text='CALC uses the escalation rate (as a percentage) '
+                  'to calculate out-year pricing. '
+                  'Leave this field blank or enter 0 if this contract does '
+                  'not have a fixed escalation rate.',
+        min_value=MIN_ESCALATION_RATE,
+        max_value=MAX_ESCALATION_RATE,
+        required=False,
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        start = cleaned_data.get('contract_start')
+        end = cleaned_data.get('contract_end')
+        if start and end and start > end:
+            self.add_error('contract_start',
+                           'Start date must be before end date.')
+        return cleaned_data
+
+    def clean_escalation_rate(self):
+        value = self.cleaned_data['escalation_rate']
+        if value is None:
+            value = 0
+        return value
+
+    class Meta:
+        model = SubmittedPriceList
+        fields = Step1Form.Meta.fields + Step2Form.Meta.fields
+
+    @classmethod
+    def from_post_data_subsets(cls, *post_datas):
+        combined_post_data = {}
+        for post_data in post_datas:
+            combined_post_data.update(post_data)
+        return cls(combined_post_data)

--- a/data_capture/forms/price_list.py
+++ b/data_capture/forms/price_list.py
@@ -183,6 +183,12 @@ class Step4Form(forms.ModelForm):
 
     @classmethod
     def from_post_data_subsets(cls, *post_datas):
+        '''
+        This form is basically a superset of the data from earlier steps,
+        and this method makes it easy to pass in the POST data from those
+        earlier steps to obtain an instance of this form.
+        '''
+
         combined_post_data = {}
         for post_data in post_datas:
             combined_post_data.update(post_data)

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -39,6 +39,17 @@
 
     {% fieldset form.escalation_rate %}
   {% endwith %}
+
+  <div class="form-button-row clearfix">
+    <div class="submit-group">
+      <button type="submit" class="button" name="save-changes">Save changes</button>
+    </div>
+
+    {# TODO: This should include any existing querystring args. #}
+
+    <a type="submit" href="?">Discard changes</a>
+  </div>
+
 </div>
 
 {% if not show_edit_form %}

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -36,9 +36,7 @@
       <button type="submit" class="button" name="save-changes">Save changes</button>
     </div>
 
-    {# TODO: This should include any existing querystring args. #}
-
-    <a type="submit" href="?">Discard changes</a>
+    <a type="submit" href="{{ step_4_without_edit_url }}">Discard changes</a>
   </div>
 
 </div>
@@ -71,9 +69,7 @@
   </dl>
 </div>
 
-{# TODO: This should include any existing querystring args. #}
-
-<p><a href="?show_edit_form=on" class="button" data-edit-btn>Edit</a></p>
+<p><a href="{{ step_4_with_edit_url }}" class="button" data-edit-btn>Edit</a></p>
 </div>
 {% endif %}
 

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -56,11 +56,14 @@
 <div data-contract-details>
 <div class="row">
   <dl class="contract-details columns eight">
-    <dt>Vendor</dt>
-    <dd>{{ price_list.vendor_name }}</dd>
+    <dt>Schedule</dt>
+    <dd>{{ gleaned_data.title }}</dd>
 
     <dt>Contract number</dt>
     <dd>{{ price_list.contract_number }}</dd>
+
+    <dt>Vendor</dt>
+    <dd>{{ price_list.vendor_name }}</dd>
 
     <dt>Small business</dt>
     <dd>{% if price_list.is_small_business == 'True' %}Yes{% else %}No{% endif %}</dd>
@@ -74,10 +77,6 @@
 
     <dt>Escalation rate</dt>
     <dd>{{ price_list.escalation_rate }}%</dd>
-
-    <dt>Schedule</dt>
-    <dd>{{ gleaned_data.title }}</dd>
-    </dd>
   </dl>
 </div>
 

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -5,15 +5,44 @@
 {% block subtitle %}Verify data{% endblock %}
 
 {% block step_body %}
-{% with rows=gleaned_data.valid_rows %}
-  {% with total=rows|length %}
-    <h2>Verify {{ total }} row{{ total|pluralize }} of data </h2>
-  {% endwith %}
-
-  {{ gleaned_data.to_table|safe }}
-{% endwith %}
+<form method="post">
+  {% csrf_token %}
 
 <h2>Verify vendor and contract details</h2>
+
+<div data-edit-contract-details {% if not show_edit_form %}style="display: none"{% endif %}>
+
+  {{ step_1_form.non_field_errors }}
+  {{ step_2_form.non_field_errors }}
+
+  {# TODO: Maybe reuse view logic from steps 1 and 2 here to stay DRY? #}
+
+  {% load frontend %}
+
+  {% with form=step_1_form %}
+    {# TODO: It'd be nice if we could just eliminate this field. #}
+    <div style="display: none">{% fieldset form.schedule %}</div>
+
+    {% fieldset form.contract_number %}
+    {% fieldset form.vendor_name %}
+  {% endwith %}
+
+  {% with form=step_2_form %}
+    {% fieldset form.is_small_business %}
+    {% fieldset form.contractor_site %}
+
+    <div class="date-range {% if form.contract_start.errors or form.contract_end.errors%}fieldset-error{% endif %}">
+      {% fieldset form.contract_start %}
+      <p>to</p>
+      {% fieldset form.contract_end %}
+    </div>
+
+    {% fieldset form.escalation_rate %}
+  {% endwith %}
+</div>
+
+{% if not show_edit_form %}
+<div data-contract-details>
 <div class="row">
   <dl class="contract-details columns eight">
     <dt>Vendor</dt>
@@ -41,6 +70,12 @@
   </dl>
 </div>
 
+{# TODO: This should include any existing querystring args. #}
+
+<p><a href="?show_edit_form=on" class="button" data-edit-btn>Edit</a></p>
+</div>
+{% endif %}
+
 {% if not is_preferred_schedule %}
   <div class="row">
     <div class="columns eight">
@@ -56,9 +91,16 @@
   </div>
 {% endif %}
 
+<br>
 
-<form method="post">
-  {% csrf_token %}
+{% with rows=gleaned_data.valid_rows %}
+  {% with total=rows|length %}
+    <h2>Verify {{ total }} row{{ total|pluralize }} of data </h2>
+  {% endwith %}
+
+  {{ gleaned_data.to_table|safe }}
+{% endwith %}
+
   <div class="form-button-row clearfix">
     {% if prev_url %}
       <a href="{{ prev_url }}" class="button button-previous">Previous</a>
@@ -80,5 +122,29 @@
     <button type="submit" class="button-link" name="cancel" data-a11y-dialog-show="cancel-dialog" formnovalidate>Cancel</button>
   </div>
 </form>
+
+{% if not is_safe_mode_enabled %}
+<script>
+$(function() {
+  var editBtn = $('[data-edit-btn]');
+  var contractDetails = $("[data-contract-details]");
+  var editContractDetails = $("[data-edit-contract-details]");
+
+  if (editBtn.length && contractDetails.length &&
+      editContractDetails.length) {
+    editBtn.click(function(e) {
+      contractDetails.slideUp();
+      editContractDetails.slideDown();
+      e.preventDefault();
+    });
+  } else {
+    console.log(
+      "Warning! Couldn't find edit button and/or related elements, " +
+      "falling back to baseline behavior."
+    );
+  }
+});
+</script>
+{% endif %}
 
 {% endblock %}

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -14,8 +14,6 @@
 
   {{ form.non_field_errors }}
 
-  {# TODO: Maybe reuse view logic from steps 1 and 2 here to stay DRY? #}
-
   {% load frontend %}
 
   {{ form.schedule }}

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -128,30 +128,8 @@
 </form>
 
 {% if not is_safe_mode_enabled and not show_edit_form %}
-<script>
-$(function() {
-  var editBtn = $('[data-edit-btn]');
-  var contractDetails = $("[data-contract-details]");
-  var editContractDetails = $("[data-edit-contract-details]");
-
-  if (editBtn.length && contractDetails.length &&
-      editContractDetails.length) {
-    editBtn.click(function(e) {
-      contractDetails.slideUp();
-      editContractDetails.slideDown();
-      $('[data-edit-text]').each(function() {
-        $(this).text($(this).attr('data-edit-text'));
-      });
-      e.preventDefault();
-    });
-  } else {
-    console.log(
-      "Warning! Couldn't find edit button and/or related elements, " +
-      "falling back to baseline behavior."
-    );
-  }
-});
-</script>
+{% load staticfiles %}
+<script src= "{% static 'frontend/built/js/data-capture-price-list-upload-step-4/index.min.js' %}"></script>
 {% endif %}
 
 {% endblock %}

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -12,33 +12,26 @@
 
 <div data-edit-contract-details {% if not show_edit_form %}style="display: none"{% endif %}>
 
-  {{ step_1_form.non_field_errors }}
-  {{ step_2_form.non_field_errors }}
+  {{ form.non_field_errors }}
 
   {# TODO: Maybe reuse view logic from steps 1 and 2 here to stay DRY? #}
 
   {% load frontend %}
 
-  {% with form=step_1_form %}
-    {# TODO: It'd be nice if we could just eliminate this field. #}
-    <div style="display: none">{% fieldset form.schedule %}</div>
+  {{ form.schedule }}
 
-    {% fieldset form.contract_number %}
-    {% fieldset form.vendor_name %}
-  {% endwith %}
+  {% fieldset form.contract_number %}
+  {% fieldset form.vendor_name %}
+  {% fieldset form.is_small_business %}
+  {% fieldset form.contractor_site %}
 
-  {% with form=step_2_form %}
-    {% fieldset form.is_small_business %}
-    {% fieldset form.contractor_site %}
+  <div class="date-range {% if form.contract_start.errors or form.contract_end.errors%}fieldset-error{% endif %}">
+    {% fieldset form.contract_start %}
+    <p>to</p>
+    {% fieldset form.contract_end %}
+  </div>
 
-    <div class="date-range {% if form.contract_start.errors or form.contract_end.errors%}fieldset-error{% endif %}">
-      {% fieldset form.contract_start %}
-      <p>to</p>
-      {% fieldset form.contract_end %}
-    </div>
-
-    {% fieldset form.escalation_rate %}
-  {% endwith %}
+  {% fieldset form.escalation_rate %}
 
   <div class="form-button-row clearfix">
     <div class="submit-group">

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -112,10 +112,17 @@
 
     {% if gleaned_data.valid_rows %}
       <div class="submit-group">
-        <button type="submit" class="button-primary">Submit for review</button>
-        <span class="submit-label">
-          Submit price list data to an administrator for approval.
-        </span>
+        {% if show_edit_form %}
+          <button type="submit" class="button-primary">Save and submit for review</button>
+          <span class="submit-label">
+            Save changes and submit price list data to an administrator for approval.
+          </span>
+        {% else %}
+          <button type="submit" class="button-primary" data-edit-text="Save and submit for review">Submit for review</button>
+          <span class="submit-label" data-edit-text="Save changes and submit price list data to an administrator for approval.">
+            Submit price list data to an administrator for approval.
+          </span>
+        {% endif %}
       </div>
     {% endif %}
 
@@ -123,7 +130,7 @@
   </div>
 </form>
 
-{% if not is_safe_mode_enabled %}
+{% if not is_safe_mode_enabled and not show_edit_form %}
 <script>
 $(function() {
   var editBtn = $('[data-edit-btn]');
@@ -135,6 +142,9 @@ $(function() {
     editBtn.click(function(e) {
       contractDetails.slideUp();
       editContractDetails.slideDown();
+      $('[data-edit-text]').each(function() {
+        $(this).text($(this).attr('data-edit-text'));
+      });
       e.preventDefault();
     });
   } else {

--- a/data_capture/tests/test_price_list_upload_views.py
+++ b/data_capture/tests/test_price_list_upload_views.py
@@ -419,6 +419,7 @@ class Step4Tests(PriceListStepTestCase,
         session.save()
         self.set_fake_gleaned_data(self.rows)
         res = self.client.get(self.url)
+        self.assertFalse(res.context['show_edit_form'])
         self.assertEqual(res.status_code, 200)
 
     def test_context_has_prev_url_if_query_param_present(self):
@@ -501,6 +502,7 @@ class Step4Tests(PriceListStepTestCase,
         data = self.valid_post_data.copy()
         data['contractor_site'] = 'LOL'
         res = self.client.post(self.url, data)
+        self.assertTrue(res.context['show_edit_form'])
         self.assertContains(res, 'LOL is not one of the available choices')
 
     def test_valid_post_creates_models(self):

--- a/data_capture/tests/test_price_list_upload_views.py
+++ b/data_capture/tests/test_price_list_upload_views.py
@@ -408,6 +408,10 @@ class Step4Tests(PriceListStepTestCase,
         'step_2_POST': Step2Tests.valid_form,
     }
 
+    valid_post_data = {}
+    valid_post_data.update(Step1Tests.valid_form)
+    valid_post_data.update(Step2Tests.valid_form)
+
     def test_get_is_ok(self):
         self.login()
         session = self.client.session
@@ -473,7 +477,7 @@ class Step4Tests(PriceListStepTestCase,
         session['data_capture:price_list'] = self.session_data
         session.save()
         self.set_fake_gleaned_data(self.rows)
-        self.client.post(self.url)
+        self.client.post(self.url, self.valid_post_data)
         p = SubmittedPriceList.objects.filter(
             contract_number='GS-123-4567'
         )[0]
@@ -492,7 +496,7 @@ class Step4Tests(PriceListStepTestCase,
         session['data_capture:price_list'] = self.session_data
         session.save()
         self.set_fake_gleaned_data(self.rows)
-        res = self.client.post(self.url)
+        res = self.client.post(self.url, self.valid_post_data)
         assert 'data_capture:price_list' not in self.client.session
         self.assertRedirects(res, Step5Tests.url)
 

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -299,6 +299,10 @@ def step_4(request, step):
     if request.method == 'POST':
         if form.is_valid():
             if 'save-changes' in request.POST:
+                # There's not a particularly easy way to separate one
+                # step's fields from another, but fortunately that's OK
+                # because Django's Form constructors take only the POST
+                # data they need, and ignore the rest.
                 session_pl['step_1_POST'] = request.POST
                 session_pl['step_2_POST'] = request.POST
 

--- a/frontend/source/js/data-capture-price-list-upload-step-4/index.js
+++ b/frontend/source/js/data-capture-price-list-upload-step-4/index.js
@@ -1,0 +1,23 @@
+/* global jQuery */
+
+const $ = jQuery;
+const editBtn = $('[data-edit-btn]');
+const contractDetails = $('[data-contract-details]');
+const editContractDetails = $('[data-edit-contract-details]');
+
+if (editBtn.length && contractDetails.length &&
+    editContractDetails.length) {
+  editBtn.click(e => {
+    contractDetails.slideUp();
+    editContractDetails.slideDown();
+    $('[data-edit-text]').each((_, el) => {
+      $(el).text($(el).attr('data-edit-text'));
+    });
+    e.preventDefault();
+  });
+} else {
+  throw new Error(
+    'Warning! Couldn\'t find edit button and/or related elements, ' +
+    'falling back to baseline behavior.'
+  );
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ const bundles = {
     dirName: 'data-capture',
   },
   dataCapturePriceListUploadStep4: {
-    dirName: 'data-capture-price-list-upload-step-4'
+    dirName: 'data-capture-price-list-upload-step-4',
   },
   // Styleguide scripts
   styleguide: {},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,6 +74,9 @@ const bundles = {
   dataCapture: {
     dirName: 'data-capture',
   },
+  dataCapturePriceListUploadStep4: {
+    dirName: 'data-capture-price-list-upload-step-4'
+  },
   // Styleguide scripts
   styleguide: {},
   // CALC 2.0 Tests


### PR DESCRIPTION
This attempts to add an **Edit** button below the vendor and contract details section of step 4 of price list upload.

If the user is in safe mode (or doesn't have JS) they are sent to a version of the page with an edit form on it.  Otherwise, the vendor/contract details slide up and are replaced by a form:

> ![expandable-area2](https://cloud.githubusercontent.com/assets/124687/20397077/6464f0a0-acb6-11e6-9c19-bdf2d30a59e6.gif)

If the user submits anything invalid, they are re-shown step 4 with the edit form already displayed and the appropriate error(s) highlighted.

Otherwise, If their changes are valid, the price list is submitted and the user moves to step 5. (We could potentially change this to re-show step 4 without the edit form, so that the user is forced to re-verify that everything looks OK.)

To do:

- [x] Verify with @hbillings that this is actually what she wanted.
- [x] Add tests.
- [x] Fix any broken tests.
- [x] ~~Possibly move the JS out of an inline jQuery-powered `<script>` tag. I could turn it into an actual web component but I'm not sure what the best plan for actually making it reusable is...~~ Mehh, unless someone else feels really strongly about this I am gonna just leave it as-is. See my [rationale](https://github.com/18F/calc/pull/1043#discussion_r88679802) for why I think it's OK to not treat this the way we treat some of our other production JS.
- [x] Make sure that the edit form lists fields in the same order as the summary it's replacing (it doesn't currently).
- [x] Make sure the "previous" button still goes where the user expects it to, even during POST requests with invalid data. Urgh. Or just file it as an issue to be dealt with later.
