### PR TITLE
Data Explorer filter styling fixes

### DIFF
--- a/frontend/source/sass/data_explorer.scss
+++ b/frontend/source/sass/data_explorer.scss
@@ -453,6 +453,10 @@ a.focus-input {
   border-radius: $border-radius;
   display: inline-block;
   padding-left: 0; // ul default override
+
+  label {
+    font-size: $base-font-size;
+  }
 }
 
 .contract-year-item {
@@ -618,10 +622,7 @@ input[type="radio"]:focus + .checkbox-focus {
   border-right: 1px solid $color-gray-lighter;
   &:last-of-type {
     border: none;
-    margin-right: -1px;
-  }
-  &:not(:first-child) {
-    margin-left: -3px
+    margin-right: -3px;
   }
 }
 

--- a/frontend/source/sass/data_explorer.scss
+++ b/frontend/source/sass/data_explorer.scss
@@ -111,6 +111,7 @@ span.dollars {
 
 .filter-title {
   padding-bottom: 0;
+  margin: 1em 0 1.5em 0;
 }
 
 .filter-block {
@@ -118,6 +119,10 @@ span.dollars {
   border-radius: $border-radius;
   margin-bottom: 0;
   padding: 1rem 2rem;
+
+  legend {
+    font-size: $small-font-size;
+  }
 }
 
 
@@ -347,7 +352,6 @@ section.search {
   .experience_range select {
     width: auto;
     height: auto;
-    margin: 15px 0;
     min-width: 51px;
     display: inline-block;
   }
@@ -642,6 +646,4 @@ input[type="radio"]:focus + .checkbox-focus {
 
 .contract-year legend {
   float: left;
-  margin-bottom: 10px;
-  font-size: $small-font-size;
 }


### PR DESCRIPTION
Closes #1229
Closes #1371

- Increase size of contract year radio labels to `$base-font-size`, which is inline with the size of other stuff in the `.filter-block` section
- Simplify/fix negative margins on `.contract-year-item`s so that the light gray borders show properly
- Fix font size of Experience `legend`
- Adjust margins on "Optional filters" heading
- Remove extraneous `margin-bottom` and `font-size` on `.contract-year legend`

Contract Year Radios Before:
<img width="238" alt="screen shot 2017-02-14 at 9 06 17 am" src="https://cloud.githubusercontent.com/assets/697848/22934593/25652882-f295-11e6-9e01-1af49d0a1cd9.png">

Contract Year Radios After:
<img width="233" alt="screen shot 2017-02-14 at 9 31 21 am" src="https://cloud.githubusercontent.com/assets/697848/22935509/6398ade2-f298-11e6-8649-4e62f5ff1c6a.png">

Entire Filter Block Before:
<img width="250" alt="screen shot 2017-02-14 at 9 24 12 am" src="https://cloud.githubusercontent.com/assets/697848/22935366/034f1f84-f298-11e6-813c-96662b0ac217.png">

Entire Filter Block After:
<img width="230" alt="screen shot 2017-02-14 at 9 23 54 am" src="https://cloud.githubusercontent.com/assets/697848/22935395/1a0ebda6-f298-11e6-8257-7180e9e2fdf2.png">

