### PR TITLE
Pin gulp-clean-css to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-react": "^6.9.0",
     "eyeglass": "1.1.2",
     "gulp": "^3.9.1",
-    "gulp-clean-css": "^2.0.11",
+    "gulp-clean-css": "2.3.2",
     "gulp-concat": "^2.6.0",
     "gulp-eslint": "^3.0.1",
     "gulp-if": "^2.0.1",


### PR DESCRIPTION
This ~~fixes~~ works around #1343 by pinning our `gulp-clean-css` to the most recent working *deprecated* version, 2.3.2.  I don't think we can actually upgrade to 3.0 yet because of the breakages documented in #1343, so we might want to leave fixing that to a different PR.