### PR TITLE
Glean first integer in cell contents for min experience

### DIFF
--- a/data_capture/schedules/coercers.py
+++ b/data_capture/schedules/coercers.py
@@ -146,3 +146,28 @@ def extract_hour_unit_of_issue(text):
         return text
 
     return 'Hour'
+
+
+def extract_first_int(text):
+    '''
+    Returns the first integer found in the input text.
+
+    >>> extract_first_int('At least 12 years with 8 years management')
+    12
+
+    >>> extract_first_int('5+')
+    5
+
+    >>> extract_first_int(8.0)
+    8
+
+    Returns the original value if an integer is not found.
+
+    >>> extract_first_int('No integers here')
+    'No integers here'
+    '''
+    match = re.search(r'\d+', str(text))
+    if not match:
+        return text
+
+    return int(match.group())

--- a/data_capture/schedules/s70.py
+++ b/data_capture/schedules/s70.py
@@ -10,7 +10,7 @@ from django.template.loader import render_to_string
 from .base import (BasePriceList, min_price_validator,
                    hourly_rates_only_validator)
 from .coercers import (strip_non_numeric, extract_min_education,
-                       extract_hour_unit_of_issue)
+                       extract_hour_unit_of_issue, extract_first_int)
 from contracts.models import EDUCATION_CHOICES
 
 
@@ -150,7 +150,7 @@ def glean_labor_categories_from_book(book, sheet_name=DEFAULT_SHEET_NAME):
     # as a string
     coercion_map = {
         'price_including_iff': strip_non_numeric,
-        'min_years_experience': int,
+        'min_years_experience': extract_first_int,
         'education_level': extract_min_education,
         'unit_of_issue': extract_hour_unit_of_issue,
     }

--- a/data_capture/tests/test_s70.py
+++ b/data_capture/tests/test_s70.py
@@ -193,6 +193,12 @@ class GleanLaborCategoriesTests(TestCase):
 
         self.assertEqual(rows[0]['unit_of_issue'], 'Hour')
 
+    def test_min_experience_is_gleaned_from_text(self):
+        book = FakeWorkbook()
+        book._sheets[0]._cells[1][3] = 'At least 3 years but up to 20'
+        rows = s70.glean_labor_categories_from_book(book)
+        self.assertEqual(rows[0]['min_years_experience'], '3')
+
     def test_validation_error_raised_when_sheet_not_present(self):
         with self.assertRaisesRegexp(
             ValidationError,


### PR DESCRIPTION
This replaces the simple `int` coercer for `min_experience` with a new one called `extract_first_int` that instead returns the _first_ integer value found in the cell's contents.

This will allow gleaning of contents like `"At least 5 years, with 2 years management"` (-> `5`) that @tram has been seeing in research sessions. It will also handle contents like `"10+"` (-> `10`). And it will of course handle the "normal" case of just having an integer in the cell.

We discussed wanting to have "warning messages" shown for this special gleaning case (and maybe some others), since it is possible our parser could glean an unintended or surprising value, so it would be nice to notify the user, but not throw out the row. I think implementation of these warnings should be handled separately though.