### PR TITLE
Smoothly scroll to location hash on new page load

### DIFF
--- a/frontend/source/js/tests/smooth-scroll_tests.js
+++ b/frontend/source/js/tests/smooth-scroll_tests.js
@@ -43,11 +43,14 @@ class FakeWindow {
           this.state = state;
         },
       },
-      location: 'http://foo/',
+      location: {
+        hash: '',
+      },
       document: {
         body: { scrollTop: 0 },
         documentElement: { scrollTop: 0 },
         readyState: options.readyState || 'loading',
+        getElementById() { return null; },
       },
       sessionStorage: options.sessionStorage || {},
       listeners: {},


### PR DESCRIPTION
This builds on the smooth scroll functionality to smoothly scroll the page on initial page loads, if there's a valid id in the location hash.

If this seems OK, we could additionally improve it by making it auto-scroll to `#messages` (or other configurable default id) if it exists *and* there's no other id defined in the location hash, as suggested in https://github.com/18F/calc/pull/1089#discussion_r93454626.