### PR TITLE
Support fake filenames in upload widget

### DIFF
--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -157,23 +157,6 @@ class UploadWidget extends window.HTMLElement {
     let dragCounter = 0;
     let lastDragEnterTarget = null;
 
-    const finishInitialization = () => {
-      if (this.uploadInput instanceof UploadInput) {
-        if (!this.isDegraded) {
-          this.uploadInput.upgrade();
-
-          const fakeInitialFilename = $el.attr('data-fake-initial-filename');
-
-          if (fakeInitialFilename) {
-            setCurrentFilename(fakeInitialFilename);  // eslint-disable-line
-          }
-        }
-        dispatchBubbly($el[0], 'uploadwidgetready');
-      } else {
-        $el.one('uploadinputready', finishInitialization);
-      }
-    };
-
     function setCurrentFilename(filename) {
       $('input', $el).nextAll().remove();
 
@@ -189,6 +172,23 @@ class UploadWidget extends window.HTMLElement {
       $('.upload-filename', current).text(filename);
       $el.append(current);
     }
+
+    const finishInitialization = () => {
+      if (this.uploadInput instanceof UploadInput) {
+        if (!this.isDegraded) {
+          this.uploadInput.upgrade();
+
+          const fakeInitialFilename = $el.attr('data-fake-initial-filename');
+
+          if (fakeInitialFilename) {
+            setCurrentFilename(fakeInitialFilename);
+          }
+        }
+        dispatchBubbly($el[0], 'uploadwidgetready');
+      } else {
+        $el.one('uploadinputready', finishInitialization);
+      }
+    };
 
     function showInvalidFileMessage() {
       $('input', $el).nextAll().remove();

--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -161,6 +161,12 @@ class UploadWidget extends window.HTMLElement {
       if (this.uploadInput instanceof UploadInput) {
         if (!this.isDegraded) {
           this.uploadInput.upgrade();
+
+          const fakeInitialFilename = $el.attr('data-fake-initial-filename');
+
+          if (fakeInitialFilename) {
+            setCurrentFilename(fakeInitialFilename);  // eslint-disable-line
+          }
         }
         dispatchBubbly($el[0], 'uploadwidgetready');
       } else {

--- a/frontend/source/js/tests/upload_tests.js
+++ b/frontend/source/js/tests/upload_tests.js
@@ -11,7 +11,7 @@ import { UploadWidget } from '../data-capture/upload';
   let upload;
   let input;
 
-  function makeWidget(isDegraded, cb) {
+  function makeWidget(isDegraded, cb, options = {}) {
     const div = document.createElement('div');
 
     $parentDiv = $(div);
@@ -30,6 +30,11 @@ import { UploadWidget } from '../data-capture/upload';
     // could synchronously upgrade the elements.
     div.innerHTML = UPLOAD_HTML;
 
+    if (options.fakeInitialFilename) {
+      $('upload-widget', div).attr('data-fake-initial-filename',
+                                   options.fakeInitialFilename);
+    }
+
     // This will cause the attached/connected callbacks (depending on
     // version of custom elements spec) to be triggered.
     document.body.appendChild(div);
@@ -46,7 +51,7 @@ import { UploadWidget } from '../data-capture/upload';
     });
   }
 
-  function advancedTest(name, cb) {
+  function advancedTest(name, cb, options = {}) {
     if (!UploadWidget.HAS_BROWSER_SUPPORT) {
       return QUnit.skip(name, cb);
     }
@@ -56,7 +61,7 @@ import { UploadWidget } from '../data-capture/upload';
       makeWidget(false, () => {
         cb(assert);
         done();
-      });
+      }, options);
     });
   }
 
@@ -137,6 +142,16 @@ import { UploadWidget } from '../data-capture/upload';
 
   advancedTest('advanced upload sets aria-live', (assert) => {
     assert.equal(upload.attr('aria-live'), 'polite');
+  });
+
+  advancedTest('advanced upload sets fake filename if provided', (assert) => {
+    assert.equal(upload.find('.upload-filename').text(), 'boop.csv');
+  }, {
+    fakeInitialFilename: 'boop.csv',
+  });
+
+  advancedTest('advanced upload does not set filename by default', (assert) => {
+    assert.equal(upload.find('.upload-filename').text(), '');
   });
 
   advancedTest('advanced upload does not allow non-accepted file types', (assert) => {

--- a/frontend/source/sass/components/_upload.scss
+++ b/frontend/source/sass/components/_upload.scss
@@ -3,7 +3,6 @@
 upload-widget {
   margin: 3rem 0;
   display: flex;
-  height: 6em;
   position: relative;
   align-items: center;
   padding: 0 3em;
@@ -55,6 +54,12 @@ upload-widget {
 
 // Rules specific to JS-upgraded widgets.
 upload-widget[aria-live] {
+  height: 6em;
+
+  .nojs-preamble {
+    display: none;
+  }
+
   input {
     width: 0.1px;
     height: 0.1px;
@@ -70,6 +75,8 @@ upload-widget:not([aria-live]) {
   font-size: 1.3rem;
   display: block;
   border: none;
+  padding-top: 1em;
+  padding-bottom: 1em;
 
   input {
     border: none;

--- a/frontend/tests/test_upload.py
+++ b/frontend/tests/test_upload.py
@@ -1,0 +1,16 @@
+from django.test import SimpleTestCase
+
+from ..upload import UploadWidget
+
+
+class UploadWidgetTests(SimpleTestCase):
+    def test_error_raised_if_required_and_existing_filename(self):
+        uw = UploadWidget(existing_filename='boop.csv')
+        with self.assertRaises(AssertionError):
+            uw.render('a', 'b')
+
+    def test_existing_filename_works(self):
+        uw = UploadWidget(existing_filename='boop.csv', required=False)
+        html = uw.render('a', 'b')
+        assert "You've already uploaded" in html
+        assert 'data-fake-initial-filename="boop.csv"' in html

--- a/frontend/upload.py
+++ b/frontend/upload.py
@@ -44,6 +44,7 @@ class UploadWidget(forms.widgets.FileInput):
         if self.degraded:
             widget_attrs['data-force-degradation'] = ''
 
+        nojs_preamble = ''
         if self.existing_filename:
             if 'required' in final_attrs:
                 raise AssertionError(
@@ -51,15 +52,17 @@ class UploadWidget(forms.widgets.FileInput):
                     'the "required" attribute'
                 )
             widget_attrs['data-fake-initial-filename'] = self.existing_filename
-            instructions.append(
-                'Leave this field blank to continue using '
-                '<code>{}</code>.'.format(
+            nojs_preamble = (
+                'You\'ve already uploaded '
+                '<code>{}</code>. '.format(
                     escape(self.existing_filename)
-                )
+                ) +
+                'You can keep using it or select a new file to replace it.'
             )
 
         return "\n".join([
             '<upload-widget%s>' % flatatt(widget_attrs),
+            '  <span class="nojs-preamble">%s</span>' % nojs_preamble,
             '  %s' % super().render(name, value, final_attrs),
             '  <div class="upload-chooser">',
             '    <label for="%s">Choose file</label>' % id_for_label,

--- a/frontend/upload.py
+++ b/frontend/upload.py
@@ -37,8 +37,6 @@ class UploadWidget(forms.widgets.FileInput):
         final_attrs['is'] = 'upload-input'
 
         id_for_label = final_attrs.get('id', '')
-        instructions = [self.extra_instructions or '']
-
         widget_attrs = {}
 
         if self.degraded:
@@ -66,7 +64,7 @@ class UploadWidget(forms.widgets.FileInput):
             '  %s' % super().render(name, value, final_attrs),
             '  <div class="upload-chooser">',
             '    <label for="%s">Choose file</label>' % id_for_label,
-            '    <span>%s</span>' % ' '.join(instructions),
+            '    <span>%s</span>' % self.extra_instructions,
             '  </div>',
             '</upload-widget>'
         ])

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -146,6 +146,52 @@
     </div>
   </div>
 
+  <h3>Existing Filenames</h3>
+
+  <p>
+    In some cases, it may be preferable to indicate to a user that a
+    file upload field is not only optional, but that a default which
+    the user has uploaded earlier will be used if nothing else is
+    provided.
+  </p>
+
+  <expandable-area>
+    <h4>Examples</h4>
+
+    <p>
+      The baseline experience simply explains to the user that leaving
+      the field blank will result in the use of their previously-uploaded
+      file.
+    </p>
+
+    <div class="styleguide-example">
+      <div class="rendering">
+        <h3 class="example-heading">Example (no JavaScript)</h3>
+        {{ existing_filename_upload_form.no_js }}
+      </div>
+    </div>
+
+    <p>
+      The server, of course, will not receive any data if the user
+      doesn't supply a file. Finding and using the previously uploaded
+      file is the server's responsibility.
+    </p>
+
+    <p>
+      However, if proper browser support exists, the user experience is
+      progressively enhanced: the widget will <em>appear</em> populated,
+      but as with the baseline experience, the server will not actually
+      receive any data unless the user explicitly chooses a different file.
+    </p>
+
+    <div class="styleguide-example">
+      <div class="rendering">
+        <h3 class="example-heading">Example</h3>
+        {{ existing_filename_upload_form.js }}
+      </div>
+    </div>
+  </expandable-area>
+
   {% guide_section "Buttons" %}
 
   <p>

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -12,9 +12,25 @@ def get_degraded_upload_widget():
     return MyForm()['file']
 
 
+def get_existing_filename_upload_form():
+    class MyForm(forms.Form):
+        js = forms.FileField(widget=UploadWidget(
+            required=False,
+            existing_filename='boop.csv',
+        ))
+        no_js = forms.FileField(widget=UploadWidget(
+            degraded=True,
+            required=False,
+            existing_filename='boop.csv',
+        ))
+
+    return MyForm()
+
+
 def index(request):
     ctx = {
-        'degraded_upload_widget': get_degraded_upload_widget()
+        'degraded_upload_widget': get_degraded_upload_widget(),
+        'existing_filename_upload_form': get_existing_filename_upload_form(),
     }
     ctx.update(ajaxform_example.create_template_context())
     ctx.update(date_example.create_template_context())


### PR DESCRIPTION
As per yesterday's coworking discussion, this PR provides functionality that allows a progressively-enhanced upload widget to *appear* to be "pre-populated" on page load, with a fallback for the baseline experience:

> ![screen shot 2016-11-23 at 7 47 07 am](https://cloud.githubusercontent.com/assets/124687/20562395/597eefde-b151-11e6-8023-618da0240e55.png)

Note that this PR does *not* actually use this functionality anywhere yet (other than the styleguide). That comes in a later PR!

To do:

- [x] Ensure w/ the rest of the team that this is acceptable behavior.
- [x] Get rid of the `eslint-disable-line` in the code.
- [x] Maybe add a JS-side unit test.
- [x] Maybe add a python-side unit test.
- [x] Since there's more copy in the baseline version of the widget, if the user's screen is narrow or the filename is really long, the content can overflow the widget, which currently has a fixed height of 6em. We might want ameliorate the CSS.
