### PR TITLE
Send 'Cache-Control: max-age=0' by default

### DIFF
--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -142,6 +142,7 @@ else:
     WHITENOISE_MIDDLEWARE = 'whitenoise.middleware.WhiteNoiseMiddleware'
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.cache.UpdateCacheMiddleware',
     'hourglass.middleware.ComplianceMiddleware',
     WHITENOISE_MIDDLEWARE,
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -157,6 +158,7 @@ MIDDLEWARE_CLASSES = (
     # when the ProfilingPanel is enabled
     # http://django-debug-toolbar.readthedocs.io/en/stable/panels.html#profiling
     'hourglass.middleware.DebugOnlyDebugToolbarMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (
@@ -309,6 +311,15 @@ UAA_CLIENT_SECRET = os.environ.get('UAA_CLIENT_SECRET')
 LOGIN_URL = 'uaa_client:login'
 
 LOGIN_REDIRECT_URL = '/'
+
+# We *always* want to send a Cache-Control header downstream, especially
+# in the event where we've got a reverse proxy with aggressive caching
+# defaults like Amazon CloudFront in front of us.
+#
+# For now we're just going to tell any downstream caches to never cache
+# any dynamic content we give them, to ensure that stale content never
+# gets served to end-users.
+CACHE_MIDDLEWARE_SECONDS = 0
 
 if DEBUG:
     INSTALLED_APPS += ('fake_uaa_provider',)

--- a/hourglass/tests/tests.py
+++ b/hourglass/tests/tests.py
@@ -305,6 +305,12 @@ class StaffLoginRequiredTests(DjangoTestCase):
         self.assertEqual(403, res.status_code)
 
 
+class CachingTests(DjangoTestCase):
+    def test_max_age_defaults_to_zero(self):
+        res = self.client.get('/')
+        self.assertEqual(res['Cache-Control'], 'max-age=0')
+
+
 class ContextProcessorTests(DjangoTestCase):
     @override_settings(GA_TRACKING_ID='boop')
     def test_ga_tracking_id_is_included(self):


### PR DESCRIPTION
This attempts to at least temporarily resolve #1257 by explicitly telling downstream caches to never cache our dynamic views by default.

In order to send the `Cache-Control` headers we also enable [Django's site-wide cache middleware](https://docs.djangoproject.com/en/1.10/topics/cache/#the-per-site-cache).

Because we're setting the default expiry via [`CACHE_MIDDLEWARE_SECONDS`](https://docs.djangoproject.com/en/1.10/ref/settings/#std:setting-CACHE_MIDDLEWARE_SECONDS), individual views and middlewares (like whitenoise, which serves our static files) should be able to override the default, so that we can still leverage CloudFront for resources that we actually *want* to cache.

Note, though, that because we're actively preventing our views from being cached by default, it might actually overload our server if too many folks are visiting our site at once!  If that happens we might want to consider setting `CACHE_MIDDLEWARE_SECONDS` to some low integer, so that we can at least cache our dynamic views for a short period of time.