### PR TITLE
Mention not to squash or rebase in RELEASE.md.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,8 +63,9 @@ To release version 0.0.4 of CALC:
     git push
     ```
 
-8.  Merge the PR into `master`. Once Travis CI is finished, the site
-    will be deployed to staging.
+8.  Merge the PR into `master` via the **Create a merge commit** merge
+    strategy (i.e., do *not* squash or rebase). Once Travis CI is finished,
+    the site will be deployed to staging.
 
 9.  Visit the [staging instance][staging] and make sure all is functioning as
     expected.


### PR DESCRIPTION
This mentions not to squash or rebase the release candidate PR into `master`, as that was the cause of the schism which prompted https://github.com/18F/calc/pull/1336#issuecomment-278130292 and #1337.