### PR TITLE
Add frontend/crotchety.py to simulate production static file storage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
 script:
 - phantomjs --version
 - python manage.py ultratest flake8
+- npm run gulp -- build
+- python manage.py collectstatic --noinput --link
 - echo "For details on why we're ignoring selenium tests, see https://github.com/18F/calc/issues/330"
 - bandit -r .
 - py.test --ignore=frontend/tests/test_selenium.py --cov
@@ -34,6 +36,7 @@ env:
   - TRAVIS_NODE_VERSION=6.5.0
   - PHANTOMJS_TIMEOUT=15
   - CF_CLI_VERSION=6.22.2
+  - SKIP_STATIC_ASSET_BUILDING=yup
   - DEBUG=yup
   - DATABASE_URL=postgres://postgres@localhost/hourglass
 

--- a/frontend/crotchety.py
+++ b/frontend/crotchety.py
@@ -1,0 +1,30 @@
+# This middleware + static file storage backend makes development behave more
+# like production by disallowing references to nonexistent files from being
+# generated in templates.
+
+from django.contrib.staticfiles.storage import StaticFilesStorage
+from django.contrib.staticfiles import finders
+from whitenoise.middleware import WhiteNoiseMiddleware
+
+
+class CrotchetyWhiteNoiseMiddleware(WhiteNoiseMiddleware):
+    def get_name_without_hash(self, filename):
+        # The default implementation of this sometimes returns
+        # the names of nonexistent files (e.g. converting files with
+        # .min.js extensions to just .js) which then makes the static
+        # file storage backend throw an exception.
+        #
+        # Since this middleware should only be used in development,
+        # where hashes are never included as part of filenames, we'll
+        # just return the filename here.
+        return filename
+
+
+class CrotchetyStaticFilesStorage(StaticFilesStorage):
+    def url(self, name):
+        foundpath = finders.find(name)
+
+        if not foundpath:
+            raise Exception('Cannot find %s' % name)
+
+        return super().url(name)

--- a/frontend/crotchety.py
+++ b/frontend/crotchety.py
@@ -20,11 +20,15 @@ class CrotchetyWhiteNoiseMiddleware(WhiteNoiseMiddleware):
         return filename
 
 
+class CrotchetyFileNotFoundError(Exception):
+    pass
+
+
 class CrotchetyStaticFilesStorage(StaticFilesStorage):
     def url(self, name):
         foundpath = finders.find(name)
 
         if not foundpath:
-            raise Exception('Cannot find %s' % name)
+            raise CrotchetyFileNotFoundError('Cannot find %s' % name)
 
         return super().url(name)

--- a/frontend/tests/test_crotchety.py
+++ b/frontend/tests/test_crotchety.py
@@ -1,0 +1,15 @@
+from django.test import SimpleTestCase
+from django.template import Template, Context
+
+from ..crotchety import CrotchetyFileNotFoundError
+
+
+class CrotchetyTests(SimpleTestCase):
+    def test_exception_is_thrown_when_file_not_found(self):
+        template = Template("""
+            {% load staticfiles %}
+            {% static 'i/am/nonexistent.js' %}
+        """)
+
+        with self.assertRaises(CrotchetyFileNotFoundError):
+            template.render(Context({}))

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -130,9 +130,17 @@ INSTALLED_APPS = (
     'frontend',
 )
 
+if DEBUG:
+    STATICFILES_STORAGE = 'frontend.crotchety.CrotchetyStaticFilesStorage'
+    WHITENOISE_MIDDLEWARE = 'frontend.crotchety.CrotchetyWhiteNoiseMiddleware'
+else:
+    STATICFILES_STORAGE = ('whitenoise.storage.'
+                           'CompressedManifestStaticFilesStorage')
+    WHITENOISE_MIDDLEWARE = 'whitenoise.middleware.WhiteNoiseMiddleware'
+
 MIDDLEWARE_CLASSES = (
     'hourglass.middleware.ComplianceMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
+    WHITENOISE_MIDDLEWARE,
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -180,10 +188,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATICFILES_DIRS = (
     # os.path.join(BASE_DIR, 'static'),
 )
-
-if not DEBUG:
-    STATICFILES_STORAGE = ('whitenoise.storage.'
-                           'CompressedManifestStaticFilesStorage')
 
 RQ_QUEUES = {
     'default': {


### PR DESCRIPTION
This is an alternative to #1141 that tries to fix #1136 by implementing a development-only static file storage backend whose `url()` method throws an exception when passed a non-existent file name, just like the @$💥%#💩!ing `CompressedManifestStaticFilesStorage` does in production.
