### PR TITLE
Maybe make API docs less confusing

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,47 @@
-## API
+# API
 
-### Rates API
-You can access rate information at `http://localhost:8000/api/rates/`.
+## Access from third-party code
+
+If you want to write a third-party app that uses the
+API from CALC's production instance, you can
+do so by first signing up for an [api.data.gov API key][apikey].
+
+Then, follow the documentation below, but instead of accessing
+the API root at `http://localhost:8000/api/`, you will
+want to use `https://api.data.gov/gsa/calc/`.
+
+[apikey]: https://api.data.gov/signup/
+
+## Access from CALC front-end code
+
+In production, CALC's public API is actually fronted by
+an [API Umbrella][] instance on api.data.gov which proxies all
+API requests to CALC. This allows CALC to not have to concern itself
+with details like API keys and rate limiting.
+
+However, this means that front-end code can't simply make requests
+against `/api/`, as the documentation below might imply.
+Instead, a global called `API_HOST` is available to all front-end
+JS code on every CALC page. When developing locally, it will be
+set to `/api/`, but on CALC's development, staging, and
+production deployments it will be an absolute URL.
+
+Thus, all API requests made from front-end CALC code should use
+`API_HOST` as the base URL for all API requests.
+
+[API Umbrella]: https://apiumbrella.io/
+
+## API endpoints
+
+The following documentation assumes you're trying to access the API
+via a tool like `curl` on a local development instance of CALC at
+`http://localhost:8000/`. If your context or environment is
+different, you will need to use a different base URL, as documented
+previously.
+
+### `/rates/`
+
+You can access rate information at `/rates/`.
 
 #### Labor Categories
 You can search for prices of specific labor categories by using the `q`

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -232,10 +232,8 @@ source /home/vcap/app/.profile.d/python.sh
 
 ### Setting up the API
 
-In production, CALC's public API is actually fronted by an [API Umbrella][]
-instance on api.data.gov which proxies all API requests to CALC. This
-allows CALC to not have to concern itself with details like API keys and
-rate limiting.
+As mentioned in the [API documentation](api.md), CALC's public API
+is actually proxied by api.data.gov.
 
 In order to configure the proxying between api.data.gov and CALC,
 you will need to obtain an administrative account on api.data.gov.
@@ -297,6 +295,5 @@ command-line option.
 
 [UPS]: https://docs.cloudfoundry.org/devguide/services/user-provided.html
 [`README.md`]: https://github.com/18F/calc#readme
-[API Umbrella]: https://apiumbrella.io/
 [api.data.gov User Manual]: https://github.com/18F/api.data.gov/wiki/User-Manual:-Agencies
 [Securing your API backend]: https://github.com/18F/api.data.gov/wiki/User-Manual:-Agencies#securing-your-api-backend


### PR DESCRIPTION
Uggh this is an attempt to make the API docs less confusing.  I think that eventually the real solution will be to have a snazzy interactive documentation page that uses Swagger or whatever, but I guess this is hopefully good enough for now.