### PR TITLE
Fix infinite loop case in autocomplete.js

### DIFF
--- a/frontend/source/js/data-explorer/autocomplete.js
+++ b/frontend/source/js/data-explorer/autocomplete.js
@@ -7,7 +7,6 @@ export function appendHighlightedTerm($el, term, searchStr) {
     .trim()
     .split(/[ ]+/)
     .join('|');
-  const re = new RegExp(`(${sanitizedSearch})`, 'gi');
 
   const plainText = (start, end) => document.createTextNode(
     term.substring(start, end),
@@ -15,6 +14,12 @@ export function appendHighlightedTerm($el, term, searchStr) {
   const highlightedText = (start, end) => $('<b></b>').text(
     term.substring(start, end),
   )[0];
+
+  if (sanitizedSearch.length === 0) {
+    return $el.append(plainText(term));
+  }
+
+  const re = new RegExp(`(${sanitizedSearch})`, 'gi');
 
   let done = false;
   let lastIndex = 0;
@@ -66,6 +71,7 @@ export function initialize(el, {
       }, (error, result) => {
         autoCompReq = null;
         if (error) { return done([]); }
+        debugger;
         const categories = result.slice(0, 20).map(d => ({
           term: d.labor_category,
           count: d.count,

--- a/frontend/source/js/data-explorer/autocomplete.js
+++ b/frontend/source/js/data-explorer/autocomplete.js
@@ -71,7 +71,6 @@ export function initialize(el, {
       }, (error, result) => {
         autoCompReq = null;
         if (error) { return done([]); }
-        debugger;
         const categories = result.slice(0, 20).map(d => ({
           term: d.labor_category,
           count: d.count,

--- a/frontend/source/js/tests/data-explorer_tests.js
+++ b/frontend/source/js/tests/data-explorer_tests.js
@@ -18,6 +18,30 @@ QUnit.test('appendHighlightedTerm() prevents stored XSS', (assert) => {
   );
 });
 
+QUnit.test('appendHighlightedTerm() works', (assert) => {
+  assert.equal(
+    appendHighlightedTerm(
+      $('<span></span>'),
+      'superduperman',
+      'super').html(),
+    '<b>super</b>duperman');
+
+  assert.equal(
+    appendHighlightedTerm(
+      $('<span></span>'),
+      'superduperman',
+      'uper').html(),
+    's<b>uper</b>d<b>uper</b>man');
+
+  // test to make sure it doesn't blow up on special-character-only search term
+  assert.equal(
+    appendHighlightedTerm(
+      $('<span></span>'),
+      'superduperman',
+      '{{{').html(),
+    'superduperman');
+});
+
 QUnit.test('parseQuery() works', (assert) => {
   assert.deepEqual(
     parseQuery('?foo=bar'),


### PR DESCRIPTION
Fixes #1355

In the case of `searchStr` comprising only special characters (like `"{{"`) the `while` loop in `appendHighlightedTerm` would never exit because the `sanitizedSearchString` was the empty string, so the regular expression built from it would always return a match.

The code in `autocomplete.js` is still a bit dubious, and I don't love that it is using jQuery. I bet we could could either find or write a better React autocomplete.