### PR TITLE
Move example email metadata into emails.py

### DIFF
--- a/data_capture/email.py
+++ b/data_capture/email.py
@@ -1,6 +1,8 @@
 import re
+from functools import wraps
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.utils.html import strip_tags
+from django.utils import timezone
 from django.template.loader import render_to_string
 from django.contrib.auth.models import User
 from django.template.defaultfilters import pluralize
@@ -93,7 +95,52 @@ def send_mail(subject, to, template, ctx, reply_to=None):
     return msg.send()
 
 
-def price_list_approved(price_list):
+EXAMPLES = []
+
+
+def email_sender(template, example_ctx):
+    '''
+    Decorator for any function that sends an email. Takes a template
+    name and an example context to pass to it; this information will
+    be added to EXAMPLES, which can then be used to render example
+    emails for debugging/development.
+
+    The given template name will be passed on to the decorated function
+    as its first argument.
+    '''
+
+    def wrap(func):
+        name = func.__name__.replace('_', ' ')
+
+        EXAMPLES.append({
+            'subject': f'Example {name}',
+            'template': template,
+            'ctx': example_ctx,
+        })
+
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            return func(template, *args, **kwargs)
+
+        wrapped.example_ctx = example_ctx
+
+        return wrapped
+    return wrap
+
+
+@email_sender(
+    template='data_capture/email/price_list_approved.html',
+    example_ctx={
+        'price_list': {
+            'created_at': timezone.now(),
+            'contract_number': 'GS-12-Example',
+            'get_schedule_title': 'Fake Schedule',
+            'vendor_name': 'Example Vendor, Inc.',
+        },
+        'details_link': 'https://example.com/price-list/details',
+    }
+)
+def price_list_approved(template, price_list):
     details_link = absolute_reverse('data_capture:price_list_details',
                                     kwargs={'id': price_list.pk})
 
@@ -107,7 +154,7 @@ def price_list_approved(price_list):
 
     result = send_mail(
         subject='CALC Price List Approved',
-        template='data_capture/email/price_list_approved.html',
+        template=template,
         ctx=ctx,
         reply_to=[settings.HELP_EMAIL],
         to=[price_list.submitter.email],
@@ -118,7 +165,11 @@ def price_list_approved(price_list):
     )
 
 
-def price_list_retired(price_list):
+@email_sender(
+    template='data_capture/email/price_list_retired.html',
+    example_ctx=price_list_approved.example_ctx
+)
+def price_list_retired(template, price_list):
     details_link = absolute_reverse('data_capture:price_list_details',
                                     kwargs={'id': price_list.pk})
 
@@ -132,7 +183,7 @@ def price_list_retired(price_list):
 
     result = send_mail(
         subject='CALC Price List Retired',
-        template='data_capture/email/price_list_retired.html',
+        template=template,
         ctx=ctx,
         reply_to=[settings.HELP_EMAIL],
         to=[price_list.submitter.email],
@@ -143,7 +194,11 @@ def price_list_retired(price_list):
     )
 
 
-def price_list_rejected(price_list):
+@email_sender(
+    template='data_capture/email/price_list_rejected.html',
+    example_ctx=price_list_approved.example_ctx
+)
+def price_list_rejected(template, price_list):
     details_link = absolute_reverse('data_capture:price_list_details',
                                     kwargs={'id': price_list.pk})
 
@@ -154,7 +209,7 @@ def price_list_rejected(price_list):
 
     result = send_mail(
         subject='CALC Price List Rejected',
-        template='data_capture/email/price_list_rejected.html',
+        template=template,
         ctx=ctx,
         reply_to=[settings.HELP_EMAIL],
         to=[price_list.submitter.email]
@@ -167,7 +222,20 @@ def price_list_rejected(price_list):
     )
 
 
-def bulk_upload_succeeded(upload_source, num_contracts, num_bad_rows):
+@email_sender(
+    template='data_capture/email/bulk_upload_succeeded.html',
+    example_ctx={
+        'upload_source': {
+            'id': 2,
+            'submitter': {'email': 'example_admin@example.com'},
+            'created_at': timezone.now(),
+        },
+        'num_contracts': 50123,
+        'num_bad_rows': 25,
+    }
+)
+def bulk_upload_succeeded(template, upload_source, num_contracts,
+                          num_bad_rows):
     ctx = {
         'upload_source': upload_source,
         'num_contracts': num_contracts,
@@ -177,7 +245,7 @@ def bulk_upload_succeeded(upload_source, num_contracts, num_bad_rows):
     result = send_mail(
         subject='CALC Region 10 bulk data results - upload #{}'.format(
             upload_source.id),
-        template='data_capture/email/bulk_upload_succeeded.html',
+        template=template,
         ctx=ctx,
         reply_to=[settings.HELP_EMAIL],
         to=[upload_source.submitter.email],
@@ -188,7 +256,14 @@ def bulk_upload_succeeded(upload_source, num_contracts, num_bad_rows):
     )
 
 
-def bulk_upload_failed(upload_source, traceback):
+@email_sender(
+    template='data_capture/email/bulk_upload_failed.html',
+    example_ctx={**bulk_upload_succeeded.example_ctx, **{
+        'r10_upload_link': 'https://example.com/r10_bulk_upload',
+        'traceback': 'error traceback'
+    }}
+)
+def bulk_upload_failed(template, upload_source, traceback):
     r10_upload_link = absolute_reverse(
         'data_capture:bulk_region_10_step_1')
 
@@ -202,7 +277,7 @@ def bulk_upload_failed(upload_source, traceback):
         subject='CALC Region 10 bulk data results - upload #{}'.format(
             upload_source.id
         ),
-        template='data_capture/email/bulk_upload_failed.html',
+        template=template,
         ctx=ctx,
         reply_to=[settings.HELP_EMAIL],
         to=[upload_source.submitter.email],
@@ -213,7 +288,13 @@ def bulk_upload_failed(upload_source, traceback):
     )
 
 
