### PR TITLE
Make styleguide reuse s70 error table template.

### DIFF
--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -321,67 +321,13 @@
   {% endexample %}
 
   <p>When errors are displayed in tables, they look like this. Note that this markup is automatically generated on Step 3.</p>
-  {% example %}
-  <table class="price-list-table">
-    <thead>
-      <tr>
-        <th>SIN(s) proposed</th>
-        <th>Service proposed <span>(e.g. job title/task)</span></th>
-        <th>Minimum education <br>/ certification level</th>
-        <th class="number">Minimum years <br>of experience</th>
-        <th>Unit of issue</th>
-        <th class="number">Price offered to GSA <span>(including IFF)</span></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class=" ">
-          <span>none</span>
-        </td>
-        <td class=" ">
-          <span>Button Presser</span>
-        </td>
-        <td class="error ">
-          <span aria-describedby="error__row-1__col-3">NA</span>
-          <div class="error__tooltip" role="tooltip" id="error__row-1__col-3"><ul class="errorlist"><li>This field must contain one of the following values: High School, Associates, Bachelors, Masters, Ph.D.</li></ul></div>
-        </td>
-        <td class=" number">
-          <span>1</span>
-        </td>
-        <td class=" ">
-          <span>Hour</span>
-        </td>
-        <td class="error number">
-          <span aria-describedby="error__row-1__col-6">$9.0</span>
-          <div class="error__tooltip" role="tooltip" id="error__row-1__col-6"><ul class="errorlist"><li>Price must be at least the federal contractor minimum wage ($10.10)</li></ul></div>
-        </td>
-      </tr>
-      <tr>
-        <td class=" ">
-          <span>none</span>
-        </td>
-        <td class=" ">
-          <span>Button Presser</span>
-        </td>
-        <td class="error ">
-          <span aria-describedby="error__row-2__col-3">NA</span>
-          <div class="error__tooltip" role="tooltip" id="error__row-2__col-3"><ul class="errorlist"><li>This field must contain one of the following values: High School, Associates, Bachelors, Masters, Ph.D.</li></ul></div>
-        </td>
-        <td class="error number">
-          <span aria-describedby="error__row-2__col-4">all of them</span>
-          <div class="error__tooltip" role="tooltip" id="error__row-2__col-4"><ul class="errorlist"><li>Enter a whole number.</li></ul></div>
-        </td>
-        <td class=" ">
-          <span>Hour</span>
-        </td>
-        <td class="error number">
-          <span aria-describedby="error__row-2__col-6">$9.0</span>
-          <div class="error__tooltip" role="tooltip" id="error__row-2__col-6"><ul class="errorlist"><li>Price must be at least the federal contractor minimum wage ($10.10)</li></ul></div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  {% endexample %}
+
+  <div class="styleguide-example">
+    <div class="rendering">
+      <h3 class="example-heading">Example</h3>
+      {{ s70_error_table }}
+    </div>
+  </div>
 
   {% guide_section "Excel Tables" %}
 

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import render
 
 from frontend.upload import UploadWidget
 from frontend.steps import StepsWidget
+from data_capture.schedules.s70 import Schedule70PriceList
 from . import ajaxform_example, date_example, radio_checkbox_example
 
 
@@ -28,8 +29,30 @@ def get_existing_filename_upload_form():
     return MyForm()
 
 
+def get_s70_pricelist_error_table():
+    return Schedule70PriceList([
+        {
+            'sin': 'none',
+            'labor_category': 'Button Presser',
+            'education_level': 'NA',
+            'min_years_experience': '1',
+            'unit_of_issue': 'Hour',
+            'price_including_iff': '9.0',
+        },
+        {
+            'sin': 'none',
+            'labor_category': 'Button Presser',
+            'education_level': 'NA',
+            'min_years_experience': 'all of them',
+            'unit_of_issue': 'Hour',
+            'price_including_iff': '9.0',
+        }
+    ]).to_error_table()
+
+
 def index(request):
     ctx = {
+        's70_error_table': get_s70_pricelist_error_table(),
         'degraded_upload_widget': get_degraded_upload_widget(),
         'existing_filename_upload_form': get_existing_filename_upload_form(),
         'steps_widget': StepsWidget(


### PR DESCRIPTION
Hey @hbillings, this is a PR against your PR #1245 to make the error table in the styleguide render using your same code for the s70 error table, so that it won't go stale.  Feel free to modify at will or reject this PR outright.
