### PR TITLE
Make /updates/ friendlier to non-developers

### DIFF
--- a/hourglass/changelog.py
+++ b/hourglass/changelog.py
@@ -24,7 +24,8 @@ UNRELEASED_HEADER = '## [Unreleased][unreleased]'
 
 
 def django_view(request):
-    html = mark_safe(markdown.markdown(get_contents()))  # nosec
+    contents = strip_preamble(get_contents())
+    html = mark_safe(markdown.markdown(contents))  # nosec
     return render(request, 'changelog.html', dict(html=html))
 
 
@@ -57,6 +58,20 @@ def get_latest_release(contents):
     '''
 
     return RELEASE_HEADER_RE.search(contents).group(1)
+
+
+def strip_preamble(contents):
+    '''
+    Removes any expository text before the beginning of the
+    "Unreleased" section, if it's non-empty.  If the "Unreleased" section
+    is empty, it is removed as well.
+    '''
+
+    if get_unreleased_notes(contents).strip():
+        result = contents[contents.index(UNRELEASED_HEADER):]
+    else:
+        result = contents[RELEASE_HEADER_RE.search(contents).start():]
+    return result
 
 
 def bump_version(contents, new_version, date=None):

--- a/hourglass/templates/changelog.html
+++ b/hourglass/templates/changelog.html
@@ -1,9 +1,15 @@
 {% extends "base.html" %}
 
+{% block title %}Updates{% endblock %}
+
 {% block body %}
 <div class="container card--narrow">
   <div class="card">
       <div class="card__content">
+        <h1>Updates</h1>
+
+        <p>Curious what’s new that you might find helpful as a CALC user? Here are highlights from our updates as we’ve improved the product.</p>
+
         {{ html }}
       </div>
   </div>

--- a/hourglass/templates/changelog.html
+++ b/hourglass/templates/changelog.html
@@ -8,7 +8,7 @@
       <div class="card__content">
         <h1>Updates</h1>
 
-        <p>Curious what’s new that you might find helpful as a CALC user? Here are highlights from our updates as we’ve improved the product.</p>
+        <p>Curious about what’s new in CALC? Here are highlights from our updates as we’ve improved the product.</p>
 
         {{ html }}
       </div>

--- a/hourglass/tests/test_changelog.py
+++ b/hourglass/tests/test_changelog.py
@@ -73,6 +73,18 @@ class UtilTests(TestCase):
             ''
             )
 
+    def test_strip_preamble_includes_unreleased_when_nonempty(self):
+        self.assertEqual(
+            changelog.strip_preamble('BLARG\n' + self.BEFORE_BUMP)[:10],
+            '## [Unrele'
+            )
+
+    def test_strip_preamble_removes_unreleased_when_empty(self):
+        self.assertEqual(
+            changelog.strip_preamble('BLARG\n' + self.AFTER_BUMP)[:10],
+            '## [1.0.1]'
+            )
+
     def test_release_header_re_matches_unbracketed_version(self):
         self.assertEqual(
             changelog.RELEASE_HEADER_RE.search('## 1.2.3 ').group(1),
@@ -89,7 +101,7 @@ class UtilTests(TestCase):
 class DjangoViewTests(DjangoTestCase):
     def test_it_works(self):
         res = self.client.get('/updates/')
-        self.assertContains(res, 'Change Log')
+        self.assertContains(res, 'Updates')
         self.assertEqual(res.status_code, 200)
 
 


### PR DESCRIPTION
This attempts to make `/updates/` a bit friendlier to non-developers by removing the expository text from `CHANGELOG.md` (which mentions things like keepachangelog.com and semver) and replacing it with expository text in the `changelog.html` template:

> ![screen shot 2017-01-18 at 8 21 40 am](https://cloud.githubusercontent.com/assets/124687/22065636/2cf9bf84-dd57-11e6-96e9-ba1163dffb59.png)

It also renames the page from "Change Log" to "Updates", following the lead of [cloud.gov/updates/](https://cloud.gov/updates/). It also just sounds less technical.

Also, if the "Unreleased" section is empty--which it should be on production deploys--then it is removed entirely from the page.