### PR TITLE
Clean up styleguide

### DIFF
--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -1,6 +1,6 @@
 .styleguide-toc {
   background-color: #f0f0f0;
-  padding: 1em;
+  padding: 1em 2.5em;
 }
 
 .styleguide-toc li:last-child {
@@ -35,7 +35,7 @@ h3.styleguide-section {
 }
 
 .styleguide-example .rendering {
-  padding: 8px;
+  padding: 1em 2.5em;
 }
 
 .styleguide-example .rendering .example-heading {

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -19,7 +19,8 @@
   </p>
 
   <p>
-    CALC uses <a href="http://getskeleton.com/">Skeleton</a> as the foundation
+    CALC uses <a href="http://bourbon.io/">Bourbon</a> and
+    <a href="http://neat.bourbon.io/">Neat</a> as the foundation
     for its styles, with alterations based on the
     <a href="https://standards.usa.gov/">U.S. Web Design Standards (USWDS)</a>.
   </p>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -1,18 +1,7 @@
-{% extends "base.html" %}
-{% load staticfiles %}
+{% extends "styleguide_base.html" %}
 {% load styleguide %}
 
-{% block title %}Style Guide{% endblock %}
-
-{% block head %}
-<link rel="stylesheet" href="{% static 'frontend/built/style/data_explorer.min.css' %}">
-<link rel="stylesheet" href="{% static 'frontend/built/style/data_capture.min.css' %}">
-<link rel="stylesheet" href="{% static 'styleguide/styleguide.css' %}">
-<link rel="stylesheet" href="{% static 'styleguide/vendor/prism.css' %}">
-{% endblock %}
-
-{% block body %}
-<div class="container">
+{% block styleguide_body %}
   <h1>CALC Style Guide</h1>
 
   {% guide %}
@@ -731,11 +720,4 @@
   {% endif %}
 
   {% endguide %}
-</div>
-{% if not is_safe_mode_enabled %}
-<script src="{% static 'styleguide/vendor/prism.js' %}"></script>
-<script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
-<script src="{% static 'frontend/built/js/styleguide/index.min.js' %}"></script>
-{% endif %}
-{% include 'frontend/safe_mode/ui.html' %}
 {% endblock %}

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -213,17 +213,12 @@
   </p>
 
   <p>
-    The widget extends to the full width of its container, with each
-    step consuming an equal amount of horizontal space.
-  </p>
-
-  <p>
     Use <code>li.current</code> to identify a step as being the current
     one.
   </p>
 
   <p>
-    We recommend adding <code>aria-hidden="true"</code> to the list, as
+    We recommend adding <code>aria-hidden="true"</code> to the widget, as
     there isn't an easy way to communicate the information to vision-impaired
     users without being overly verbose (thus annoying the user) or confusing.
     However, <em>do</em> be sure to repeat the name of the current step
@@ -232,17 +227,16 @@
   </p>
 
   {% example %}
-  <ol class="steps" aria-hidden="true">
-    <li>
-      <label>Upload price list</label>
-    </li>
-    <li class="current">
-      <label>Validate data</label>
-    </li>
-    <li>
-      <label>Submit data</label>
-    </li>
-  </ol>
+  <div class="step-bar" aria-hidden="true">
+    <label>
+      Validate data
+    </label>
+    <ol class="steps">
+      <li></li>
+      <li class="current"></li>
+      <li></li>
+    </ol>
+  </div>
   {% endexample %}
 
   {% guide_section "Alerts" %}

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -185,9 +185,7 @@
   {% guide_section "Buttons" %}
 
   <p>
-    Unless otherwise specified buttons take after Skeleton's default, which is
-    white with a gray border and uppercase text. The color of primary, secondary,
-    disabled and gray buttons matches the
+    The color of primary, secondary, disabled and gray buttons matches the
     <a href="https://standards.usa.gov/buttons/">primary colors</a>
     of the USWDS. Use primary buttons to indicate primary actions, default to
     indicate less important actions, and secondary to indicate actions such as

--- a/styleguide/templates/styleguide_ajaxform.html
+++ b/styleguide/templates/styleguide_ajaxform.html
@@ -1,12 +1,7 @@
-{% extends "base.html" %}
-{% load staticfiles %}
+{% extends "styleguide_base.html" %}
 
-{% block body %}
-<div class="container">
+{% block styleguide_body %}
   <h1>Ajax Form Example</h1>
 
   {% include "styleguide_ajaxform_example.html" %}
-</div>
-
-<script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
 {% endblock %}

--- a/styleguide/templates/styleguide_base.html
+++ b/styleguide/templates/styleguide_base.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block title %}CALC Style Guide{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{% static 'frontend/built/style/data_capture.min.css' %}">
+<link rel="stylesheet" href="{% static 'styleguide/styleguide.css' %}">
+<link rel="stylesheet" href="{% static 'styleguide/vendor/prism.css' %}">
+{% endblock %}
+
+{% block body %}
+<div class="container card--wide">
+<div class="row">
+  <div class="card">
+    <div class="card__content">
+    {% block styleguide_body %}{% endblock %}
+    </div>
+  </div>
+</div>
+
+{% if not is_safe_mode_enabled %}
+<script src="{% static 'styleguide/vendor/prism.js' %}"></script>
+<script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
+<script src="{% static 'frontend/built/js/styleguide/index.min.js' %}"></script>
+{% endif %}
+{% include 'frontend/safe_mode/ui.html' %}
+
+{% endblock %}

--- a/styleguide/templates/styleguide_date.html
+++ b/styleguide/templates/styleguide_date.html
@@ -1,8 +1,6 @@
-{% extends "base.html" %}
-{% load staticfiles %}
+{% extends "styleguide_base.html" %}
 
-{% block body %}
-<div class="container">
+{% block styleguide_body %}
   <h1>Date Widget Example</h1>
 
   {% if date_form_is_valid %}
@@ -10,7 +8,4 @@
   {% endif %}
 
   {% include "styleguide_date_example.html" %}
-</div>
-
-<script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
 {% endblock %}

--- a/styleguide/templates/styleguide_radio.html
+++ b/styleguide/templates/styleguide_radio.html
@@ -1,14 +1,9 @@
-{% extends "base.html" %}
-{% load staticfiles %}
+{% extends "styleguide_base.html" %}
 
-{% block body %}
-<div class="container">
+{% block styleguide_body %}
   <h1>Radio and Checkbox Widget Example</h1>
 
   {% include 'data_capture/messages.html' %}
 
   {% include "styleguide_radio_checkbox_example.html" %}
-</div>
-
-<script src="{% static 'frontend/built/js/data-capture/index.min.js' %}"></script>
 {% endblock %}

--- a/styleguide/templates/styleguide_section.html
+++ b/styleguide/templates/styleguide_section.html
@@ -1,4 +1,9 @@
-<h3 class="styleguide-section" id="{{ section.id }}" tabindex="-1">
-  <a href="#{{ section.id }}" aria-hidden="true"></a>
-  {{ section.name }}
-</h3>
+  </div> <!--card__content-->
+</div> <!--card-->
+
+<div class="card">
+  <div class="card__content">
+    <h3 class="styleguide-section" id="{{ section.id }}" tabindex="-1">
+      <a href="#{{ section.id }}" aria-hidden="true"></a>
+      {{ section.name }}
+    </h3>


### PR DESCRIPTION
This fixes #1115.

To do:

- [x] FIgure out how to clean up the list items that now extend outside of the borders of their containers, e.g.:

  > ![borderz](https://cloud.githubusercontent.com/assets/124687/21272612/fccc219a-c38d-11e6-9c87-3655c7c33e2d.png)

- [x] Replace mentions of Skeleton with Bourbon/Neat.
- [x] Fix steps widget to use the new markup introduced in #1078.
- [ ] Fix the [2 rows have errors](https://cloud.githubusercontent.com/assets/697848/21199638/f6fec89c-c209-11e6-88a2-28b0e8bf0d9a.png) alert (maybe just file as a separate bug/leave for later).
- [ ] Fix the [forms example](https://cloud.githubusercontent.com/assets/697848/21199644/fe16a1b8-c209-11e6-8d22-274d4656d95e.png)  (maybe just file as a separate bug/leave for later).
