### PR TITLE
A few more data explorer refactorings

### DIFF
--- a/frontend/source/js/data-explorer/explorer.js
+++ b/frontend/source/js/data-explorer/explorer.js
@@ -233,6 +233,8 @@ function popstate() {
 }
 
 function initialize() {
+  initializeTable(form, submit);
+
   popstate();
 
   initializeAutocomplete(form, api, $('#labor_category'));
@@ -267,8 +269,6 @@ $('.tooltip').tooltipster({
     return $(this).attr('aria-label');
   },
 });
-
-initializeTable(form, submit);
 
 initialize();
 

--- a/frontend/source/js/data-explorer/explorer.js
+++ b/frontend/source/js/data-explorer/explorer.js
@@ -10,7 +10,6 @@ import hourglass from '../common/hourglass';
 import {
   location,
   getUrlParameterByName,
-  parseSortOrder,
   arrayToCSV,
   formatCommas,
   isNumberOrPeriodKey,
@@ -19,8 +18,7 @@ import {
 import {
   updateExcluded,
   updateResults,
-  updateSortOrder,
-  sortHeaders,
+  updateSort,
   initializeTable,
 } from './table';
 
@@ -229,18 +227,7 @@ function popstate() {
     submit(true);
   });
 
-  const sort = parseSortOrder(data.sort);
-  const sortable = (d) => d.sortable;
-  sortHeaders
-    .filter(sortable)
-    .classed('sorted', (d) => {
-      d.sorted = (d.key === sort.key); // eslint-disable-line no-param-reassign
-    })
-    .classed('descending', (d) => {
-      d.descending = (d.sorted && sort.order === '-'); // eslint-disable-line no-param-reassign
-    });
-
-  updateSortOrder(sort.key);
+  updateSort(data.sort);
 
   submit(false);
 }

--- a/frontend/source/js/data-explorer/histogram.js
+++ b/frontend/source/js/data-explorer/histogram.js
@@ -5,6 +5,11 @@ import {
   formatCommas,
 } from './util';
 
+const PRICE_HISTOGRAM = '#price-histogram';
+const AVG_PRICE_HIGHLIGHT = '#avg-price-highlight';
+const STDDEV_MINUS_HIGHLIGHT = '#standard-deviation-minus-highlight';
+const STDDEV_PLUS_HIGHLIGHT = '#standard-deviation-plus-highlight';
+
 const formatPrice = d3.format(',.0f');
 
 let histogramUpdated = false;
