### PR TITLE
Report version number in /healthcheck.

### DIFF
--- a/hourglass/healthcheck.py
+++ b/hourglass/healthcheck.py
@@ -3,6 +3,8 @@ from django.db.migrations.executor import MigrationExecutor
 from django.db import connections, DEFAULT_DB_ALIAS
 import django_rq
 
+from hourglass import __version__
+
 
 def is_database_synchronized(database=DEFAULT_DB_ALIAS):
     connection = connections[database]
@@ -14,6 +16,7 @@ def is_database_synchronized(database=DEFAULT_DB_ALIAS):
 
 def healthcheck(request):
     results = {
+        'version': __version__,
         'is_database_synchronized': is_database_synchronized(),
         'rq_jobs': len(django_rq.get_queue().jobs),
     }

--- a/hourglass/tests/tests.py
+++ b/hourglass/tests/tests.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.conf.urls import url
 
-from .. import healthcheck
+from .. import healthcheck, __version__
 from ..urls import urlpatterns
 from ..decorators import staff_login_required
 from ..settings_utils import (load_cups_from_vcap_services,
@@ -74,6 +74,7 @@ class HealthcheckTests(DjangoTestCase):
         res = self.client.get('/healthcheck/')
         self.assertEqual(res.status_code, 200)
         self.assertJSONEqual(str(res.content, encoding='utf8'), {
+            'version': __version__,
             'is_database_synchronized': True,
             'rq_jobs': 0
         })
@@ -84,6 +85,7 @@ class HealthcheckTests(DjangoTestCase):
         res = self.client.get('/healthcheck/')
         self.assertEqual(res.status_code, 500)
         self.assertJSONEqual(str(res.content, encoding='utf8'), {
+            'version': __version__,
             'is_database_synchronized': False,
             'rq_jobs': 0
         })


### PR DESCRIPTION
**Note: This is a PR against #1193, not `develop`.**

This adds the version number to the `/healthcheck` endpoint.

I'm actually a bit conflicted about whether this is a good place to put the version (it doesn't have to be the *only* place we put it, of course).  It's not *directly* related to the health of a deployment, but at the same time, it does give some significant *context* with which one could judge the deployment's health, so... I dunno. Feel free to just close this PR if you don't like it.
