### PR TITLE
Oops, migrate temp requirements into requirements.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,11 @@ beautifulsoup4==4.5.3
 semantic_version==2.6.0
 freezegun==0.3.8
 pexpect==4.2.1
+
+# These are used to generate the static documentation, which may be
+# served in production; but because they're statically compiled
+# by CI, they won't be needed by the actual Django app during
+# production, so they can stay here.
+Sphinx==1.5.2
+sphinx-rtd-theme==0.1.9
+recommonmark==0.4.0

--- a/requirements-temp-extras.txt
+++ b/requirements-temp-extras.txt
@@ -8,8 +8,3 @@
 # should be moved into requirements.txt or requirements-dev.txt before
 # the PR is merged. In other words, this file should always be empty
 # in the master/develop branches.
-
-# TODO: Move these before merging this branch into develop!
-Sphinx==1.5.2
-sphinx-rtd-theme==0.1.9
-recommonmark==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,3 @@ mypy-lang==0.4.6
 pytz==2016.10
 Markdown==2.6.8
 cg-django-uaa==0.0.1
-
-# These are currently needed in production because we're serving
-# the docs in production at /docs/.
-Sphinx==1.5.2
-sphinx-rtd-theme==0.1.9
-recommonmark==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,9 @@ mypy-lang==0.4.6
 pytz==2016.10
 Markdown==2.6.8
 cg-django-uaa==0.0.1
+
+# These are currently needed in production because we're serving
+# the docs in production at /docs/.
+Sphinx==1.5.2
+sphinx-rtd-theme==0.1.9
+recommonmark==0.4.0


### PR DESCRIPTION
Oooof, I was a bit too eager to merge #1353 and did so without migrating the requirements out of `requirements-temp-extras.txt`.

This moves them into `requirements.txt`, rather than `requirements-dev.txt`, because right now we're actually serving the developer docs on production... which makes sense I guess since we're also serving the style guide on production too...
