### PR TITLE
Load Data Explorer React app in <head>

### DIFF
--- a/data_explorer/templates/index.html
+++ b/data_explorer/templates/index.html
@@ -39,11 +39,11 @@
 
 {% block body %}
 <div data-embed-jsx-app-here class="card--half-padding">
-  <noscript>
-    <div class="card">
+  <div class="card">
+    <noscript>
       Please enable JavaScript to use this page's functionality.
-    </div>
-  </noscript>
+    </noscript>
+  </div>
 </div>
 
 <![if gt IE 8]>

--- a/data_explorer/templates/index.html
+++ b/data_explorer/templates/index.html
@@ -45,11 +45,12 @@
     </noscript>
   </div>
 </div>
-
-<![if gt IE 8]>
-{# For the list of files included in this built script, see gulpfile.js #}
-<script src= "{% static 'frontend/built/js/data-explorer/vendor.min.js' %}"></script>
-<script src= "{% static 'frontend/built/js/data-explorer/index.min.js' %}"></script>
-<![endif]>
-
 {% endblock %}
+
+{% block before_body_close %}
+  <![if gt IE 8]>
+  {# For the list of files included in this built script, see gulpfile.js #}
+  <script src= "{% static 'frontend/built/js/data-explorer/vendor.min.js' %}"></script>
+  <script src= "{% static 'frontend/built/js/data-explorer/index.min.js' %}"></script>
+  <![endif]>
+{% endblock before_body_close %}

--- a/data_explorer/templates/index.html
+++ b/data_explorer/templates/index.html
@@ -11,7 +11,13 @@
   <link rel="stylesheet" href="{% static 'frontend/style/vendor/vex.css' %}" />
   <link rel="stylesheet" href="{% static 'frontend/style/vendor/vex-theme-default.css' %}" />
 <![endif]-->
-{% endblock %}
+
+<![if gt IE 8]>
+  {# For the list of files included in this built script, see gulpfile.js #}
+  <script src= "{% static 'frontend/built/js/data-explorer/vendor.min.js' %}"></script>
+  <script src= "{% static 'frontend/built/js/data-explorer/index.min.js' %}"></script>
+<![endif]>
+{% endblock head %}
 
 {% block header_extension %}
 <div class="row clearfix">
@@ -46,11 +52,3 @@
   </div>
 </div>
 {% endblock %}
-
-{% block before_body_close %}
-  <![if gt IE 8]>
-  {# For the list of files included in this built script, see gulpfile.js #}
-  <script src= "{% static 'frontend/built/js/data-explorer/vendor.min.js' %}"></script>
-  <script src= "{% static 'frontend/built/js/data-explorer/index.min.js' %}"></script>
-  <![endif]>
-{% endblock before_body_close %}

--- a/frontend/source/js/data-explorer/explorer.js
+++ b/frontend/source/js/data-explorer/explorer.js
@@ -53,11 +53,14 @@ historySynchronizer.initialize(store, () => {
 
 store.dispatch(invalidateRates());
 
-ReactDOM.render(
-  React.createElement(
-    Provider,
-    { store },
-    React.createElement(App, { api }),
-  ),
-  $('[data-embed-jsx-app-here]')[0],
-);
+// Load the React app once the document is ready
+$(() => {
+  ReactDOM.render(
+    React.createElement(
+      Provider,
+      { store },
+      React.createElement(App, { api }),
+    ),
+    $('[data-embed-jsx-app-here]')[0],
+  );
+});

--- a/frontend/source/sass/components/_header.scss
+++ b/frontend/source/sass/components/_header.scss
@@ -56,7 +56,7 @@ header {
 
 .logo {
   display: inline-block;
-  width: 140px;
+  height: 58px;
   padding-bottom: 0;
 }
 .description-main {


### PR DESCRIPTION
Fixes #1341 by moving the Data Explorer scripts back into the document `<head>`. While this will cause (hopefully unnoticeably) more time before the page is rendered, it should get rid of weird jumps that happen due to the React app even starting to load after other DOM elements.