### PR TITLE
Upgrade defusedxml to 0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ PyJWT==1.4.2
 requests==2.13.0
 python-dotenv==0.6.3
 xlrd==1.0.0
-defusedxml==0.4.1
+defusedxml==0.5.0
 rq==0.7.1
 django-rq==0.9.4
 rq-scheduler==0.7.0


### PR DESCRIPTION
New version of `defusedxml` was released today - see changelog at https://github.com/tiran/defusedxml#defusedxml-050rc1.

This should allow us to proceed with upgrading to Python 3.6: https://github.com/18F/calc/pull/1265.