### PR TITLE
Output mostly blank row when analysis not available, fix exception

### DIFF
--- a/data_capture/analysis/export.py
+++ b/data_capture/analysis/export.py
@@ -5,6 +5,10 @@ from django.http import HttpResponse
 from django.utils import timezone
 
 
+def pct_diff(a, b):
+    return (a - b)/((a + b) / 2) * 100
+
+
 class AnalysisExport:
     output_headers = [
         '#',
@@ -32,13 +36,30 @@ class AnalysisExport:
         self.analyzed_rows = [row['analysis'] for row in rows]
 
     def _to_output_row(self, num, analyzed_row, valid_row):
-        def pct_diff(a, b):
-            return (a - b)/((a + b) / 2) * 100
-
+        # NOTE: analyzed_row['severe'] and 'url'
+        # are not included in the output because they are not in the template
         proposed_price = float(valid_row['price'])
 
-        # TODO: analyzed_row['severe'] and 'url'
-        # are not included in the output because they are not in the template
+        # Use presence of 'count' as a proxy to determine if the
+        # analyzed_row is populated.
+        if 'count' not in analyzed_row:
+            # If not, then return a mostly empty line
+            return [
+                num + 1,
+                0,
+                valid_row['labor_category'],
+                'Error: Comparables not found',
+                valid_row['education_level'],
+                valid_row['min_years_experience'],
+                '',
+                '',
+                proposed_price,
+                '',
+                '',
+                '',
+                '',
+                valid_row['sin'],
+            ]
 
         outside_one_std_dev = 'Yes' if analyzed_row['stddevs'] > 1 else 'No'
 


### PR DESCRIPTION
Fixes a bug encountered by a user of this experimental feature today. On export, they were getting an error (due to a `KeyError`) when one or more labor categories were not able to be analyzed. This PR adds a simple check to make sure the `analyzed_row` is populated (by considering the presence of the `'count'` key to mean that the rest of the fields will also be available).