### PR TITLE
Delete bulk-created Contracts when SubmittedPriceList with same Contract Number is approved

### DIFF
--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -187,8 +187,7 @@ def approve(modeladmin, request, queryset):
             schedule=price_list.get_schedule_title(),  # on same schedule
             upload_source__isnull=False,  # and that have bulk upload src
         )
-        # TODO: keep track of num deleted (per contract num) and add to message
-        # num_existing = existing_bulk_contracts.count()
+        # keep track of num deleted (per contract num)
         existing_count = existing_bulk_contracts.count()
         if existing_count:
             deleted_counts[price_list.contract_number] = existing_count

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -208,7 +208,7 @@ def approve(modeladmin, request, queryset):
     for del_contract_num, del_count in deleted_counts.items():
         messages.add_message(
             request,
-            messages.INFO,
+            messages.WARNING,
             '{} existing row(s) of bulk-loaded data for contract number {} '
             'were removed from CALC'.format(del_count, del_contract_num)
         )


### PR DESCRIPTION
When an admin approves submitted price lists, now any bulk-loaded contract data with the same contract numbers (and on the same schedule) as any of the submitted price lists will be DELETED. 

This is to prevent duplicate data showing up in the API/Data Explorer as S70 COs enter price lists through Data Capture's flow.

Closes #1421

<img width="744" alt="screen shot 2017-02-23 at 3 27 45 pm" src="https://cloud.githubusercontent.com/assets/697848/23279912/c0301572-f9dc-11e6-902d-cca3792f7dd0.png">
