### PR TITLE
Add a selenium test for data capture.

### DIFF
--- a/data_capture/tests/test_selenium.py
+++ b/data_capture/tests/test_selenium.py
@@ -48,7 +48,7 @@ urlpatterns += [
 class DataCaptureTests(SeleniumTestCase):
     screenshot_filename = 'data_capture.png'
 
-    def test_awesome(self):
+    def test_data_capture(self):
         registry._init()
         call_command('initgroups', stdout=io.StringIO())
         t = BaseLoginTestCase()
@@ -65,4 +65,22 @@ class DataCaptureTests(SeleniumTestCase):
             .send_keys('GS-123-4567')
         e = self.driver.find_element_by_name('vendor_name')
         e.send_keys('Battaglia Sausage Peddlers, Inc.')
+        e.submit()
+
+        self.driver.find_element_by_css_selector(
+            '[for="id_is_small_business_0"]'
+        ).click()
+
+        self.driver.find_element_by_css_selector(
+            '[for="id_contractor_site_2"]'
+        ).click()
+
+        self.driver.find_element_by_name('contract_start_1').send_keys('04')
+        self.driver.find_element_by_name('contract_start_2').send_keys('28')
+        self.driver.find_element_by_name('contract_start_0').send_keys('2016')
+
+        self.driver.find_element_by_name('contract_end_1').send_keys('03')
+        self.driver.find_element_by_name('contract_end_2').send_keys('27')
+        e = self.driver.find_element_by_name('contract_end_0')
+        e.send_keys('2017')
         e.submit()

--- a/data_capture/tests/test_selenium.py
+++ b/data_capture/tests/test_selenium.py
@@ -1,0 +1,68 @@
+import io
+import django.contrib.auth
+from django.conf.urls import url
+from django.test import override_settings
+from django.http import HttpResponse
+from django.core.management import call_command
+
+from hourglass.urls import urlpatterns
+from hourglass.tests.common import BaseLoginTestCase
+from data_capture.tests.common import FAKE_SCHEDULE
+from data_capture.schedules import registry
+from frontend.tests.test_selenium import SeleniumTestCase
+from frontend import safe_mode
+
+
+USERNAME = 'boop'
+PASSWORD = 'passwordy'
+
+
+def autologin(request):
+    user = django.contrib.auth.authenticate(
+        username=USERNAME,
+        password=PASSWORD
+    )
+    if user is None:
+        raise Exception('Unable to authenticate')
+    django.contrib.auth.login(request, user)
+    request.session[safe_mode.SESSION_KEY] = True
+    return HttpResponse('{} is now logged in'.format(
+        user.email
+    ))
+
+
+urlpatterns += [
+    url(r'^autologin/$', autologin),
+]
+
+
+@override_settings(
+    ROOT_URLCONF=__name__,
+    DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE],
+    # This will make tests run faster.
+    PASSWORD_HASHERS=['django.contrib.auth.hashers.MD5PasswordHasher'],
+    # Ignore our custom auth backend so we can log the user in via
+    # Django 1.8's login helpers.
+    AUTHENTICATION_BACKENDS=['django.contrib.auth.backends.ModelBackend'],
+)
+class DataCaptureTests(SeleniumTestCase):
+    screenshot_filename = 'data_capture.png'
+
+    def test_awesome(self):
+        registry._init()
+        call_command('initgroups', stdout=io.StringIO())
+        t = BaseLoginTestCase()
+        t.create_user(
+            username=USERNAME,
+            password=PASSWORD,
+            email='boop.jones@gsa.gov',
+            groups=('Data Administrators',)
+        )
+        self.load('/autologin')
+        self.load('/data-capture/step/1')
+
+        self.driver.find_element_by_name('contract_number')\
+            .send_keys('GS-123-4567')
+        e = self.driver.find_element_by_name('vendor_name')
+        e.send_keys('Battaglia Sausage Peddlers, Inc.')
+        e.submit()

--- a/data_capture/tests/test_selenium.py
+++ b/data_capture/tests/test_selenium.py
@@ -7,8 +7,9 @@ from django.core.management import call_command
 
 from hourglass.urls import urlpatterns
 from hourglass.tests.common import BaseLoginTestCase
-from data_capture.tests.common import FAKE_SCHEDULE
+from data_capture.tests.common import FAKE_SCHEDULE, FAKE_SCHEDULE_EXAMPLE_PATH
 from data_capture.schedules import registry
+from data_capture.models import SubmittedPriceList
 from frontend.tests.test_selenium import SeleniumTestCase
 from frontend import safe_mode
 
@@ -52,11 +53,11 @@ class DataCaptureTests(SeleniumTestCase):
         registry._init()
         call_command('initgroups', stdout=io.StringIO())
         t = BaseLoginTestCase()
-        t.create_user(
+        user = t.create_user(
             username=USERNAME,
             password=PASSWORD,
             email='boop.jones@gsa.gov',
-            groups=('Data Administrators',)
+            groups=('Contract Officers',)
         )
         self.load('/autologin')
         self.load('/data-capture/step/1')
@@ -84,3 +85,27 @@ class DataCaptureTests(SeleniumTestCase):
         e = self.driver.find_element_by_name('contract_end_0')
         e.send_keys('2017')
         e.submit()
+
+        e = self.driver.find_element_by_name('file')
+        e.send_keys(FAKE_SCHEDULE_EXAMPLE_PATH)
+        e.submit()
+
+        self.driver.find_element_by_css_selector('.button-primary').submit()
+
+        p = SubmittedPriceList.objects.all()[0]
+        self.assertEqual(p.contract_number, 'GS-123-4567')
+        self.assertEqual(p.vendor_name, 'Battaglia Sausage Peddlers, Inc.')
+        self.assertEqual(p.is_small_business, True)
+        self.assertEqual(p.contractor_site, 'Both')
+        self.assertEqual(p.contract_start.year, 2016)
+        self.assertEqual(p.contract_start.month, 4)
+        self.assertEqual(p.contract_start.day, 28)
+        self.assertEqual(p.contract_end.year, 2017)
+        self.assertEqual(p.contract_end.month, 3)
+        self.assertEqual(p.contract_end.day, 27)
+        self.assertEqual(p.escalation_rate, 0)
+        self.assertEqual(p.submitter, user)
+        self.assertEqual(p.schedule, FAKE_SCHEDULE)
+
+        r = p.rows.all()[0]
+        self.assertEqual(r.labor_category, 'Project Manager')


### PR DESCRIPTION
This adds a single selenium test for data capture, which goes through the whole data capture workflow by uploading the example CSV for the fake schedule. It shouldn't run into any weird race conditions because it's doing everything in compatibility mode, so all the progressive enhancement is disabled.

To use it:

1. Run `python manage.py test data_capture.tests.test_selenium`.
2. Once you've run that once, you can add `SKIP_STATIC_ASSET_BUILDING=yup` to your `.env`, which will speed things up a lot if you're just tinkering with stuff on the python side.
