### PR TITLE
Add nonce-based CSP to index page only

### DIFF
--- a/data_explorer/templates/base.html
+++ b/data_explorer/templates/base.html
@@ -11,7 +11,7 @@
     <script src="{% static 'frontend/js/vendor/history.min.js' %}"></script>
     <![endif]-->
 
-    <script>
+    <script {{ csp_nonce }}>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="{% static 'frontend/built/style/main.min.css' %}"/>
 
     <![if gt IE 8]>
-    <script>
+    <script {{ csp_nonce }}>
       var API_HOST = "{{ API_HOST }}";
     </script>
 
@@ -117,7 +117,7 @@
       {% endif %}
 
       <![if gt IE 8]>
-      <script>
+      <script {{ csp_nonce }}>
         if (typeof aight === 'object') {
           d3.select('body')
             .classed('ie', true)

--- a/data_explorer/templates/index.html
+++ b/data_explorer/templates/index.html
@@ -8,7 +8,7 @@
 
 <!--[if IE 9]>
   <script src="{% static 'frontend/js/vendor/vex.combined.min.js' %}"></script>
-  <script>vex.defaultOptions.className = 'vex-theme-default';</script>
+  <script {{ csp_nonce }}>vex.defaultOptions.className = 'vex-theme-default';</script>
   <link rel="stylesheet" href="{% static 'frontend/style/vendor/vex.css' %}" />
   <link rel="stylesheet" href="{% static 'frontend/style/vendor/vex-theme-default.css' %}" />
 <![endif]-->

--- a/data_explorer/views.py
+++ b/data_explorer/views.py
@@ -14,9 +14,17 @@ def index(request):
     response = render(request, 'index.html', {
         'csp_nonce': mark_safe('nonce="{}"'.format(csp_nonce))
     })
+    script_src = ' '.join([
+        "'self'",
+        "*.googleapis.com",
+        "dap.digitalgov.gov",
+        "www.google-analytics.com",
+        "'unsafe-inline'",
+        "'nonce-{}'".format(csp_nonce)
+    ])
     response['Content-Security-Policy'] = '; '.join([
         "default-src *",
-        "script-src * 'unsafe-inline' 'nonce-{}'".format(csp_nonce),
+        "script-src {}".format(script_src),
         "style-src * 'unsafe-inline'",
         "img-src * data:",
     ])

--- a/data_explorer/views.py
+++ b/data_explorer/views.py
@@ -19,6 +19,7 @@ def index(request):
         "*.googleapis.com",
         "dap.digitalgov.gov",
         "www.google-analytics.com",
+        "ethn.io",
         # Browsers that don't support CSP v2 need this to work.
         "'unsafe-inline'",
         # For browsers that *do* support CSP v2, the following will

--- a/data_explorer/views.py
+++ b/data_explorer/views.py
@@ -1,7 +1,23 @@
 from django.shortcuts import render
+from django.utils.safestring import mark_safe
+from django.utils.crypto import get_random_string
 
 
 def about(request):
     return render(request, 'about.html', {
         'current_selected_tab': 'about'
     })
+
+
+def index(request):
+    csp_nonce = get_random_string(length=10)
+    response = render(request, 'index.html', {
+        'csp_nonce': mark_safe('nonce="{}"'.format(csp_nonce))
+    })
+    response['Content-Security-Policy'] = '; '.join([
+        "default-src *",
+        "script-src * 'unsafe-inline' 'nonce-{}'".format(csp_nonce),
+        "style-src * 'unsafe-inline'",
+        "img-src * data:",
+    ])
+    return response

--- a/data_explorer/views.py
+++ b/data_explorer/views.py
@@ -19,7 +19,10 @@ def index(request):
         "*.googleapis.com",
         "dap.digitalgov.gov",
         "www.google-analytics.com",
+        # Browsers that don't support CSP v2 need this to work.
         "'unsafe-inline'",
+        # For browsers that *do* support CSP v2, the following will
+        # override our earlier 'unsafe-inline' directive.
         "'nonce-{}'".format(csp_nonce)
     ])
     response['Content-Security-Policy'] = '; '.join([

--- a/frontend/templates/frontend/safe_mode/script_tag.html
+++ b/frontend/templates/frontend/safe_mode/script_tag.html
@@ -1,5 +1,5 @@
 {% if not is_safe_mode_enabled %}
-<script>
+<script {{ csp_nonce }}>
 {% include 'frontend/safe_mode/script.js' %}
 </script>
 {% endif %}

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     # Examples:
     # url(r'^$', 'hourglass.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
-    url(r'^$', TemplateView.as_view(template_name='index.html'), name='index'),
+    url(r'^$', 'data_explorer.views.index', name='index'),
     url(r'^about/$', 'data_explorer.views.about', name='about'),
     url(r'^safe-mode/', include('frontend.safe_mode', namespace='safe_mode')),
     url(r'^healthcheck/', healthcheck),


### PR DESCRIPTION
This is a quick fix that adds some basic defense in-depth to mitigate any latent XSS vulnerabilities in the data explorer index page *only* (e.g. #1060).  It's a very broad CSP rule that basically allows anything except scripts that we "bless"--specifically, ones that originate from us/DAP/ethnio/GA and inline scripts that we've added a `nonce` attribute to.

The CSP doesn't actually do anything particularly helpful on IE or Edge or any [other](http://caniuse.com/#feat=contentsecuritypolicy2) browsers that only support CSP version 1, because it takes advantage of the [nonce-source](https://blog.mozilla.org/security/2014/10/04/csp-for-the-web-we-have/) feature of CSP 2 to make it easy for us to quickly add CSP without having to un-inline all our scripts.

Note that Firefox applies CSP directives to script elements injected by add-ons, so it might prevent some add-ons from working, and this could result in spurious error messages in the console. You can see these script elements by running the following in the web console:

```js
document.querySelectorAll('script:not([src]):not([nonce])');
```

To do:

- [x] ~~I think that this might mess up the Django Debug Toolbar (on the index page only) because it might have some inline scripts in it. Need to check.~~ Nope, DjDT doesn't include any inline scripts.
