### PR TITLE
Scale down instances to 1 during deployment

### DIFF
--- a/deploy-travis.sh
+++ b/deploy-travis.sh
@@ -33,4 +33,8 @@ MANIFEST="manifests/manifest-$DEPLOY_ENV.yml"
 echo "Deploying to $DEPLOY_ENV space."
 
 cf login -a $API -u $DEPLOY_USER -p $DEPLOY_PASS -o $ORG -s $SPACE
+
+# scale down the app instances to avoid overrunning our memory allotment
+cf scale -i 1 $APP_NAME
+
 cf zero-downtime-push $APP_NAME -f $MANIFEST


### PR DESCRIPTION
Because we have a fairly slim memory-allocation-margin, our production deployment will actually fail due to exceeding that allocation if the number of app instances is not scaled back before the `cf zero-downtime-push`. 

This PR mitigates the issue by scaling the app instances down to 1 before pushing the new version.

Note that the new version will launch with the number of instances specified in its corresponding manifest.yml (2 in the case of calc-prod).