### PR TITLE
make eslint ensure import statements are valid.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb-base",
   "rules": {
-    "no-underscore-dangle": ["error", { "allowAfterThis": true }]
+    "no-underscore-dangle": ["error", { "allowAfterThis": true }],
+    "import/named": 2
   }
 }

--- a/frontend/source/js/data-capture/ajaxform.js
+++ b/frontend/source/js/data-capture/ajaxform.js
@@ -6,7 +6,7 @@ import * as supports from './feature-detection';
 
 import ga from '../common/ga';
 
-import { dispatchBubbly } from './custom-event';
+import dispatchBubbly from './custom-event';
 
 const $ = jQuery;
 

--- a/frontend/source/js/data-capture/alerts.js
+++ b/frontend/source/js/data-capture/alerts.js
@@ -1,6 +1,6 @@
 /* global window, document */
 
-import { dispatchBubbly } from './custom-event';
+import dispatchBubbly from './custom-event';
 
 /**
  * AlertsWidget represents an <alerts-widget> web component.

--- a/frontend/source/js/data-capture/custom-event.js
+++ b/frontend/source/js/data-capture/custom-event.js
@@ -30,8 +30,8 @@ if (typeof window.CustomEvent !== 'function') {
   window.CustomEvent = CustomEvent;
 }
 
-exports.dispatchBubbly = (el, eventType, params) => {
+export default function dispatchBubbly(el, eventType, params) {
   el.dispatchEvent(new window.CustomEvent(eventType, Object.assign({
     bubbles: true,
   }, params || {})));
-};
+}

--- a/frontend/source/js/data-capture/expandable-area.js
+++ b/frontend/source/js/data-capture/expandable-area.js
@@ -6,7 +6,7 @@ import * as supports from './feature-detection';
 
 import ga from '../common/ga';
 
-import { dispatchBubbly } from './custom-event';
+import dispatchBubbly from './custom-event';
 
 const KEY_SPACE = 32;
 const KEY_ENTER = 13;

--- a/frontend/source/js/data-capture/upload.js
+++ b/frontend/source/js/data-capture/upload.js
@@ -4,7 +4,7 @@ import 'document-register-element';
 
 import * as supports from './feature-detection';
 
-import { dispatchBubbly } from './custom-event';
+import dispatchBubbly from './custom-event';
 
 const HAS_BROWSER_SUPPORT = supports.dragAndDrop() && supports.formData() &&
                             supports.dataTransfer();
@@ -19,7 +19,7 @@ const HAS_BROWSER_SUPPORT = supports.dragAndDrop() && supports.formData() &&
  * manually submit the `upgradedValue` to a server via ajax.
  */
 
-class UploadInput extends window.HTMLInputElement {
+export class UploadInput extends window.HTMLInputElement {
   createdCallback() {
     this.isUpgraded = false;
     this._upgradedValue = null;
@@ -121,7 +121,7 @@ document.registerElement('upload-input', {
  * submitting the dropped file via ajax.
  */
 
-class UploadWidget extends window.HTMLElement {
+export class UploadWidget extends window.HTMLElement {
   _stopAndPrevent(event) {
     event.stopPropagation();
     event.preventDefault();
@@ -268,6 +268,3 @@ UploadWidget.HAS_BROWSER_SUPPORT = HAS_BROWSER_SUPPORT;
 document.registerElement('upload-widget', {
   prototype: UploadWidget.prototype,
 });
-
-exports.UploadInput = UploadInput;
-exports.UploadWidget = UploadWidget;


### PR DESCRIPTION
Currently our eslint configuration doesn't ensure that `import` statements in our code are actually valid, so if we have e.g.:

```js
import nonExistentMethod from './util';
```

then eslint won't complain, and the code will actually run fine, until `nonExistentMethod` gets used somewhere, at which point it will be `undefined`.

This just enables an eslint rule to ensure that the `import` statements make sense, so our test suite will fail if they don't.  It also fixes some warnings raised by the addition of the new rule.