### PR TITLE
[WIP] Encapsulate steps widget HTML rendering in a StepsWidget class

### DIFF
--- a/frontend/steps.py
+++ b/frontend/steps.py
@@ -1,0 +1,34 @@
+from collections import namedtuple
+
+from django.template.loader import render_to_string
+
+
+Step = namedtuple('Step', ['label', 'number', 'current'])
+
+
+class StepsWidget:
+    '''
+    The steps widget can be used to visualize the user's progress through a
+    multi-step process.
+
+    While it is described as a "widget", it is not actually a widget
+    in the Django sense--i.e., it is not used to present users with
+    a form UI.
+    '''
+
+    def __init__(self, labels, current):
+        self.labels = labels
+        self.current = current
+
+    def render(self):
+        steps = [
+            Step(label=label, number=i, current=(i == self.current))
+            for label, i in zip(self.labels, range(1, len(self.labels) + 1))
+        ]
+        return render_to_string('frontend/steps.html', {
+            'current_step': steps[self.current - 1],
+            'steps': steps,
+        })
+
+    def __str__(self):
+        return self.render()

--- a/frontend/templates/frontend/steps.html
+++ b/frontend/templates/frontend/steps.html
@@ -1,0 +1,13 @@
+<div class="step-bar">
+  <label>
+    <span class="sr-only">
+      Step {{ current_step.number }} of {{ steps|length }}:
+    </span>
+    {{ current_step.label }}
+  </label>
+  <ol class="steps" aria-hidden="true">
+    {% for step in steps %}
+      <li{% if step.current %} class="current"{% endif %}></li>
+    {% endfor %}
+  </ol>
+</div>

--- a/frontend/tests/test_steps.py
+++ b/frontend/tests/test_steps.py
@@ -1,0 +1,14 @@
+from django.test import SimpleTestCase
+
+from frontend.steps import StepsWidget
+
+
+class StepsWidgetTests(SimpleTestCase):
+    def test_it_works(self):
+        steps = StepsWidget(
+            labels=('foo', 'bar', 'baz'),
+            current=2
+        )
+        html = str(steps)
+        assert 'bar' in html
+        assert 'Step 2 of 3' in html

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -212,31 +212,22 @@
   </p>
 
   <p>
-    Use <code>li.current</code> to identify a step as being the current
-    one.
+    Vision-impaired users will hear an audio description of the
+    visualization, e.g. "Step 2 of 3", followed by the name of the
+    current step.
   </p>
 
   <p>
-    We recommend adding <code>aria-hidden="true"</code> to the widget, as
-    there isn't an easy way to communicate the information to vision-impaired
-    users without being overly verbose (thus annoying the user) or confusing.
-    However, <em>do</em> be sure to repeat the name of the current step
-    elsewhere in a header, so that the user knows what step they're currently
-    on.
+    Rather than writing out the raw HTML of the steps widget, we
+    recommend using {% pyobjname 'frontend.steps.StepsWidget' %}.
   </p>
 
-  {% example %}
-  <div class="step-bar" aria-hidden="true">
-    <label>
-      Validate data
-    </label>
-    <ol class="steps">
-      <li></li>
-      <li class="current"></li>
-      <li></li>
-    </ol>
+  <div class="styleguide-example">
+    <div class="rendering">
+      <h3 class="example-heading">Example</h3>
+      {{ steps_widget }}
+    </div>
   </div>
-  {% endexample %}
 
   {% guide_section "Alerts" %}
 

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -2,6 +2,7 @@ from django import forms
 from django.shortcuts import render
 
 from frontend.upload import UploadWidget
+from frontend.steps import StepsWidget
 from . import ajaxform_example, date_example, radio_checkbox_example
 
 
@@ -31,6 +32,10 @@ def index(request):
     ctx = {
         'degraded_upload_widget': get_degraded_upload_widget(),
         'existing_filename_upload_form': get_existing_filename_upload_form(),
+        'steps_widget': StepsWidget(
+            labels=('Upload data', 'Validate data', 'Recover costs'),
+            current=2
+        )
     }
     ctx.update(ajaxform_example.create_template_context())
     ctx.update(date_example.create_template_context())


### PR DESCRIPTION
This attempts to encapsulate the steps widget rendering into a `StepsWidget` class, which uses its own template to render itself. This helps us stay DRY and easily add/change steps widgets where needed.

To do:

- [ ] Modify existing "manual" steps widgets to use this.