@@ -17,7 +22,7 @@ export default function updatePriceHistogram(data) {
   const left = pad[3];
   const right = width - pad[1];
   const bottom = height - pad[2];
-  const svg = d3.select('#price-histogram')
+  const svg = d3.select(PRICE_HISTOGRAM)
     .attr('viewBox', [0, 0, width, height].join(' '))
     .attr('preserveAspectRatio', 'xMinYMid meet');
   const formatDollars = (n) => `$${formatPrice(n)}`;
@@ -34,7 +39,7 @@ export default function updatePriceHistogram(data) {
       .domain([0].concat(countExtent))
       .range([0, 1, bottom - top]);
 
-  d3.select('#avg-price-highlight')
+  d3.select(AVG_PRICE_HIGHLIGHT)
     .text(formatDollars(data.average));
 
   let stdDevMin = data.average - data.first_standard_deviation;
@@ -43,10 +48,10 @@ export default function updatePriceHistogram(data) {
   if (isNaN(stdDevMin)) stdDevMin = 0;
   if (isNaN(stdDevMax)) stdDevMax = 0;
 
-  d3.select('#standard-deviation-minus-highlight')
+  d3.select(STDDEV_MINUS_HIGHLIGHT)
     .text(formatDollars(stdDevMin));
 
-  d3.select('#standard-deviation-plus-highlight')
+  d3.select(STDDEV_PLUS_HIGHLIGHT)
     .text(formatDollars(stdDevMax));
 
   let stdDev = svg.select('.stddev');
@@ -100,10 +105,10 @@ export default function updatePriceHistogram(data) {
   }
 
 
-  d3.select('#standard-deviation-minus-highlight')
+  d3.select(STDDEV_MINUS_HIGHLIGHT)
     .text(stdMinus);
 
-  d3.select('#standard-deviation-plus-highlight')
+  d3.select(STDDEV_PLUS_HIGHLIGHT)
     .text(stdPlus);
 
 

--- a/frontend/source/js/data-explorer/table.js
+++ b/frontend/source/js/data-explorer/table.js
@@ -1,7 +1,6 @@
 /* global $, d3, document */
 
 import {
-  parseSortOrder,
   formatCommas,
   getFormat,
 } from './util';
@@ -11,7 +10,7 @@ const RESTORE_EXCLUDED = '#restore-excluded';
 const RESULTS_COUNT = '#results-count';
 
 const resultsTable = d3.select(RESULTS_TABLE).style('display', 'none');
-export const sortHeaders = resultsTable.selectAll('thead th');
+const sortHeaders = resultsTable.selectAll('thead th');
 
 function getExcludedIds(form) {
   const str = form.get('exclude');
@@ -44,6 +43,24 @@ function excludeRow(form, id, submit) {
   }
   form.set('exclude', excluded.join(','));
   submit(true);
+}
+
+function parseSortOrder(order) {
+  if (!order) {
+    return { key: null, order: null };
+  }
+  const first = order.charAt(0);
+  const sort = { order: '' };
+  switch (first) {
+    case '-':
+      sort.order = first;
+      order = order.substr(1); // eslint-disable-line no-param-reassign
+      break;
+    default:
+      break;
+  }
+  sort.key = order;
+  return sort;
 }
 
 export function updateResults(form, data, submit) {
@@ -176,7 +193,7 @@ export function updateResults(form, data, submit) {
     });
 }
 
-export function updateSortOrder(key) {
+function updateSortOrder(key) {
   const title = (d) => {
     if (d.sorted) {
       const order = d.descending ? 'descending' : 'ascending';
@@ -258,4 +275,19 @@ export function setupColumnHeader(form, submit, headers) {
 
 export function initializeTable(form, submit) {
   sortHeaders.call(setupColumnHeader.bind(this, form, submit));
+}
+
+export function updateSort(unparsedSortData) {
+  const sort = parseSortOrder(unparsedSortData);
+  const sortable = (d) => d.sortable;
+  sortHeaders
+    .filter(sortable)
+    .classed('sorted', (d) => {
+      d.sorted = (d.key === sort.key); // eslint-disable-line no-param-reassign
+    })
+    .classed('descending', (d) => {
+      d.descending = (d.sorted && sort.order === '-'); // eslint-disable-line no-param-reassign
+    });
+
+  updateSortOrder(sort.key);
 }

--- a/frontend/source/js/data-explorer/table.js
+++ b/frontend/source/js/data-explorer/table.js
@@ -6,7 +6,11 @@ import {
   getFormat,
 } from './util';
 
-const resultsTable = d3.select('#results-table').style('display', 'none');
+const RESULTS_TABLE = '#results-table';
+const RESTORE_EXCLUDED = '#restore-excluded';
+const RESULTS_COUNT = '#results-count';
+
+const resultsTable = d3.select(RESULTS_TABLE).style('display', 'none');
 export const sortHeaders = resultsTable.selectAll('thead th');
 
 function getExcludedIds(form) {
@@ -23,7 +27,7 @@ export function updateExcluded(form) {
   const text = len > 0
         ? ['★ Restore', len, rows].join(' ')
         : '';
-  d3.select('#restore-excluded')
+  d3.select(RESTORE_EXCLUDED)
     .style('display', len > 0
       ? null
       : 'none')
@@ -44,7 +48,7 @@ function excludeRow(form, id, submit) {
 
 export function updateResults(form, data, submit) {
   const results = data.results;
-  d3.select('#results-count')
+  d3.select(RESULTS_COUNT)
     .text(formatCommas(data.count));
 
   resultsTable.style('display', null);

--- a/frontend/source/js/data-explorer/util.js
+++ b/frontend/source/js/data-explorer/util.js
@@ -16,24 +16,6 @@ export function getUrlParameterByName(name) {
     : decodeURIComponent(results[1].replace(/\+/g, ' ')).replace(/[<>]/g, '');
 }
 
-export function parseSortOrder(order) {
-  if (!order) {
-    return { key: null, order: null };
-  }
-  const first = order.charAt(0);
-  const sort = { order: '' };
-  switch (first) {
-    case '-':
-      sort.order = first;
-      order = order.substr(1); // eslint-disable-line no-param-reassign
-      break;
-    default:
-      break;
-  }
-  sort.key = order;
-  return sort;
-}
-
 export function arrayToCSV(data) {
   // turns any array input data into a comma separated string
   // in use for the education filter


### PR DESCRIPTION
These are a few more refactorings that try to make the data explorer a little bit easier to understand:

* In `table.js` and `histogram.js`, all global CSS selectors are now constants defined at the top of the file. I thought this might make it easier to figure out what global state the modules were modifying. I wanted to do this with `explorer.js` too but there were just way too many global selectors. (Outside of these three files, none of the modules reference global CSS selectors.)

* Made  `table.js` better encapsulated by moving `parseSortOrder` from `util.js` into it, and also moving some table-specific code out of `explorer.js` into it.
