### PR TITLE
Add large Fail and Success messages

### DIFF
--- a/meta/management/commands/ultratest.py
+++ b/meta/management/commands/ultratest.py
@@ -39,6 +39,7 @@ RAINBOW_COLORS = [
     ]
 ]
 
+
 RESET_COLORS = "\033[m"
 
 ASCII_ART_LOGO = """\
@@ -50,9 +51,35 @@ ASCII_ART_LOGO = """\
   \____/|_|\__|_|  \__,_|_|\___||___/\__|"""
 
 
+FAIL_TEXT = """\
+  _____ _    ___ _     _
+ |  ___/ \  |_ _| |   | |
+ | |_ / _ \  | || |   | |
+ |  _/ ___ \ | || |___|_|
+ |_|/_/   \_\___|_____(_)"""
+
+
+SUCCESS_TEXT = """\
+  ____  _   _  ____ ____ _____ ____ ____  _
+ / ___|| | | |/ ___/ ___| ____/ ___/ ___|| |
+ \___ \| | | | |  | |   |  _| \___ \___ \| |
+  ___) | |_| | |__| |___| |___ ___) |__) |_|
+ |____/ \___/ \____\____|_____|____/____/(_)"""
+
+
 def print_with_rainbow_colors(ascii_art):
     for color, line in zip(RAINBOW_COLORS, ascii_art.splitlines()):
         print(color + line)
+    print(RESET_COLORS)
+
+
+def print_big_fail():
+    print('\033[91m' + FAIL_TEXT)
+    print(RESET_COLORS)
+
+
+def print_big_success():
+    print('\033[92m' + SUCCESS_TEXT)
     print(RESET_COLORS)
 
 
@@ -202,8 +229,11 @@ def command(verbosity, testtype):
             echo('\n', 0)
 
     if len(failures) > 0:
+        print_big_fail()
         echo('Failing tests: {}'.format(', '.join(failures)), 0)
         exit_code = 1
+    else:
+        print_big_success()
 
     if report_coverage:
         coverage_after = get_coverage()


### PR DESCRIPTION
Closes #1192 

On fail:
<img width="190" alt="screen shot 2017-01-06 at 9 22 50 am" src="https://cloud.githubusercontent.com/assets/697848/21722482/772952d6-d3f2-11e6-862c-ed83762aeb88.png">

On success:
<img width="302" alt="screen shot 2017-01-06 at 9 26 52 am" src="https://cloud.githubusercontent.com/assets/697848/21722485/7d0053ee-d3f2-11e6-8c70-b8a135182ed6.png">
