### PR TITLE
Show help if ./docker-update.sh fails

### DIFF
--- a/docker-update.sh
+++ b/docker-update.sh
@@ -1,6 +1,24 @@
 #! /bin/bash
 
-set -e
+if docker-compose build; then
+  if docker-compose run app ./update.sh; then
+    echo
+    echo "Docker environment updated successfully."
+    exit 0
+  fi
+fi
 
-docker-compose build
-docker-compose run app ./update.sh
+echo
+echo "Alas, something didn't work when trying to update your Docker setup."
+echo "If you're not sure what the problem is, you might want to just "
+echo "reset your environment by running:"
+echo
+echo "    docker-compose stop"
+echo "    docker-compose rm -v"
+echo "    $0"
+echo
+echo "Note that this will reset your database! It will also re-fetch"
+echo "your package dependencies, among other things, so make sure you"
+echo "have a good internet connection."
+
+exit 1


### PR DESCRIPTION
If `./docker-update.sh` ever fails, which it is likely to do, users (especially those new to docker) might be left feeling confused and alone.

This PR helps them out a bit by printing the following in the case of failure:

```
Alas, something didn't work when trying to update your Docker setup.
If you're not sure what the problem is, you might want to just
reset your environment by running:

    docker-compose stop
    docker-compose rm -v
    ./docker-update.sh

Note that this will reset your database! It will also re-fetch
your package dependencies, among other things, so make sure you
have a good internet connection.
```
