### PR TITLE
Move icon credits to About page

### DIFF
--- a/data_explorer/templates/_footer.html
+++ b/data_explorer/templates/_footer.html
@@ -19,9 +19,6 @@
             <p>We're always looking for feedback on CALC!<br>
               To share your thoughts, email us at <a href="mailto:{{ HELP_EMAIL }}">{{ HELP_EMAIL }}</a>.</p>
             <p class="github"><a href="https://github.com/18F/calc">View our code on GitHub</a></p>
-            {% if request.path == "/" %}
-            <p class="credits">Icons: Paulo Sá Ferreira, Luis Prado, John Testa, Andrew Forrester from <a href="https://thenounproject.com/">The Noun Project</a>.</p>
-            {% endif %}
           </div>
 
           <div id="logos" class="three columns">

--- a/data_explorer/templates/about.html
+++ b/data_explorer/templates/about.html
@@ -86,6 +86,18 @@
       <i>Note: IT Schedule 70 is newly added so available results in CALC is currently limited.</i></p>
     </div><!--card__content-->
   </div><!--card-->
+  <div class="card">
+    <div class="card__content">
+      <h2 id="credits">Icon credits</h2>
+      <p>
+        "Briefcase" by <a href="https://thenounproject.com/jontesta/uploads/?i=13466">John Testa</a>,
+        "Donkey" by <a href="https://thenounproject.com/term/donkey/28242/">Luis Prado</a>,
+        "Globe" by <a href="https://thenounproject.com/term/globe/1806/">Andrew Forrester</a>,
+        "Roof" by <a href="https://thenounproject.com/term/roof/633227/">Symbolon</a>
+        from <a href="https://thenounproject.com/">the Noun Project</a>.
+      </p>
+    </div><!--card__content-->
+  </div><!--card-->
 </div><!--row-->
 <div class="card__footer"></div>
 

--- a/data_explorer/templates/about.html
+++ b/data_explorer/templates/about.html
@@ -90,10 +90,10 @@
     <div class="card__content">
       <h2 id="credits">Icon credits</h2>
       <p>
-        "Briefcase" by <a href="https://thenounproject.com/jontesta/uploads/?i=13466">John Testa</a>,
-        "Donkey" by <a href="https://thenounproject.com/term/donkey/28242/">Luis Prado</a>,
-        "Globe" by <a href="https://thenounproject.com/term/globe/1806/">Andrew Forrester</a>,
-        "Roof" by <a href="https://thenounproject.com/term/roof/633227/">Symbolon</a>
+        <a href="https://thenounproject.com/jontesta/uploads/?i=13466">&ldquo;Briefcase&rdquo;</a> by John Testa,
+        <a href="https://thenounproject.com/term/donkey/28242/">&ldquo;Donkey&rdquo;</a> by Luis Prado,
+        <a href="https://thenounproject.com/term/globe/1806/">&ldquo;Globe&rdquo;</a> by Andrew Forrester,
+        <a href="https://thenounproject.com/term/roof/633227/">&ldquo;Roof&rdquo;</a> by Symbolon
         from <a href="https://thenounproject.com/">the Noun Project</a>.
       </p>
     </div><!--card__content-->

--- a/frontend/source/sass/components/_footer.scss
+++ b/frontend/source/sass/components/_footer.scss
@@ -42,23 +42,6 @@ footer {
   margin: 3rem 0 1rem 0;
 }
 
-.credits {
-  color: $color-white;
-  font-size: 1.2rem;
-  margin-top: 0;
-  opacity: 0.7;
-  a {
-    color: $color-white;
-    opacity: 0.7;
-    &:hover,
-    &:active {
-      color: $color-white;
-      opacity: 0.7;
-      text-decoration: underline;
-    }
-  }
-}
-
 #logos {
   text-align: right;
   a {


### PR DESCRIPTION
Closes #1273

In this PR, I've moved the icon credits out of the footer template and down to a new section at the bottom of the About page. I manually searched Noun Project to figure out which icon came from whom. One interesting thing is that I couldn't find anything by "Paulo Sá Ferreira" but I did find that our Roof icon seems to come from a previously unmentioned author ("Symbolon"). I followed https://thenounproject.zendesk.com/hc/en-us/articles/200744853-How-do-I-credit-multiple-icons- for how to do the attribution.

<img width="623" alt="screen shot 2017-01-25 at 12 34 37 pm" src="https://cloud.githubusercontent.com/assets/697848/22303842/aadeef16-e2fa-11e6-92b1-ba60d34219cc.png">

