### PR TITLE
Allow NON_PROD_INSTANCE_NAME to contain HTML

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -95,7 +95,8 @@ string), the boolean is true; otherwise, it's false.
 
 * `NON_PROD_INSTANCE_NAME` is an optional instance name that when specified
   will cause a banner to be shown at the top of every page to let users know
-  that they are viewing a non-production instance of CALC.
+  that they are viewing a non-production instance of CALC. This value
+  can contain HTML, so it's possible to e.g. wrap the value in a hyperlink.
 
 * `NEW_RELIC_LICENSE_KEY` is the private New Relic license key for this project.
   If it is present, then the WSGI app will be wrapped with the  New Relic agent.

--- a/hourglass/context_processors.py
+++ b/hourglass/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.safestring import mark_safe
 
 
 def api_host(request):
@@ -23,4 +24,5 @@ def help_email(request):
 
 def non_prod_instance_name(request):
     '''Include NON_PROD_INSTANCE_NAME in all request contexts'''
-    return {'NON_PROD_INSTANCE_NAME': settings.NON_PROD_INSTANCE_NAME}
+    value = mark_safe(settings.NON_PROD_INSTANCE_NAME)  # nosec
+    return {'NON_PROD_INSTANCE_NAME': value}

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -66,7 +66,7 @@ API_HOST = os.environ.get('API_HOST', '/api/')
 
 GA_TRACKING_ID = os.environ.get('GA_TRACKING_ID', '')
 
-NON_PROD_INSTANCE_NAME = os.environ.get('NON_PROD_INSTANCE_NAME')
+NON_PROD_INSTANCE_NAME = os.environ.get('NON_PROD_INSTANCE_NAME', '')
 
 TEMPLATES = [{
     'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
For temporary AWS sandbox deployments of CALC that contain WIP PRs, I thought it'd be nice if the banner could link to the PR, e.g.:

```bash
NON_PROD_INSTANCE_NAME="<a href='https://github.com/18F/calc/pull/997'>price list analysis</a>"
```

could display on the site as:

> ![screen shot 2017-02-23 at 8 19 38 am](https://cloud.githubusercontent.com/assets/124687/23260762/5f933216-f9a1-11e6-8929-f59d12562b19.png)

Even for our dev/staging deploys, perhaps if we eventually write up a document that explains what they are (e.g. that `dev` is the head of the `develop` branch while `staging` is pre-tagged `master`) we could link them to the explanatory document.

Wat u say @jseppi ?