-def approval_reminder(count_unreviewed):
+@email_sender(
+    template='data_capture/email/approval_reminder.html',
+    example_ctx={
+        'unreviewed_url': 'https://example.com/unreviewed_price_lists',
+    }
+)
+def approval_reminder(template, count_unreviewed):
     unreviewed_url = absolute_reverse(
         'admin:data_capture_unreviewedpricelist_changelist')
 
@@ -227,7 +308,7 @@ def approval_reminder(count_unreviewed):
     result = send_mail(
         subject='CALC Reminder - {} price list{} not reviewed'.format(
             count_unreviewed, pluralize(count_unreviewed)),
-        template='data_capture/email/approval_reminder.html',
+        template=template,
         ctx=ctx,
         reply_to=[settings.HELP_EMAIL],
         to=recipients,

--- a/data_capture/management/commands/send_example_emails.py
+++ b/data_capture/management/commands/send_example_emails.py
@@ -1,70 +1,6 @@
-from django.utils import timezone
-
 import djclick as click
 
 from data_capture import email
-
-
-pl_ctx = {
-    'price_list': {
-        'created_at': timezone.now(),
-        'contract_number': 'GS-12-Example',
-        'get_schedule_title': 'Fake Schedule',
-        'vendor_name': 'Example Vendor, Inc.',
-    },
-    'details_link': 'https://example.com/price-list/details',
-}
-
-EXAMPLES = [
-    dict(
-        subject='Example Price List Approved',
-        template='data_capture/email/price_list_approved.html',
-        ctx=pl_ctx
-    ),
-    dict(
-        subject='Example Price List Rejected',
-        template='data_capture/email/price_list_rejected.html',
-        ctx=pl_ctx
-    ),
-    dict(
-        subject='Example Price List Retired',
-        template='data_capture/email/price_list_retired.html',
-        ctx=pl_ctx
-    ),
-    dict(
-        subject='Example Bulk Upload Succeeded',
-        template='data_capture/email/bulk_upload_succeeded.html',
-        ctx={
-                'upload_source': {
-                    'id': 2,
-                    'submitter': {'email': 'example_admin@example.com'},
-                    'created_at': timezone.now(),
-                },
-                'num_contracts': 50123,
-                'num_bad_rows': 25,
-        }
-    ),
-    dict(
-        subject='Example Bulk Upload Failed',
-        template='data_capture/email/bulk_upload_failed.html',
-        ctx={
-                'upload_source': {
-                    'id': 2,
-                    'submitter': {'email': 'example_admin@example.com'},
-                    'created_at': timezone.now(),
-                },
-                'r10_upload_link': 'https://example.com/r10_bulk_upload',
-                'traceback': 'error traceback'
-            }
-    ),
-    dict(
-        subject='Example Price List Review Reminder',
-        template='data_capture/email/approval_reminder.html',
-        ctx={
-                'unreviewed_url': 'https://example.com/unreviewed_price_lists',
-            }
-    )
-]
 
 
 @click.command()
@@ -74,7 +10,7 @@ def command(to):
     Send examples of all the email templates in the Data Capture application.
     '''
 
-    for example in EXAMPLES:
+    for example in email.EXAMPLES:
         kwargs = {'to': [to]}
         kwargs.update(example)
         email.send_mail(**kwargs)

--- a/styleguide/email_examples.py
+++ b/styleguide/email_examples.py
@@ -3,10 +3,7 @@ from django.http import HttpResponse
 from django.conf.urls import url
 from django.core.urlresolvers import reverse
 
-from data_capture.email import render_mail
-from data_capture.management.commands.send_example_emails import (
-    EXAMPLES
-)
+from data_capture.email import render_mail, EXAMPLES
 
 
 # Erg, we want to be able to give templates the full path to our


### PR DESCRIPTION
@jseppi I'm also not sure if this is what you meant by https://github.com/18F/calc/pull/1407#discussion_r103044659, but I thought it might be a good idea to move the metadata about example emails closer to the definition of the email sending functions.

Advantages:

* It allows us to enforce DRY a bit, by not specifying the template name in two different places.
* It should also help ensure that future emails added to the system come with built-in examples (rather than not coming with examples b/c the contributor didn't know how to add them).

Disadvantages:

* I'm not sure if I'm a big fan of the decorator approach, which is responsible for passing the template name in as the first argument to the sender function. This makes it harder to understand how to use a sender function just by looking at its call signature.

  I thought about passing `template` in as a keyword argument instead, thereby allowing it to be specified last in the call signature, or even via `**kwargs` and popped-off, but neither of those seemed like very big improvements. I guess the alternative is to convert these functions into classes, but that would also require changing all of their call sites (of which there admittedly aren't many).
