### PR TITLE
Add private DEFAULT_DEBUG_EMAIL_URL env var

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,7 +5,7 @@ services:
       - .:/calc
     command: python manage.py runserver 0.0.0.0:${DOCKER_EXPOSED_PORT}
     environment:
-      - EMAIL_URL=smtp://mailcatcher:25/
+      - DEFAULT_DEBUG_EMAIL_URL=smtp://mailcatcher:25/
     links:
       - mailcatcher
   gulp:
@@ -19,14 +19,14 @@ services:
     volumes:
       - .:/calc
     environment:
-      - EMAIL_URL=smtp://mailcatcher:25/
+      - DEFAULT_DEBUG_EMAIL_URL=smtp://mailcatcher:25/
     links:
       - mailcatcher
   rq_scheduler:
     volumes:
       - .:/calc
     environment:
-      - EMAIL_URL=smtp://mailcatcher:25/
+      - DEFAULT_DEBUG_EMAIL_URL=smtp://mailcatcher:25/
     links:
       - mailcatcher
   mailcatcher:

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -39,7 +39,10 @@ if DEBUG:
         'SECRET_KEY',
         'I am an insecure secret key intended ONLY for dev/testing.'
     )
-    os.environ.setdefault('EMAIL_URL', 'console:')
+    os.environ.setdefault(
+        'EMAIL_URL',
+        os.environ.get('DEFAULT_DEBUG_EMAIL_URL', 'console:')
+    )
     if 'REDIS_URL' not in os.environ:
         # Only set a default REDIS_TEST_URL if REDIS_URL is not
         # explicitly defined either.


### PR DESCRIPTION
So one of the things I noticed while working on #1407 is that it's not easy to change `EMAIL_URL` on local development instances because the environment variables specified in `docker-compose.local.yml` override those in the user's `.env` file.

To work around this, I added a new, undocumented `DEFAULT_DEBUG_EMAIL_URL` environment variable that basically tells debug instances what email URL to use if `EMAIL_URL` isn't defined. It defaults to `console:`, just like `EMAIL_URL` did.

I'm leaving this new variable undocumented because it's really more of an implementation detail--not something that we expect devs or deployers to redefine.

This will allow devs to specify `EMAIL_URL` in their `.env` file to deliver "real" emails if they really need to test that out.
