### PR TITLE
Sync page <title> to name of search

### DIFF
--- a/frontend/source/js/data-explorer/components/app.jsx
+++ b/frontend/source/js/data-explorer/components/app.jsx
@@ -24,6 +24,7 @@ import Site from './site';
 import BusinessSize from './business-size';
 import LaborCategory from './labor-category';
 import LoadingIndicator from './loading-indicator';
+import TitleTagSynchronizer from './title-tag-synchronizer';
 
 import { autobind } from '../util';
 
@@ -90,6 +91,7 @@ class App extends React.Component {
         onSubmit={this.handleSubmit}
         role="form"
       >
+        <TitleTagSynchronizer />
         <section className="search">
           <div className="container">
             <p className="help-text">

--- a/frontend/source/js/data-explorer/components/description.jsx
+++ b/frontend/source/js/data-explorer/components/description.jsx
@@ -12,12 +12,7 @@ import {
   SCHEDULE_LABELS,
 } from '../constants';
 
-import { formatCommas } from '../util';
-
-function stripTrailingComma(str) {
-  // Removes trailing comma and whitespace from given string
-  return str.replace(/,\s*$/, '');
-}
+import { formatCommas, stripTrailingComma } from '../util';
 
 export function Description({
   shownResults,

--- a/frontend/source/js/data-explorer/components/title-tag-synchronizer.jsx
+++ b/frontend/source/js/data-explorer/components/title-tag-synchronizer.jsx
@@ -1,0 +1,50 @@
+/* global window */
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { stripTrailingComma } from '../util';
+
+export class TitleTagSynchronizer extends React.Component {
+  componentDidMount() {
+    this.originalTitle = this.props.document.title;
+    this.synchronize();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.q !== this.props.q) {
+      this.synchronize();
+    }
+  }
+
+  componentWillUnmount() {
+    this.props.document.title = this.originalTitle;
+  }
+
+  synchronize() {
+    const q = stripTrailingComma(this.props.q);
+
+    if (q) {
+      this.props.document.title = `${q} - CALC Search`;
+    } else {
+      this.props.document.title = this.originalTitle;
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+TitleTagSynchronizer.propTypes = {
+  q: React.PropTypes.string.isRequired,
+  document: React.PropTypes.object,
+};
+
+TitleTagSynchronizer.defaultProps = {
+  document: window.document,
+};
+
+export default connect(
+  state => ({ q: state.q }),
+)(TitleTagSynchronizer);

--- a/frontend/source/js/data-explorer/tests/title-tag-synchronizer.test.jsx
+++ b/frontend/source/js/data-explorer/tests/title-tag-synchronizer.test.jsx
@@ -1,0 +1,44 @@
+import { TitleTagSynchronizer } from '../components/title-tag-synchronizer';
+import makeSetup from './testSetup';
+
+describe('<TitleTagSynchronzer>', () => {
+  let fakeDocument;
+  let mounted;
+
+  const setup = (extraProps) => {
+    fakeDocument = { title: 'original' };
+
+    mounted = makeSetup(TitleTagSynchronizer, {
+      q: '',
+      document: fakeDocument,
+    })(extraProps).mounted;
+  };
+
+  it('leaves title unchanged on mount if query is empty', () => {
+    setup();
+    expect(fakeDocument.title).toBe('original');
+  });
+
+  it('sets title to search query on mount if it is non-empty', () => {
+    setup({ q: 'blarg' });
+    expect(fakeDocument.title).toBe('blarg - CALC Search');
+  });
+
+  it('sets title to non-empty search query on props change', () => {
+    setup();
+    mounted.setProps({ q: 'boop,' });
+    expect(fakeDocument.title).toBe('boop - CALC Search');
+  });
+
+  it('sets title to original if query is empty on props change', () => {
+    setup({ q: 'boop' });
+    mounted.setProps({ q: '' });
+    expect(fakeDocument.title).toBe('original');
+  });
+
+  it('resets title to original on unmount', () => {
+    setup({ q: 'boop' });
+    mounted.unmount();
+    expect(fakeDocument.title).toBe('original');
+  });
+});

--- a/frontend/source/js/data-explorer/util.js
+++ b/frontend/source/js/data-explorer/util.js
@@ -91,3 +91,8 @@ export function getLastCommaSeparatedTerm(term) {
   const pieces = term.split(/\s*,\s*/);
   return pieces[pieces.length - 1];
 }
+
+export function stripTrailingComma(str) {
+  // Removes trailing comma and whitespace from given string
+  return str.replace(/,\s*$/, '');
+}


### PR DESCRIPTION
This fixes #1315.

Note that I decided to make this a React component that doesn't actually render anything, but instead changes `document.title` whenever its `props` change.  I thought this was a decent way to encapsulate-out the functionality without e.g. bloating an existing class with it.  I also thought about making it redux middleware instead, but I currently find redux middleware a bit more confusing than react components, and besides, changing the `<title>` does *feel* like a view logic kind of thing, even if we're not literally rendering the `<title>` tag via the virtual DOM.
