### PR TITLE
Adjust front page header text

### DIFF
--- a/data_explorer/templates/index.html
+++ b/data_explorer/templates/index.html
@@ -22,8 +22,8 @@
 {% block header_extension %}
 <div class="row clearfix">
   <div class="eight columns">
-    <h1 class="description-main">Search awarded ceiling rates for labor categories</h1>
-    <h2 class="description-secondary">CALC lets you conduct market research on professional service labor categories quickly and easily, helping you make better informed decisions. Results shown are awarded hourly rates from GSA IDIQ service schedules.</h2>
+    <h1 class="description-main">Search awarded services hourly rates for government contracts</h1>
+    <h2 class="description-secondary">CALC lets you conduct market research for labor categories quickly, helping you make better informed decisions. Results shown are from Federal Government contracts.</h2>
   </div>
   <div class="price-callout four columns">
     <h3>CALC offers &hellip;</h3>


### PR DESCRIPTION
Quick adjustment of header text based on https://github.com/18F/calc/issues/1383#issuecomment-280153642

<img width="974" alt="screen shot 2017-02-21 at 12 31 18 pm" src="https://cloud.githubusercontent.com/assets/697848/23183754/fcb485ac-f831-11e6-917b-1e5162393cad.png">


Closes #1383