### PR TITLE
Add requirements-temp-extras.txt for easy tinkering/WIP PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 - node --version
 install:
 - pip install -r requirements-dev.txt
+- pip install -r requirements-temp-extras.txt
 - npm install -g gulp-cli
 - npm install
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,7 @@ COPY requirements-dev.txt /calc/
 
 RUN pip install -r /calc/requirements-dev.txt
 
+COPY requirements-temp-extras.txt /calc/
+RUN pip install -r /calc/requirements-temp-extras.txt
+
 ENTRYPOINT ["python", "/calc/docker_django_management.py"]

--- a/requirements-temp-extras.txt
+++ b/requirements-temp-extras.txt
@@ -1,0 +1,10 @@
+# This file can be used to add any temporary extra Python packages
+# for experimentation or use by work-in-progress pull requests. It's
+# particularly useful for folks using Docker, as it means that
+# changing dependencies around a bit doesn't require re-fetching
+# and re-downloading all of them.
+#
+# While this file may be populated during a WIP PR, though, its contents
+# should be moved into requirements.txt or requirements-dev.txt before
+# the PR is merged. In other words, this file should always be empty
+# in the master/develop branches.


### PR DESCRIPTION
In #997 and #1353, to make it easier to iterate on Python dependencies and switch between WIP PRs, I made a `requirements-<something>.txt` file and installed it at the end of my `Dockerfile` and in `.travis.yml`.  This mitigates the Python side of #1230, at least. (Afaik there isn't a similar way to mitigate the node side due to the monolithic nature of `package.json`.)

This PR is an attempt to formalize this pattern by just adding a `requirements-temp-extras.txt` to the repository, which should always be empty (save for its explanatory comments) on the `master`/`develop` branches, but which may contain modules on one's personal checkout or in WIP PRs.
