### PR TITLE
Use pyflakes 1.4 for python 3.6 f-string support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 
 # Testing and development dependencies
 bandit>=1.0,<2.0
+pyflakes==1.4.0
 flake8==3.2.1
 pytest==3.0.6
 pytest-cov==2.4.0


### PR DESCRIPTION
As mentioned in https://github.com/18F/calc/pull/1384#discussion_r101420670:

> Blerg, this is a dependency of `flake8`, but flake8 implicitly gives us 1.3.0, which doesn't have https://github.com/PyCQA/pyflakes/pull/80, which fixes an incompatibility with parsing files that have f-strings in them.  So we're explicitly requiring the newer version here.

This PR doesn't add any actual f-strings, but every PR i've been working on in the past day has used them and i'm sick of pyflakes barfing on me. 😣 