### PR TITLE
Serve docs from /docs/ instead of /static/docs/

### DIFF
--- a/hourglass/tests/test_wsgi_middleware.py
+++ b/hourglass/tests/test_wsgi_middleware.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+
+from ..wsgi_middleware import static_url_rewriter
+
+
+class StaticUrlRewriterTests(TestCase):
+    def app(self, environ, start_response):
+        start_response('200 OK', [])
+        return ['hi from ' + environ['PATH_INFO']]
+
+    def start_response(self, status, headers):
+        self.status = status
+        self.headers = headers
+
+    def request(self, path_info):
+        self.status = None
+        self.headers = None
+        self.environ = {'PATH_INFO': path_info}
+        wrapper = static_url_rewriter(self.app, '/boop/', '/static/boop/')
+        return wrapper(self.environ, self.start_response)
+
+    def test_prefix_without_slash_redirects_to_prefix_with_slash(self):
+        self.assertEqual(self.request('/boop'), [])
+        self.assertEqual(self.status, '302 Found')
+        self.assertEqual(self.headers, [('Location', '/boop/')])
+
+    def test_paths_ending_in_slash_rewritten_to_end_with_index_html(self):
+        self.assertEqual(self.request('/boop/'),
+                         ['hi from /static/boop/index.html'])
+
+    def test_paths_not_ending_in_slash_rewritten_to_dest_prefix(self):
+        self.assertEqual(self.request('/boop/_meh/blarg.css'),
+                         ['hi from /static/boop/_meh/blarg.css'])
+
+    def test_paths_not_starting_with_prefix_are_not_rewritten(self):
+        self.assertEqual(self.request('/zzzz/foo'),
+                         ['hi from /zzzz/foo'])

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.views.generic import TemplateView, RedirectView
+from django.views.generic import TemplateView
 
 from .decorators import staff_login_required
 from .healthcheck import healthcheck
@@ -32,9 +32,6 @@ urlpatterns = [
     url(r'^updates/$', view_changelog, name='updates'),
     url(r'^auth/', include('uaa_client.urls', namespace='uaa_client')),
     url(r'^account/', include('user_account.urls', namespace='user_account')),
-    url(r'^docs/',
-        RedirectView.as_view(url=settings.STATIC_URL + 'docs/index.html'),
-        name='sphinx-docs')
 ]
 
 tests_url = url(r'^tests/$', TemplateView.as_view(template_name='tests.html'),

--- a/hourglass/wsgi.py
+++ b/hourglass/wsgi.py
@@ -27,7 +27,38 @@ if nr_license and nr_app_name:
     nr_settings.app_name = nr_app_name
     newrelic.agent.initialize()
 
+
+def static_url_rewriter(app, src_prefix, dest_prefix):
+    '''
+    WSGI middleware to rewrite the `PATH_INFO` of the WSGI
+    environment based on a source and destination prefix.
+
+    The content being served from the site is assumed to be static
+    content, so `index.html` is appended to the path if needed.
+    '''
+
+    def wrapper(environ, start_response):
+        path = environ['PATH_INFO']
+        if path == src_prefix[:-1]:
+            start_response('302 Found', [
+                ('Location', src_prefix)
+            ])
+            return []
+        elif path.startswith(src_prefix):
+            path_info = dest_prefix + path[len(src_prefix):]
+            if path_info.endswith('/'):
+                path_info += 'index.html'
+            environ['PATH_INFO'] = path_info
+        return app(environ, start_response)
+
+    return wrapper
+
+
 try:
-    application = get_wsgi_application()
+    application = static_url_rewriter(
+        get_wsgi_application(),
+        '/docs/',
+        '/static/docs/'
+    )
 except Exception as e:
     print(e)

--- a/hourglass/wsgi.py
+++ b/hourglass/wsgi.py
@@ -12,6 +12,9 @@ from django.core.wsgi import get_wsgi_application
 import newrelic.agent
 from hourglass.settings_utils import load_cups_from_vcap_services
 
+from .wsgi_middleware import static_url_rewriter
+
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hourglass.settings")
 
 # Load user-provided service credentials into the environment so that
@@ -26,32 +29,6 @@ if nr_license and nr_app_name:
     nr_settings.license_key = nr_license
     nr_settings.app_name = nr_app_name
     newrelic.agent.initialize()
-
-
-def static_url_rewriter(app, src_prefix, dest_prefix):
-    '''
-    WSGI middleware to rewrite the `PATH_INFO` of the WSGI
-    environment based on a source and destination prefix.
-
-    The content being served from the site is assumed to be static
-    content, so `index.html` is appended to the path if needed.
-    '''
-
-    def wrapper(environ, start_response):
-        path = environ['PATH_INFO']
-        if path == src_prefix[:-1]:
-            start_response('302 Found', [
-                ('Location', src_prefix)
-            ])
-            return []
-        elif path.startswith(src_prefix):
-            path_info = dest_prefix + path[len(src_prefix):]
-            if path_info.endswith('/'):
-                path_info += 'index.html'
-            environ['PATH_INFO'] = path_info
-        return app(environ, start_response)
-
-    return wrapper
 
 
 try:

--- a/hourglass/wsgi_middleware.py
+++ b/hourglass/wsgi_middleware.py
@@ -1,0 +1,24 @@
+def static_url_rewriter(app, src_prefix, dest_prefix):
+    '''
+    WSGI middleware to rewrite the `PATH_INFO` of the WSGI
+    environment based on a source and destination prefix.
+
+    The content being served from the site is assumed to be static
+    content, so `index.html` is appended to the path if needed.
+    '''
+
+    def wrapper(environ, start_response):
+        path = environ['PATH_INFO']
+        if path == src_prefix[:-1]:
+            start_response('302 Found', [
+                ('Location', src_prefix)
+            ])
+            return []
+        elif path.startswith(src_prefix):
+            path_info = dest_prefix + path[len(src_prefix):]
+            if path_info.endswith('/'):
+                path_info += 'index.html'
+            environ['PATH_INFO'] = path_info
+        return app(environ, start_response)
+
+    return wrapper


### PR DESCRIPTION
This is really yak shaving, but it was bugging me that `docs/` was just a redirect to `static/docs/`, so I wrote a little [WSGI](https://www.python.org/dev/peps/pep-0333/) middleware that rewrites `docs/` internally to `static/docs`.  This "fools" the underlying Django app into thinking that all requests coming in to `docs/` are actually coming in to `static/docs/`.

This is extremely low-priority, though, so feel free to just reject it and tell me to focus on more important things. 😛 

If we do decide to merge it, though, we should add tests.
