### PR TITLE
Remove out-of-date cloud.gov sandbox instructions

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -135,10 +135,6 @@ cf target -o fas-calc -s dev
 cf push -f manifests/manifest-staging.yml
 ```
 
-### Your own sandbox server
-
-If you want to deploy to your own sandbox, e.g. for the purpose of deploying a branch you're working on, see the wiki page on [How to Deploy to your cloud.gov Sandbox](https://github.com/18F/calc/wiki/How-to-Deploy-to-your-cloud.gov-Sandbox).
-
 ### Production servers
 
 Production deploys are a somewhat manual process in that they are not done


### PR DESCRIPTION
This fixes #1361 by just removing the sandbox instructions.  Upon merging we should also delete the [wiki page](https://github.com/18F/calc/wiki/How-to-Deploy-to-your-cloud.gov-Sandbox) it links to.

I figure it's safe to delete this; the main reason it was originally written was so we could easily share experimental branches via our cloud.gov sandboxes, but now that's much more easily done through our AWS sandboxes instead.