### PR TITLE
Upgrade to Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
   - node_modules
 python:
-- 3.4
+- 3.5
 addons:
   postgresql: 9.3
   sauce_connect: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4.5
+FROM python:3.5.2
 
 ENV PHANTOMJS_VERSION 1.9.7
 

--- a/data_capture/tests/test_price_list_views.py
+++ b/data_capture/tests/test_price_list_views.py
@@ -135,13 +135,13 @@ class DetailsViewTests(ProtectedViewTestCase):
         self.assertEqual(pl.contract_end, datetime.date(1989, 4, 14))
         self.assertEqual(pl.escalation_rate, 0)
 
-    @mock.patch.object(SubmittedPriceList, 'retire')
-    def test_valid_post_calls_retire(self, mock):
+    @mock.patch.object(SubmittedPriceList, 'unreview')
+    def test_valid_post_calls_unreview(self, mock):
         self.login()
         res = self.client.post(self.url, self.valid_post_data, follow=True)
         self.assertRedirects(res, self.url)
         self.assertEqual(res.status_code, 200)
-        mock.assert_called_once()
+        self.assertEqual(mock.call_count, 1)
 
     def test_invalid_post_shows_errors(self):
         self.login()

--- a/hourglass/tests/test_configuration.py
+++ b/hourglass/tests/test_configuration.py
@@ -37,7 +37,7 @@ class PythonVersionTests(TestCase):
     Ensure all our configuration files specify the same Python version.
     '''
 
-    version = Version('3.4.5')
+    version = Version('3.5.2')
 
     def test_runtime_txt(self):
         with open(path('runtime.txt')) as f:

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.4.5
+python-3.5.2

--- a/uaa_client/tests/test_views.py
+++ b/uaa_client/tests/test_views.py
@@ -99,5 +99,5 @@ class ViewTests(TestCase):
     def test_logout(self):
         with mock.patch('django.contrib.auth.logout') as logout_mock:
             response = self.client.get('/auth/logout')
-            logout_mock.assert_called()
+            self.assertEqual(logout_mock.call_count, 1)
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This upgrades CALC to work on Python 3.5, fixing #766.

The upgrade actually surfaced a bug in two of our tests: we were calling `assert` methods on `Mock` objects that were  introduced in Python 3.6, but Python 3.4 wasn't throwing an `AttributeError` on them because the mock assumed any nonexistent method calls were mock calls!  Fortunately they fixed this in [Python bug 21238](https://bugs.python.org/issue21238) so that a `Mock` *would* throw an `AttributeError` if `assert` (or a common misspelling, `assret`) was in the attribute name, which thus made our tests break.
