### PR TITLE
Add directories to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,3 +28,9 @@ docker-compose.override.yml
 .dockerignore
 
 .git
+.eyeglass_cache
+__pycache__
+docs/_build
+frontend/static/frontend/built
+contracts/docs/hourly_prices_v*.csv
+contracts/docs/s70/s70_data_v*.csv


### PR DESCRIPTION
This adds some directories to our `.dockerignore` file.  While they affect the files copied into the docker image on cloud builds, they are also uploaded to the docker host when the image is built because they constitute the [build context](https://github.com/docker/docker/issues/2342).

This means that by default, everything not mentioned in `.dockerignore` is *always* uploaded to the docker host before it even starts building the docker image.

So a really big context slows things down a little bit when developing locally, but for cloud deploys it makes a really big difference, since the context is being transmitted across the intertubes. So if you have a slow internet connection, `docker-compose build` will take an eternity.

This PR reduces the size of the build context from ~70 MB to ~20 MB.

(You can see how big the context is by running `docker build .` in the root of the repository; the first line of output will say something like `Sending build context to Docker daemon 17.29 MB`.)