### PR TITLE
Add a MailCatcher container for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ All the project's dependencies, such as those mentioned in `requirements.txt`,
 are contained in Docker container images.  Whenever these dependencies change,
 you'll want to re-run `docker-compose build` to rebuild the containers.
 
+### Reading email
+
+In the development Docker configuration, we use a container with
+[MailCatcher][] to make it easy to read the emails sent by the app. You
+can view it at port 1080 of your Docker host.
+
+[MailCatcher]: https://mailcatcher.me/
+
 ### Deploying to cloud environments
 
 The Docker setup can also be used to deploy to cloud environments.

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -4,6 +4,10 @@ app:
     # http://stackoverflow.com/a/37898591
     - /calc/node_modules/
   command: python manage.py runserver 0.0.0.0:${DOCKER_EXPOSED_PORT}
+  environment:
+    - EMAIL_URL=smtp://mailcatcher:25/
+  links:
+    - mailcatcher
 gulp:
   build: .
   volumes:
@@ -16,3 +20,7 @@ rq_worker:
 rq_scheduler:
   volumes:
     - .:/calc
+mailcatcher:
+  image: tophfr/mailcatcher:latest
+  ports:
+    - 1080:80


### PR DESCRIPTION
Since we're likely going to add some kind of HTML email support soon (see #1208) and it's annoying to read plain-text emails in the terminal that's outputting all the other log information for the app, I thought it might be useful to add a [MailCatcher](http://mailcatcher.me/) container for development.  This exposes the app on port 1080, so that a developer can just go there to easily see any emails sent from the app, and browse them in their HTML and plain text representations:

> ![screen shot 2017-01-09 at 6 36 48 pm](https://cloud.githubusercontent.com/assets/124687/21788055/b9d365c2-d69a-11e6-8964-e7a243998d23.png)

(There's no "HTML" tab in the above screenshot because we're currently only sending emails in plain text.)

I decided to use [tophfr/mailcatcher](https://hub.docker.com/r/tophfr/mailcatcher/) from Docker Hub because it uses Alpine Linux, so it's nice and small. The only downside is that apparently the maintainer hasn't been tagging versions lately, so I had to pin it on `latest`.

Note that I originally thought we could just use [maildump](https://github.com/ThiefMaster/maildump), a Python-based clone of MailCatcher (which is in Ruby), by adding it to `requirements-dev.txt` and launching it from a cloned container of `app` (like we do with `rq` etc), but apparently maildump only works with python 2.x.  At that point I figured we might as well use "the real thing", as I'm guessing MailCatcher is more likely to be maintained than maildump, but that's just a gut feeling--I'm cool with switching to maildump if anyone thinks it's a better option.
