### PR TITLE
Fix broken link in djdt docs panel.

### DIFF
--- a/data_capture/templates/data_capture/panels/docs.html
+++ b/data_capture/templates/data_capture/panels/docs.html
@@ -2,7 +2,7 @@
 
 <p>
   Please make sure you read the
-  <a href="{% url 'sphinx-docs' %}">developer documentation</a>
+  <a href="/docs/">developer documentation</a>
   thoroughly.
 </p>
 


### PR DESCRIPTION
Urrg #1391 removed the named `sphinx-docs` URL from the url config because the docs endpoint is now being served through underlying WSGI middleware instead of django.  This fixes things by just linking to `/docs/` directly.