### PR TITLE
Only copy source code & run gulp for docker cloud deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ calc-prod_manifest.yml
 tag-message-*.txt
 release-*-instructions.txt
 release-*-instructions.html
+Dockerfile.cloud

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,4 @@ COPY requirements-dev.txt /calc/
 
 RUN pip install -r /calc/requirements-dev.txt
 
-# The following lines set up our container for being run in a
-# cloud environment, where folder sharing is disabled. They're
-# irrelevant for a local development environment, where the /calc
-# directory will be superseded by a folder share.
-
-COPY . /calc/
-
-RUN gulp build
-
 ENTRYPOINT ["python", "/calc/docker_django_management.py"]

--- a/Dockerfile.cloud-extras
+++ b/Dockerfile.cloud-extras
@@ -8,7 +8,7 @@
 # The following lines set up our container for being run in a
 # cloud environment, where folder sharing is disabled. They're
 # irrelevant for a local development environment, where the /calc
-# directory will be superseded by a folder share.
+# directory is mounted via folder share.
 
 COPY . /calc/
 

--- a/Dockerfile.cloud-extras
+++ b/Dockerfile.cloud-extras
@@ -1,0 +1,15 @@
+# NOTE:
+#
+# This file should be appended to Dockerfile to create Dockerfile.cloud.
+# To "rebuild" Dockerfile.cloud, run:
+#
+#   cat Dockerfile Dockerfile.cloud-extras > Dockerfile.cloud
+
+# The following lines set up our container for being run in a
+# cloud environment, where folder sharing is disabled. They're
+# irrelevant for a local development environment, where the /calc
+# directory will be superseded by a folder share.
+
+COPY . /calc/
+
+RUN gulp build

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,34 +1,36 @@
-app:
-  volumes:
-    - .:/calc
-    # http://stackoverflow.com/a/37898591
-    - /calc/node_modules/
-  command: python manage.py runserver 0.0.0.0:${DOCKER_EXPOSED_PORT}
-  environment:
-    - EMAIL_URL=smtp://mailcatcher:25/
-  links:
-    - mailcatcher
-gulp:
-  build: .
-  volumes:
-    - .:/calc
-    - /calc/node_modules/
-  command: gulp
-rq_worker:
-  volumes:
-    - .:/calc
-  environment:
-    - EMAIL_URL=smtp://mailcatcher:25/
-  links:
-    - mailcatcher
-rq_scheduler:
-  volumes:
-    - .:/calc
-  environment:
-    - EMAIL_URL=smtp://mailcatcher:25/
-  links:
-    - mailcatcher
-mailcatcher:
-  image: tophfr/mailcatcher:latest
-  ports:
-    - 1080:80
+version: '2'
+services:
+  app:
+    volumes:
+      - .:/calc
+      # http://stackoverflow.com/a/37898591
+      - /calc/node_modules/
+    command: python manage.py runserver 0.0.0.0:${DOCKER_EXPOSED_PORT}
+    environment:
+      - EMAIL_URL=smtp://mailcatcher:25/
+    links:
+      - mailcatcher
+  gulp:
+    build: .
+    volumes:
+      - .:/calc
+      - /calc/node_modules/
+    command: gulp
+  rq_worker:
+    volumes:
+      - .:/calc
+    environment:
+      - EMAIL_URL=smtp://mailcatcher:25/
+    links:
+      - mailcatcher
+  rq_scheduler:
+    volumes:
+      - .:/calc
+    environment:
+      - EMAIL_URL=smtp://mailcatcher:25/
+    links:
+      - mailcatcher
+  mailcatcher:
+    image: tophfr/mailcatcher:latest
+    ports:
+      - 1080:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,37 @@
-app:
-  extends:
-    file: docker-services.yml
-    service: base_app
-  links:
-    - db
-    - redis
-  command: sh -c "python manage.py collectstatic --noinput ; gunicorn -b :${DOCKER_EXPOSED_PORT} hourglass.wsgi:application"
-  ports:
-    - "${DOCKER_EXPOSED_PORT}:${DOCKER_EXPOSED_PORT}"
-db:
-  image: postgres:9.4
-  environment:
-    - POSTGRES_DB=calc
-    - POSTGRES_USER=calc_user
-redis:
-  image: redis:3.0.7-alpine
-rq_worker:
-  extends:
-    file: docker-services.yml
-    service: base_app
-  links:
-    - db
-    - redis
-  command: python manage.py rqworker
-rq_scheduler:
-  extends:
-    file: docker-services.yml
-    service: base_app
-  links:
-    - db
-    - redis
-  command: python manage.py rqscheduler
-  environment:
-    - IS_RQ_SCHEDULER=yup
+version: '2'
+services:
+  app:
+    extends:
+      file: docker-services.yml
+      service: base_app
+    links:
+      - db
+      - redis
+    command: sh -c "python manage.py collectstatic --noinput ; gunicorn -b :${DOCKER_EXPOSED_PORT} hourglass.wsgi:application"
+    ports:
+      - "${DOCKER_EXPOSED_PORT}:${DOCKER_EXPOSED_PORT}"
+  db:
+    image: postgres:9.4
+    environment:
+      - POSTGRES_DB=calc
+      - POSTGRES_USER=calc_user
+  redis:
+    image: redis:3.0.7-alpine
+  rq_worker:
+    extends:
+      file: docker-services.yml
+      service: base_app
+    links:
+      - db
+      - redis
+    command: python manage.py rqworker
+  rq_scheduler:
+    extends:
+      file: docker-services.yml
+      service: base_app
+    links:
+      - db
+      - redis
+    command: python manage.py rqscheduler
+    environment:
+      - IS_RQ_SCHEDULER=yup

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -1,12 +1,14 @@
-base_app:
-  build: .
-  environment:
-    - DDM_HOST_USER=calc_user
-    - PYTHONUNBUFFERED=yup
-    - DATABASE_URL=postgres://calc_user@db/calc
-    - REDIS_URL=redis://redis:6379/0
-    - REDIS_TEST_URL=redis://redis:6379/1
-    # This *must* be at least 2 in order for the fake authentication
-    # server to work, as it makes the app connect to itself (which will
-    # cause the app to hang if only one worker exists).
-    - WEB_CONCURRENCY=2
+version: '2'
+services:
+  base_app:
+    build: .
+    environment:
+      - DDM_HOST_USER=calc_user
+      - PYTHONUNBUFFERED=yup
+      - DATABASE_URL=postgres://calc_user@db/calc
+      - REDIS_URL=redis://redis:6379/0
+      - REDIS_TEST_URL=redis://redis:6379/1
+      # This *must* be at least 2 in order for the fake authentication
+      # server to work, as it makes the app connect to itself (which will
+      # cause the app to hang if only one worker exists).
+      - WEB_CONCURRENCY=2


### PR DESCRIPTION
This helps mitigate #1322 by making things more efficient for the vast majority of use cases, and making things a bit more annoying for cloud deploys.

We do this by moving the `COPY . /calc/` and `RUN gulp build` commands out of the standard `Dockerfile`.  Instead, cloud deployers will need to create a new Dockerfile that concatenates the standard `Dockerfile` and a `Dockerfile.cloud-extras`, the latter of which contains the two missing commands, and then point to this new Dockerfile in their `docker-compose.override.yml`. This process is fully detailed in `README.md`.

Note that in order to accomplish this, I had to upgrade all our docker-compose files to [version 2](https://docs.docker.com/compose/compose-file/#/versioning).  (Uh, I also didn't realize until adding that link, that version 3 is the latest version. But apparently it's only useful for Docker Swarm stuff, which we don't use, so whatevs.)

Anyways, to upgrade to version 2 I just had to add an extra top-level layer to all the YAML files, and re-indent their existing content under a new top-level key called `services`.  **Aside from this minor change, none of the original content in the YAML files has changed.**
