### PR TITLE
Add SlideyPanel to make education dropdown slide up/down again

### DIFF
--- a/frontend/source/js/data-explorer/components/education-level.jsx
+++ b/frontend/source/js/data-explorer/components/education-level.jsx
@@ -147,7 +147,6 @@ export class EducationLevel extends React.Component {
 
                 <SlideyPanel
                   component="ul"
-                  style={{ display: 'block' }}
                   expanded={this.state.expanded}
                 >
                   {inputs}

--- a/frontend/source/js/data-explorer/components/education-level.jsx
+++ b/frontend/source/js/data-explorer/components/education-level.jsx
@@ -2,7 +2,9 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import ReactTransitionGroup from 'react-addons-transition-group';
 
+import SlideyPanel from './slidey-panel';
 import EducationLevelItem from './education-level-item';
 
 import {
@@ -18,6 +20,8 @@ import {
 import {
   toggleEducationLevel,
 } from '../actions';
+
+import { FirstChild } from './util';
 
 // TODO: We could just use jQuery for this, but I wanted to decouple
 // the new React code from jQuery as much as possible for now.
@@ -90,7 +94,6 @@ export class EducationLevel extends React.Component {
   render() {
     const levels = this.props.levels;
     const idPrefix = this.props.idPrefix;
-    const ddStyle = this.state.expanded ? { display: 'block' } : null;
     const inputs = Object.keys(EDU_LABELS).map((value) => {
       const id = idPrefix + value;
       return (
@@ -119,6 +122,17 @@ export class EducationLevel extends React.Component {
     }
 
     const eduLevelId = `${this.props.idPrefix}education_level`;
+
+    let panel = null;
+
+    if (this.state.expanded) {
+      panel = (
+        <SlideyPanel component="ul" style={{ display: 'block' }}>
+          {inputs}
+        </SlideyPanel>
+      );
+    }
+
     return (
       <div>
         <label htmlFor={eduLevelId}>Education level:</label>
@@ -143,9 +157,10 @@ export class EducationLevel extends React.Component {
             <div className="multiSelect">
               <fieldset>
                 <legend className="sr-only">Education level:</legend>
-                <ul style={ddStyle}>
-                  {inputs}
-                </ul>
+
+                <ReactTransitionGroup component={FirstChild}>
+                  {panel}
+                </ReactTransitionGroup>
               </fieldset>
             </div>
           </dd>

--- a/frontend/source/js/data-explorer/components/education-level.jsx
+++ b/frontend/source/js/data-explorer/components/education-level.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import ReactTransitionGroup from 'react-addons-transition-group';
 
 import SlideyPanel from './slidey-panel';
 import EducationLevelItem from './education-level-item';
@@ -20,8 +19,6 @@ import {
 import {
   toggleEducationLevel,
 } from '../actions';
-
-import { FirstChild } from './util';
 
 // TODO: We could just use jQuery for this, but I wanted to decouple
 // the new React code from jQuery as much as possible for now.
@@ -123,16 +120,6 @@ export class EducationLevel extends React.Component {
 
     const eduLevelId = `${this.props.idPrefix}education_level`;
 
-    let panel = null;
-
-    if (this.state.expanded) {
-      panel = (
-        <SlideyPanel component="ul" style={{ display: 'block' }}>
-          {inputs}
-        </SlideyPanel>
-      );
-    }
-
     return (
       <div>
         <label htmlFor={eduLevelId}>Education level:</label>
@@ -158,9 +145,13 @@ export class EducationLevel extends React.Component {
               <fieldset>
                 <legend className="sr-only">Education level:</legend>
 
-                <ReactTransitionGroup component={FirstChild}>
-                  {panel}
-                </ReactTransitionGroup>
+                <SlideyPanel
+                  component="ul"
+                  style={{ display: 'block' }}
+                  expanded={this.state.expanded}
+                >
+                  {inputs}
+                </SlideyPanel>
               </fieldset>
             </div>
           </dd>

--- a/frontend/source/js/data-explorer/components/slidey-panel.jsx
+++ b/frontend/source/js/data-explorer/components/slidey-panel.jsx
@@ -1,17 +1,18 @@
 /* global window */
 
+/**
+ * Implementation of a panel that can slide up and down if jQuery
+ * is present on the page. If jQuery is not present, it gracefully
+ * degrades to a panel without animation.
+ */
+
 import React from 'react';
+import ReactTransitionGroup from 'react-addons-transition-group';
 
-export default class SlideyPanel extends React.Component {
-  componentWillAppear(cb) {
-    this.slideDown(cb);
-  }
+import { FirstChild } from './util';
 
+class InnerSlideyPanel extends React.Component {
   componentWillEnter(cb) {
-    this.slideDown(cb);
-  }
-
-  slideDown(cb) {
     this.props.$(this.el).hide().slideDown('fast', cb);
   }
 
@@ -36,13 +37,14 @@ export default class SlideyPanel extends React.Component {
   }
 }
 
-SlideyPanel.propTypes = {
-  component: React.PropTypes.any.isRequired,
+InnerSlideyPanel.propTypes = {
+  component: React.PropTypes.any,
   children: React.PropTypes.any.isRequired,
   $: React.PropTypes.func,
 };
 
-SlideyPanel.defaultProps = {
+InnerSlideyPanel.defaultProps = {
+  component: 'span',
   $: window.$ || function fakeJquery() {
     return {
       hide() { return this; },
@@ -51,3 +53,33 @@ SlideyPanel.defaultProps = {
     };
   },
 };
+
+export default function SlideyPanel(props) {
+  let innerPanel = null;
+
+  if (props.expanded) {
+    const innerProps = Object.assign({}, props);
+
+    delete innerProps.expanded;
+
+    innerPanel = (
+      <InnerSlideyPanel {...innerProps}>
+        {props.children}
+      </InnerSlideyPanel>
+    );
+  }
+
+  return (
+    <ReactTransitionGroup component={FirstChild}>
+      {innerPanel}
+    </ReactTransitionGroup>
+  );
+}
+
+SlideyPanel.propTypes = Object.assign({}, InnerSlideyPanel.propTypes, {
+  expanded: React.PropTypes.bool,
+});
+
+SlideyPanel.defaultProps = Object.assign({}, InnerSlideyPanel.defaultProps, {
+  expanded: false,
+});

--- a/frontend/source/js/data-explorer/components/slidey-panel.jsx
+++ b/frontend/source/js/data-explorer/components/slidey-panel.jsx
@@ -1,0 +1,41 @@
+/* global $ */
+
+import React from 'react';
+
+export default class SlideyPanel extends React.Component {
+  componentWillAppear(cb) {
+    this.slideDown(cb);
+  }
+
+  componentWillEnter(cb) {
+    this.slideDown(cb);
+  }
+
+  slideDown(cb) {
+    $(this.el).hide().slideDown('fast', cb);
+  }
+
+  componentWillLeave(cb) {
+    $(this.el).slideUp('fast', cb);
+  }
+
+  render() {
+    const newProps = { ref: (el) => { this.el = el; } };
+
+    Object.assign(newProps, this.props);
+
+    delete newProps.children;
+    delete newProps.component;
+
+    return React.createElement(
+      this.props.component,
+      newProps,
+      this.props.children,
+    );
+  }
+}
+
+SlideyPanel.propTypes = {
+  component: React.PropTypes.any.isRequired,
+  children: React.PropTypes.any.isRequired,
+};

--- a/frontend/source/js/data-explorer/components/slidey-panel.jsx
+++ b/frontend/source/js/data-explorer/components/slidey-panel.jsx
@@ -1,4 +1,4 @@
-/* global $ */
+/* global window */
 
 import React from 'react';
 
@@ -12,19 +12,11 @@ export default class SlideyPanel extends React.Component {
   }
 
   slideDown(cb) {
-    if (typeof $ !== 'undefined') {
-      $(this.el).hide().slideDown('fast', cb);
-    } else {
-      cb();
-    }
+    this.props.$(this.el).hide().slideDown('fast', cb);
   }
 
   componentWillLeave(cb) {
-    if (typeof $ !== 'undefined') {
-      $(this.el).slideUp('fast', cb);
-    } else {
-      cb();
-    }
+    this.props.$(this.el).slideUp('fast', cb);
   }
 
   render() {
@@ -34,6 +26,7 @@ export default class SlideyPanel extends React.Component {
 
     delete newProps.children;
     delete newProps.component;
+    delete newProps.$;
 
     return React.createElement(
       this.props.component,
@@ -46,4 +39,15 @@ export default class SlideyPanel extends React.Component {
 SlideyPanel.propTypes = {
   component: React.PropTypes.any.isRequired,
   children: React.PropTypes.any.isRequired,
+  $: React.PropTypes.func,
+};
+
+SlideyPanel.defaultProps = {
+  $: window.$ || function fakeJquery() {
+    return {
+      hide() { return this; },
+      slideUp(speed, cb) { cb(); },
+      slideDown(speed, cb) { cb(); },
+    };
+  },
 };

--- a/frontend/source/js/data-explorer/components/slidey-panel.jsx
+++ b/frontend/source/js/data-explorer/components/slidey-panel.jsx
@@ -12,11 +12,19 @@ export default class SlideyPanel extends React.Component {
   }
 
   slideDown(cb) {
-    $(this.el).hide().slideDown('fast', cb);
+    if (typeof $ !== 'undefined') {
+      $(this.el).hide().slideDown('fast', cb);
+    } else {
+      cb();
+    }
   }
 
   componentWillLeave(cb) {
-    $(this.el).slideUp('fast', cb);
+    if (typeof $ !== 'undefined') {
+      $(this.el).slideUp('fast', cb);
+    } else {
+      cb();
+    }
   }
 
   render() {

--- a/frontend/source/js/data-explorer/components/util.jsx
+++ b/frontend/source/js/data-explorer/components/util.jsx
@@ -15,3 +15,10 @@ export function makeOptions(labels) {
     <option key={value} value={value}>{label}</option>
   ));
 }
+
+// https://facebook.github.io/react/docs/animation.html#rendering-a-single-child
+export function FirstChild(props) {
+  const childrenArray = React.Children.toArray(props.children);
+
+  return childrenArray[0] || null;
+}

--- a/frontend/source/js/data-explorer/tests/__snapshots__/education-level.test.jsx.snap
+++ b/frontend/source/js/data-explorer/tests/__snapshots__/education-level.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`<EducationLevel> matches snapshot 1`] = `
     id="zzz_education_level">
     <dt>
       <a
-        aria-expanded="false"
+        aria-expanded="true"
         className="filter_active"
         href=""
         onClick={[Function]}
@@ -36,34 +36,43 @@ exports[`<EducationLevel> matches snapshot 1`] = `
             className="sr-only">
             Education level:
           </legend>
-          <ul
-            style={null}>
-            <EducationLevelItem
-              checked={false}
-              id="zzz_HS"
-              onCheckboxClick={[Function]}
-              value="HS" />
-            <EducationLevelItem
-              checked={false}
-              id="zzz_AA"
-              onCheckboxClick={[Function]}
-              value="AA" />
-            <EducationLevelItem
-              checked={false}
-              id="zzz_BA"
-              onCheckboxClick={[Function]}
-              value="BA" />
-            <EducationLevelItem
-              checked={true}
-              id="zzz_MA"
-              onCheckboxClick={[Function]}
-              value="MA" />
-            <EducationLevelItem
-              checked={true}
-              id="zzz_PHD"
-              onCheckboxClick={[Function]}
-              value="PHD" />
-          </ul>
+          <ReactTransitionGroup
+            childFactory={[Function]}
+            component={[Function]}>
+            <SlideyPanel
+              component="ul"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }>
+              <EducationLevelItem
+                checked={false}
+                id="zzz_HS"
+                onCheckboxClick={[Function]}
+                value="HS" />
+              <EducationLevelItem
+                checked={false}
+                id="zzz_AA"
+                onCheckboxClick={[Function]}
+                value="AA" />
+              <EducationLevelItem
+                checked={false}
+                id="zzz_BA"
+                onCheckboxClick={[Function]}
+                value="BA" />
+              <EducationLevelItem
+                checked={true}
+                id="zzz_MA"
+                onCheckboxClick={[Function]}
+                value="MA" />
+              <EducationLevelItem
+                checked={true}
+                id="zzz_PHD"
+                onCheckboxClick={[Function]}
+                value="PHD" />
+            </SlideyPanel>
+          </ReactTransitionGroup>
         </fieldset>
       </div>
     </dd>

--- a/frontend/source/js/data-explorer/tests/__snapshots__/education-level.test.jsx.snap
+++ b/frontend/source/js/data-explorer/tests/__snapshots__/education-level.test.jsx.snap
@@ -36,44 +36,41 @@ exports[`<EducationLevel> matches snapshot 1`] = `
             className="sr-only">
             Education level:
           </legend>
-          <ReactTransitionGroup
-            childFactory={[Function]}
-            component={[Function]}>
-            <SlideyPanel
-              $={[Function]}
-              component="ul"
-              style={
-                Object {
-                  "display": "block",
-                }
-              }>
-              <EducationLevelItem
-                checked={false}
-                id="zzz_HS"
-                onCheckboxClick={[Function]}
-                value="HS" />
-              <EducationLevelItem
-                checked={false}
-                id="zzz_AA"
-                onCheckboxClick={[Function]}
-                value="AA" />
-              <EducationLevelItem
-                checked={false}
-                id="zzz_BA"
-                onCheckboxClick={[Function]}
-                value="BA" />
-              <EducationLevelItem
-                checked={true}
-                id="zzz_MA"
-                onCheckboxClick={[Function]}
-                value="MA" />
-              <EducationLevelItem
-                checked={true}
-                id="zzz_PHD"
-                onCheckboxClick={[Function]}
-                value="PHD" />
-            </SlideyPanel>
-          </ReactTransitionGroup>
+          <SlideyPanel
+            $={[Function]}
+            component="ul"
+            expanded={true}
+            style={
+              Object {
+                "display": "block",
+              }
+            }>
+            <EducationLevelItem
+              checked={false}
+              id="zzz_HS"
+              onCheckboxClick={[Function]}
+              value="HS" />
+            <EducationLevelItem
+              checked={false}
+              id="zzz_AA"
+              onCheckboxClick={[Function]}
+              value="AA" />
+            <EducationLevelItem
+              checked={false}
+              id="zzz_BA"
+              onCheckboxClick={[Function]}
+              value="BA" />
+            <EducationLevelItem
+              checked={true}
+              id="zzz_MA"
+              onCheckboxClick={[Function]}
+              value="MA" />
+            <EducationLevelItem
+              checked={true}
+              id="zzz_PHD"
+              onCheckboxClick={[Function]}
+              value="PHD" />
+          </SlideyPanel>
         </fieldset>
       </div>
     </dd>

--- a/frontend/source/js/data-explorer/tests/__snapshots__/education-level.test.jsx.snap
+++ b/frontend/source/js/data-explorer/tests/__snapshots__/education-level.test.jsx.snap
@@ -39,12 +39,7 @@ exports[`<EducationLevel> matches snapshot 1`] = `
           <SlideyPanel
             $={[Function]}
             component="ul"
-            expanded={true}
-            style={
-              Object {
-                "display": "block",
-              }
-            }>
+            expanded={true}>
             <EducationLevelItem
               checked={false}
               id="zzz_HS"

--- a/frontend/source/js/data-explorer/tests/__snapshots__/education-level.test.jsx.snap
+++ b/frontend/source/js/data-explorer/tests/__snapshots__/education-level.test.jsx.snap
@@ -40,6 +40,7 @@ exports[`<EducationLevel> matches snapshot 1`] = `
             childFactory={[Function]}
             component={[Function]}>
             <SlideyPanel
+              $={[Function]}
               component="ul"
               style={
                 Object {

--- a/frontend/source/js/data-explorer/tests/education-level.test.jsx
+++ b/frontend/source/js/data-explorer/tests/education-level.test.jsx
@@ -16,6 +16,8 @@ describe('<EducationLevel>', () => {
   it('renders correctly', () => {
     const { wrapper } = setup();
 
+    wrapper.setState({ expanded: true });
+
     Object.keys(EDU_LABELS).forEach((key) => {
       const eduLevelItem = wrapper.find(`EducationLevelItem[value="${key}"]`);
       expect(eduLevelItem.exists()).toBeTruthy();
@@ -33,6 +35,7 @@ describe('<EducationLevel>', () => {
 
   it('matches snapshot', () => {
     const { wrapper } = setup();
+    wrapper.setState({ expanded: true });
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
@@ -47,6 +50,8 @@ describe('<EducationLevel>', () => {
   it('calls toggleEducationLevel when checkbox is clicked', () => {
     const { props, mounted } = setup();
     expect(props.toggleEducationLevel.mock.calls.length).toBe(0);
+
+    mounted.setState({ expanded: true });
 
     mounted.find('input[value="HS"]')
       .simulate('change', { target: { checked: true } });

--- a/frontend/source/js/data-explorer/tests/slidey-panel.test.jsx
+++ b/frontend/source/js/data-explorer/tests/slidey-panel.test.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SlideyPanel from '../components/slidey-panel';
+
+const fake$ = (el) => {
+  const name = `<${el.nodeName.toLowerCase()}>`;
+
+  return {
+    hide() {
+      fake$.log.push(`hide ${name}`);
+      return this;
+    },
+    slideUp(speed, cb) {
+      fake$.log.push(`slideUp ${name} ${speed}`);
+      cb();
+    },
+    slideDown(speed, cb) {
+      fake$.log.push(`slideDown ${name} ${speed}`);
+      cb();
+    },
+  };
+};
+
+fake$.log = [];
+
+describe('<SlideyPanel>', () => {
+  beforeEach(() => {
+    fake$.log = [];
+  });
+
+  it('shows content if it is expanded at mount', () => {
+    const wrapper = mount(<SlideyPanel expanded><p>hi</p></SlideyPanel>);
+
+    expect(wrapper.find('p').exists()).toBeTruthy();
+    expect(wrapper.text()).toBe('hi');
+  });
+
+  it('hides content if it is not expanded at mount', () => {
+    const wrapper = mount(<SlideyPanel><p>hi</p></SlideyPanel>);
+
+    expect(wrapper.find('p').exists()).toBeFalsy();
+  });
+
+  it('shows content when transitioning from collapsed -> expanded', () => {
+    const wrapper = mount(<SlideyPanel><p>hi</p></SlideyPanel>);
+
+    wrapper.setProps({ expanded: true });
+    expect(wrapper.find('p').exists()).toBeTruthy();
+    expect(wrapper.text()).toBe('hi');
+  });
+
+  it('hides content when transitioning from expanded -> collapsed', () => {
+    const wrapper = mount(<SlideyPanel expanded><p>hi</p></SlideyPanel>);
+
+    wrapper.setProps({ expanded: false });
+    expect(wrapper.find('p').exists()).toBeFalsy();
+  });
+
+  it('slides down when expanded', () => {
+    const wrapper = mount(<SlideyPanel $={fake$}><p>hi</p></SlideyPanel>);
+
+    wrapper.setProps({ expanded: true });
+    expect(fake$.log).toEqual([
+      'hide <span>',
+      'slideDown <span> fast',
+    ]);
+  });
+
+  it('slides up when collapsed', () => {
+    const wrapper = mount(<SlideyPanel $={fake$}><p>hi</p></SlideyPanel>);
+
+    wrapper.setProps({ expanded: true });
+    fake$.log = [];
+    wrapper.setProps({ expanded: false });
+    expect(fake$.log).toEqual([
+      'slideUp <span> fast',
+    ]);
+  });
+});

--- a/frontend/source/sass/data_explorer.scss
+++ b/frontend/source/sass/data_explorer.scss
@@ -148,7 +148,6 @@ dl.dropdown {
       background-color: $color-white;
       border:0;
       color:#000;
-      display:none;
       left:0px;
       padding: 2px 15px 2px 5px;
       position:absolute;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mock-xmlhttprequest": "^1.1.0",
     "react": "^15.4.1",
     "react-addons-test-utils": "^15.4.1",
+    "react-addons-transition-group": "^15.4.2",
     "react-dom": "^15.4.1",
     "react-redux": "^4.4.6",
     "redux": "^3.6.0",


### PR DESCRIPTION
This fixes #1227 by adding a `<SlideyPanel>` component that uses [`ReactTransitionGroup`](https://facebook.github.io/react/docs/animation.html#low-level-api-reacttransitiongroup) under the hood.

If jQuery is available, it uses `$.slideUp`/`$.slideDown` to animate the panel; otherwise the transition is instantaneous. I did this because we've still got it on the page, and it's a lot easier to use than CSS transitions, which are kinda painful to do sliding animations with.

To do:

- [x] Add tests.
