### PR TITLE
Include UaaBackend in tests

### DIFF
--- a/data_capture/tests/test_email.py
+++ b/data_capture/tests/test_email.py
@@ -15,12 +15,6 @@ from .test_models import ModelTestCase
 @freeze_time(datetime(2017, 1, 8, 20, 51, 0))
 @override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE],
 
-                   # Ugh, this is required for the cg-django-uaa to not
-                   # complain when running this test suite standalone.
-                   AUTHENTICATION_BACKENDS=(
-                       'uaa_client.authentication.UaaBackend',
-                   ),
-
                    # This ensures absolute URLs produced by our code
                    # are https-based.
                    SECURE_SSL_REDIRECT=True,

--- a/hourglass/tests/common.py
+++ b/hourglass/tests/common.py
@@ -20,7 +20,12 @@ class BaseTestCase(TestCase):
     PASSWORD_HASHERS=['django.contrib.auth.hashers.MD5PasswordHasher'],
     # Ignore our custom auth backend so we can log the user in via
     # Django 1.8's login helpers.
-    AUTHENTICATION_BACKENDS=['django.contrib.auth.backends.ModelBackend'],
+    AUTHENTICATION_BACKENDS=[
+        'django.contrib.auth.backends.ModelBackend',
+        # But also include UaaBackend so cg-django-uaa doesn't raise an
+        # ImproperlyConfigured error.
+        'uaa_client.authentication.UaaBackend',
+    ],
 )
 class BaseLoginTestCase(BaseTestCase):
     def create_user(self, username, password=None, is_staff=False,


### PR DESCRIPTION
This is a workaround for https://github.com/18F/calc/pull/1407#discussion_r103016299, whereby running some tests standalone results in an `ImproperlyConfigured` error.  I guess also by enabling both the standard auth backend and the `UaaBackend`, we can move towards fixing #677.
