### PR TITLE
Don't allow 'contains phrase' searches w/ empty string terms

### DIFF
--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -60,6 +60,14 @@ class ContractsTest(TestCase):
         self.assertEqual(resp.data['results'], [])
         self.assertEqual(resp.data['first_standard_deviation'], None)
 
+    def test_empty_results_2(self):
+        self.make_test_set()
+        resp = self.c.get(self.path, {'q': 'nsfr87y3487h3rufbf,',
+                                      'query_type': 'match_phrase'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['results'], [])
+        self.assertEqual(resp.data['first_standard_deviation'], None)
+
     def test_search_results(self):
         self.make_test_set()
         resp = self.c.get(self.path, {'q': 'accounting'})

--- a/api/views.py
+++ b/api/views.py
@@ -73,7 +73,7 @@ def get_contracts_queryset(request_params, wage_field):
     contracts = contracts.exclude(**{wage_field + '__isnull': True})
 
     if query:
-        qs = query.split(',')
+        qs = [s for s in query.split(',') if s.strip()]
 
         if query_type not in ('match_phrase', 'match_exact'):
             contracts = contracts.multi_phrase_search(qs)


### PR DESCRIPTION
If a comma-separated list of search terms contains an empty string as one of the terms (e.g. due to a trailing comma) then the "contains phrase" search will actually return all results because every labor category contains the empty string.

This fixes that, I think.
