### PR TITLE
Link to email template source in styleguide

### DIFF
--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -584,6 +584,12 @@
   </p>
 
   <p>
+    The base template used to render emails is at
+    {% template_link 'email/base.html' %}, while common template tags are
+    in {% pyobjname 'data_capture.templatetags.email_utils' %}.
+  </p>
+
+  <p>
     Examples of each email type that can be sent from CALC are listed
     below.
   </p>
@@ -594,7 +600,8 @@
       {{ example.subject }}
       <br>
       <a href="{{ example.plaintext_url }}">Plain text</a> |
-       <a href="{{ example.html_url }}">HTML</a>
+       <a href="{{ example.html_url }}">HTML</a> |
+       <a href="{% template_url example.template %}">Template source</a>
     </li>
     {% endfor %}
   </ul>

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -586,7 +586,7 @@
   <p>
     The base template used to render emails is at
     {% template_link 'email/base.html' %}, while common template tags are
-    in {% pyobjname 'data_capture.templatetags.email_utils' %}.
+    in the {% template_tag_library 'email_utils' %} template tag library.
   </p>
 
   <p>

--- a/styleguide/templatetags/styleguide.py
+++ b/styleguide/templatetags/styleguide.py
@@ -77,6 +77,26 @@ class WebComponentHTMLParser(HTMLParser):
                 self.extends = val
 
 
+@register.simple_tag(takes_context=True)
+def template_url(context, template_name):
+    '''
+    Return a GitHub URL to the source of the given template.
+    '''
+
+    t = context.template.engine.get_template(template_name)
+    return github_url_for_path(os.path.relpath(t.origin.name, ROOT_DIR))
+
+
+@register.simple_tag(takes_context=True)
+def template_link(context, template_name):
+    '''
+    Return a link to the source code of the given template.
+    '''
+
+    url = template_url(context, template_name)
+    return SafeString(f'<code><a href="{url}">{template_name}</a></code>')
+
+
 @register.simple_tag
 def webcomponent(html):
     '''

--- a/styleguide/templatetags/styleguide.py
+++ b/styleguide/templatetags/styleguide.py
@@ -77,14 +77,59 @@ class WebComponentHTMLParser(HTMLParser):
                 self.extends = val
 
 
+@register.simple_tag
+def template_tag_library(name):
+    from importlib import import_module
+    from django.template.base import get_templatetags_modules
+
+    mod = None
+
+    for modname in get_templatetags_modules():
+        try:
+            mod = import_module(f'{modname}.{name}')
+            break
+        except ModuleNotFoundError:
+            pass
+
+    if mod is None:
+        raise ValueError(f'template tag library {name} not found')
+
+    if not mod.__file__.startswith(ROOT_DIR):
+        raise ValueError(f'template tag library {name} is not in project')
+
+    url = github_url_for_path(os.path.relpath(mod.__file__, ROOT_DIR))
+
+    return SafeString(f'<code><a href="{url}">{name}</a></code>')
+
+
 @register.simple_tag(takes_context=True)
 def template_url(context, template_name):
     '''
     Return a GitHub URL to the source of the given template.
     '''
 
-    t = context.template.engine.get_template(template_name)
-    return github_url_for_path(os.path.relpath(t.origin.name, ROOT_DIR))
+    # Note that we can't simply use the `origin` property of a Template
+    # object, because, at least in Django 1.8, it seems this property
+    # is None if TEMPLATE_DEBUG is disabled (and we want to be able to
+    # render the styleguide in non-debug instances).
+
+    candidates = []
+
+    for loader in context.template.engine.template_loaders:
+        for candidate in loader.get_template_sources(template_name):
+            candidates.append(candidate)
+
+    path = None
+
+    for candidate in candidates:
+            if os.path.exists(candidate):
+                path = candidate
+                break
+
+    if path is None:
+        raise ValueError(f'Template {template_name} not found')
+
+    return github_url_for_path(os.path.relpath(path, ROOT_DIR))
 
 
 @register.simple_tag(takes_context=True)

--- a/styleguide/tests.py
+++ b/styleguide/tests.py
@@ -1,11 +1,9 @@
-from unittest.mock import MagicMock
 from django.test import TestCase, SimpleTestCase
 from django.template import engines
 
 from styleguide import email_examples
 from styleguide.templatetags.styleguide import (
     template_tag_library,
-    template_url,
     github_url_for_path,
 )
 

--- a/styleguide/tests.py
+++ b/styleguide/tests.py
@@ -1,6 +1,16 @@
-from django.test import TestCase
+from unittest.mock import MagicMock
+from django.test import TestCase, SimpleTestCase
+from django.template import engines
 
 from styleguide import email_examples
+from styleguide.templatetags.styleguide import (
+    template_tag_library,
+    template_url,
+    github_url_for_path,
+)
+
+
+GITHUB_TREE_URL = github_url_for_path('')[:-1]
 
 
 class StyleguideTests(TestCase):
@@ -28,3 +38,35 @@ class StyleguideTests(TestCase):
 
             plaintext_response = self.client.get(example.plaintext_url)
             self.assertEqual(plaintext_response.status_code, 200)
+
+
+class TemplateTagsTests(SimpleTestCase):
+    def render_string(self, string):
+        t = engines['django'].from_string(r'{% load styleguide %}' + string)
+        return t.render({})
+
+    def test_template_raises_exception_if_library_not_found(self):
+        with self.assertRaisesRegexp(ValueError,
+                                     'library blarg not found'):
+            template_tag_library('blarg')
+
+    def test_template_raises_exception_if_library_not_in_project(self):
+        with self.assertRaisesRegexp(ValueError,
+                                     'library staticfiles is not in project'):
+            template_tag_library('staticfiles')
+
+    def test_template_tag_library_works(self):
+        self.assertIn(
+            f'{GITHUB_TREE_URL}/styleguide/templatetags/styleguide.py',
+            template_tag_library('styleguide'),
+        )
+
+    def test_template_url_raises_error_if_template_not_found(self):
+        with self.assertRaisesRegexp(ValueError, 'Template blah not found'):
+            self.render_string('{% template_url "blah" %}')
+
+    def test_template_url_works(self):
+        self.assertEqual(
+            self.render_string('{% template_url "styleguide.html" %}'),
+            f'{GITHUB_TREE_URL}/styleguide/templates/styleguide.html'
+        )


### PR DESCRIPTION
@jseppi I'm not sure if this is what you meant by https://github.com/18F/calc/pull/1407#discussion_r103044659, but I thought it'd be useful regardless. Basically it adds `{% template_tag_library %}`, `{% template_url %}`, and `{% template_link %}` template tags to the styleguide, which allows us to link to templates and template tag libraries like so:

> ![template_links](https://cloud.githubusercontent.com/assets/124687/23368362/9c9867b6-fcdb-11e6-8a6e-2c04719ec47f.png)

That way anyone who wants to edit one of these can easily find the link (though it could also be discovered by using the Django Debug Toolbar, I think this is easier).
