### PR TITLE
Link to API docs for more details on API_HOST

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -81,7 +81,7 @@ string), the boolean is true; otherwise, it's false.
   API hosted by CALC. It defaults to `/api/` but may need to be changed
   if the API has a proxy in front of it, as it likely will be if deployed
   on government infrastructure. For more information, see
-  [Deploying to Cloud Foundry](deploy.md).
+  the [API documentation](api.md).
 
 * `SECURITY_HEADERS_ON_ERROR_ONLY` is a boolean value that indicates whether
   security-related response headers (such as `X-XSS-Protection`)


### PR DESCRIPTION
The really useful info on `API_HOST` is in the API docs as of #1366, so I figure we should link to that instead of the cloud foundry deployment instructions.