### PR TITLE
Use uglifyIFY to excise unused dependencies from bundle

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -201,6 +201,12 @@ function browserifyBundle(entryPath, outputPath, outputFile) {
     .transform(babelify.configure({ presets: ['es2015', 'react'] }));
 
   if (process.env.NODE_ENV === 'production') {
+    // Here we use uglifyify--not to be confused with uglify--to uglify
+    // each individual module by itself, which allows us to excise
+    // unused dependencies based on our build configuration. We are
+    // also passing arguments to bundler.transform() in a weird order,
+    // but it's what uglifyify's docs recommend and it seems to work,
+    // so whatever.
     bundler = bundler.transform({
       global: true,
     }, 'uglifyify');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -200,6 +200,12 @@ function browserifyBundle(entryPath, outputPath, outputFile) {
     .transform(envify({ NODE_ENV: process.env.NODE_ENV }), { global: true })
     .transform(babelify.configure({ presets: ['es2015', 'react'] }));
 
+  if (process.env.NODE_ENV === 'production') {
+    bundler = bundler.transform({
+      global: true
+    }, 'uglifyify');
+  }
+
   if (isWatching) {
     bundler = watchify(bundler);
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -202,7 +202,7 @@ function browserifyBundle(entryPath, outputPath, outputFile) {
 
   if (process.env.NODE_ENV === 'production') {
     bundler = bundler.transform({
-      global: true
+      global: true,
     }, 'uglifyify');
   }
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "envify": "^4.0.0",
+    "uglifyify": "^3.0.4",
     "watchify": "^3.7.0"
   },
   "scripts": {


### PR DESCRIPTION
Apparently there is a module called [`uglifyify`](https://github.com/hughsk/uglifyify) (not to be confused with `uglify`) which allows us to fix #1244.  See its [motivation/usage](https://www.npmjs.com/package/uglifyify#motivationusage) section for an example.

Its README *does* still encourage the use of uglify on its own, since apparently there are optimizations it can do that uglify*ify* cannot.

If we ever switch to webpack, this whole thing will not be nearly as confusing.  We just use its [`DefinePlugin`](https://webpack.github.io/docs/list-of-plugins.html#defineplugin), make sure minification is enabled, and we're done.