### PR TITLE
Expose changelog view at /updates/

### DIFF
--- a/hourglass/changelog.py
+++ b/hourglass/changelog.py
@@ -1,6 +1,9 @@
 import re
 import datetime
 import pathlib
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
+import markdown
 
 
 PATH = pathlib.Path(__file__).resolve().parent.parent / 'CHANGELOG.md'
@@ -18,6 +21,11 @@ UNRELEASED_LINK_RE = re.compile(
     )
 
 UNRELEASED_HEADER = '## [Unreleased][unreleased]'
+
+
+def django_view(request):
+    html = mark_safe(markdown.markdown(get_contents()))  # nosec
+    return render(request, 'changelog.html', dict(html=html))
 
 
 def get_contents():

--- a/hourglass/templates/changelog.html
+++ b/hourglass/templates/changelog.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block body %}
+<div class="container card--narrow">
+  <div class="card">
+      <div class="card__content">
+        {{ html }}
+      </div>
+  </div>
+</div>
+{% endblock %}

--- a/hourglass/tests/test_changelog.py
+++ b/hourglass/tests/test_changelog.py
@@ -2,6 +2,7 @@ import datetime
 from textwrap import dedent
 from unittest import TestCase
 from semantic_version import Version
+from django.test import TestCase as DjangoTestCase
 import markdown
 from bs4 import BeautifulSoup
 
@@ -83,6 +84,13 @@ class UtilTests(TestCase):
             changelog.RELEASE_HEADER_RE.search('## [1.2.3][]').group(1),
             '1.2.3'
             )
+
+
+class DjangoViewTests(DjangoTestCase):
+    def test_it_works(self):
+        res = self.client.get('/updates/')
+        self.assertContains(res, 'Change Log')
+        self.assertEqual(res.status_code, 200)
 
 
 class ChangelogMdTests(TestCase):

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -6,6 +6,7 @@ from django.views.generic import TemplateView
 from .decorators import staff_login_required
 from .healthcheck import healthcheck
 from .robots import robots_txt
+from .changelog import django_view as view_changelog
 
 # Wrap the admin site login with our staff_login_required decorator,
 # which will raise a PermissionDenied exception if a logged-in, but non-staff
@@ -27,6 +28,7 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^styleguide/', include('styleguide.urls', namespace='styleguide')),
     url(r'^robots.txt$', robots_txt),
+    url(r'^updates/$', view_changelog),
     url(r'^auth/', include('uaa_client.urls', namespace='uaa_client')),
     url(r'^account/', include('user_account.urls', namespace='user_account')),
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,6 @@ selenium==2.53.6
 model-mommy==1.2.6
 robobrowser==0.5.3
 beautifulsoup4==4.5.1
-Markdown==2.6.7
 semantic_version==2.6.0
 freezegun==0.3.8
 pexpect==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ django-rq==0.9.2
 rq-scheduler==0.7.0
 mypy-lang==0.4.6
 pytz==2016.10
+Markdown==2.6.7


### PR DESCRIPTION
This follows [cloud.gov's convention](https://cloud.gov/updates/) of exposing a human-friendly changelog at `/updates/`:

![screen shot 2017-01-17 at 9 20 27 am](https://cloud.githubusercontent.com/assets/124687/22023910/2c4d0f8a-dc96-11e6-9f35-cbd6b7e63c35.png)

It is not *particularly* human-friendly right now but we can improve it!
