### PR TITLE
Docker cloud fixes

### DIFF
--- a/Dockerfile.cloud-extras
+++ b/Dockerfile.cloud-extras
@@ -11,5 +11,3 @@
 # directory is mounted via folder share.
 
 COPY . /calc/
-
-RUN gulp build

--- a/create-aws-instance.sh
+++ b/create-aws-instance.sh
@@ -1,0 +1,58 @@
+#! /bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <instance-name>"
+  echo
+  echo "This will spin up a new remote machine called <instance-name> and "
+  echo "deploy CALC to it."
+  exit 1
+fi
+
+export INSTANCE_NAME=$1
+export ENV_FILE=activate-${INSTANCE_NAME}
+export YML_FILE=docker-compose.${INSTANCE_NAME}.yml
+export DOCKERFILE_FILE=Dockerfile.${INSTANCE_NAME}
+
+echo "Provisioning Docker machine."
+
+docker-machine create ${INSTANCE_NAME} \
+  --driver=amazonec2 --amazonec2-instance-type=t2.large
+
+echo "Creating ${DOCKERFILE_FILE}."
+
+cat Dockerfile Dockerfile.cloud-extras > ${DOCKERFILE_FILE}
+
+echo "Creating ${YML_FILE}."
+
+cat docker-compose.cloud.yml \
+  | sed "s/Dockerfile\.cloud/${DOCKERFILE_FILE}/" > ${YML_FILE}
+
+echo "Creating ${ENV_FILE}."
+
+cat << EOF > ${ENV_FILE}
+eval \$(docker-machine env ${INSTANCE_NAME})
+export COMPOSE_FILE=docker-compose.yml:${YML_FILE}
+export DOCKER_EXPOSED_PORT=80
+export DOCKER_HOST_IP=\$(echo \${DOCKER_HOST} | sed 's/tcp:\/\/\([0-9.]*\).*/\1/')
+echo "Now using Docker machine ${INSTANCE_NAME} at \${DOCKER_HOST_IP}."
+EOF
+
+source ${ENV_FILE}
+
+./docker-update.sh
+
+docker-compose run app python manage.py load_data
+
+docker-compose run app python manage.py load_s70
+
+docker-compose up -d
+
+echo "Your new instance of CALC is up at http://${DOCKER_HOST_IP}."
+echo
+echo "To target the remote machine's environment, run:"
+echo
+echo "  source ${ENV_FILE}"
+echo
+echo "Then any docker commands will be run on ${INSTANCE_NAME}."

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  app: &app
+    build:
+      dockerfile: Dockerfile.cloud
+    volumes:
+      - frontend:/calc/frontend/static/frontend/built/
+      - docs:/calc/docs/static/
+    environment:
+      # Feel free to change this value, or add new environment variables.
+      - DEBUG=yup
+      # Do not change the following value.
+      - CALC_IS_ON_DOCKER_IN_CLOUD=yup
+  rq_worker:
+    <<: *app
+  rq_scheduler:
+    <<: *app
+volumes:
+  frontend:
+  docs:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,7 +25,11 @@ html: Makefile
 	rm -rf $(BUILDDIR)
 
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	rm -rf $(DJANGODIR)
+
+# Note that $(DJANGODIR) might be a mounted volume, in which case it can't
+# be deleted, so we'll simply delete anything *inside* it.
+	rm -rf $(DJANGODIR)/*
+
 	mkdir -p $(DJANGODIR)
 	cp -R $(BUILDDIR)/html $(DJANGODIR)/docs/
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -138,6 +138,11 @@ So, you should first run `./docker-update.sh` to set everything up,
 followed by `docker-compose up`. Now you should have a server
 running in the cloud!
 
+**Note:** A script, [create-aws-instance.sh](../create-aws-instance.sh),
+actually automates all of this for you, but it's coupled to Amazon
+Web Services (AWS). You're welcome to use it directly or edit it to
+your own needs. Run it without any arguments for help.
+
 **Note:** As mentioned earlier, your app's source code is part of
 the container image. This means that every time you make a source code 
 change, you will need to re-run `./docker-update.sh`.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -120,32 +120,27 @@ Also, unlike local development, cloud deploys don't support an
 `docker-compose.override.yml` file that defines the app's
 environment variables, and also points to the alternate Dockerfile:
 
-```yaml
-version: '2'
-services:
-  app: &app
-    build:
-      dockerfile: Dockerfile.cloud
-    environment:
-      - DEBUG=yup
-  rq_worker:
-    <<: *app
-  rq_scheduler:
-    <<: *app
 ```
+cp docker-compose.cloud.yml docker-compose.override.yml
+```
+
+You can edit this file to add or change environment variables as needed.
 
 You'll also want to tell Docker Compose what port to listen on,
 which can be done in the terminal by running
 `export DOCKER_EXPOSED_PORT=8000`.
 
-At this point, you can use Docker's command-line tools, such as
-`docker-compose up`, and your actions will take effect on the remote
-host instead of your local machine. The `./docker-update.sh` script
-will also take effect on the remote host.
+At this point, you can use Docker's command-line tools and CALC's
+Docker-related scripts, and your actions will take effect on the remote
+host instead of your local machine.
+
+So, you should first run `./docker-update.sh` to set everything up,
+followed by `docker-compose up`. Now you should have a server
+running in the cloud!
 
 **Note:** As mentioned earlier, your app's source code is part of
 the container image. This means that every time you make a source code 
-change, you will need to re-run `docker-compose build`.
+change, you will need to re-run `./docker-update.sh`.
 
 [18F Docker guide]: https://pages.18f.gov/dev-environment-standardization/virtualization/docker/
 [Docker]: https://www.docker.com/

--- a/update.sh
+++ b/update.sh
@@ -13,3 +13,8 @@ python manage.py migrate --noinput
 
 echo "----- Initializing Groups -----"
 python manage.py initgroups
+
+if [ -n "${CALC_IS_ON_DOCKER_IN_CLOUD}" ]; then
+  echo "----- Building Static Assets -----"
+  gulp build
+fi


### PR DESCRIPTION
Oops, it looks like #1369 actually broke our docker cloud deployment setup. This fixes it and also adds the `create-aws-instance.sh` script, based on the one in #997, to make it easier to deploy to docker on an aws ec2 instance.

As such, this also basically fixes #1396.