### PR TITLE
Add more links to sources in styleguide.

### DIFF
--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -41,6 +41,11 @@
 
   {% guide_section "Typography" %}
 
+  <p>
+  Most typography-related styling is defined in
+  {% scss "base/_typography.scss" %} and {% scss "base/_variables.scss" %}.
+  </p>
+
   {% example %}
   <h1>Heading 1</h1>
   <h2>Heading 2</h2>
@@ -190,6 +195,10 @@
     cancelling a process or deleting information.
   </p>
 
+  <p>
+    Styling is defined in {% scss "components/_buttons.scss" %}.
+  </p>
+
   {% example %}
   <button>Default button</button>
   <a class="button button-primary" href="#">Link</a>
@@ -227,16 +236,22 @@
     </div>
   </div>
 
-  {% guide_section "Alerts" %}
-
   <p>
-    Defined in {% pathname 'frontend/source/sass/components/_alerts.scss' %}.</p>
+    The markup used by this widget is defined in
+    {% template_link "frontend/steps.html" %}, while styling is
+    in {% scss "components/_steps.scss" %}.
   </p>
+
+  {% guide_section "Alerts" %}
 
   <p>
     These are similar to the
     <a href="https://standards.usa.gov/alerts/">US Web Design Standards</a>,
     but add a stroke and the CALC standard border radius.
+  </p>
+
+  <p>
+    Styling is defined in {% scss 'components/_alerts.scss' %}.</p>
   </p>
 
   {% example %}
@@ -268,6 +283,9 @@
   {% endexample %}
 
   {% guide_section "Tables" %}
+
+  <p>Defined in {% scss "components/_tables.scss" %}.</p>
+
   <p>When displaying data in tables, be sure to add the <code>number</code> class to cells that contain numbers. This will monospace and right-align those columns. For dollar amounts, you'll need to also add the <code>currency</code> class to get the dollar sign to appear. You can add a highlight-on-hover effect to a table's rows by including the <code>hoverable</code> class on the table.</p>
   {% example %}
     <table class="hoverable">
@@ -331,7 +349,7 @@
 
   {% guide_section "Excel Tables" %}
 
-  <p>Defined in {% pathname 'frontend/source/sass/components/_exceltables.scss' %}.</p>
+  <p>Defined in {% scss 'components/_exceltables.scss' %}.</p>
 
   <p>
     Sometimes we need to display "screenshots" of Microsoft Excel tables
@@ -388,6 +406,12 @@
   {% endexample %}
 
   {% guide_section "Forms" %}
+
+  <p>
+    Defined in {% scss "components/_forms.scss" %} and
+    {% scss "uswds/_forms.scss" %}.
+  </p>
+
   {% example %}
   <label for="input-type-text">Text input label</label>
   <input id="input-type-text" name="input-type-text" type="text">
@@ -470,7 +494,7 @@
 
   {% guide_section "Form Button Row" %}
 
-  <p>Defined in {% pathname 'frontend/source/sass/components/_formbuttonrow.scss' %}.</p>
+  <p>Defined in {% scss 'components/_formbuttonrow.scss' %}.</p>
 
   <p>The form-button-row widget is used to add common buttons to the bottom of forms in a multi-step process, such as the Data Capture Upload flow.</p>
 
@@ -525,10 +549,15 @@
 
   <p>
     Styling for this component can be found in
-    {% pathname 'frontend/source/sass/components/_expandablearea.scss' %}.
+    {% scss 'components/_expandablearea.scss' %}.
   </p>
 
   {% guide_section "Modal Dialogs" %}
+
+  <p>
+    Defined in {% scss "components/_dialogs.scss" %} and
+    {% js "data-capture/modal-dialogs.js" %}.
+  </p>
 
   <p>
     Modal dialogs provide a way of display a dialog, such as a confirmation

--- a/styleguide/templatetags/styleguide.py
+++ b/styleguide/templatetags/styleguide.py
@@ -18,6 +18,10 @@ MY_DIR = os.path.abspath(os.path.dirname(__file__))
 
 ROOT_DIR = os.path.normpath(os.path.join(MY_DIR, '..', '..'))
 
+SCSS_DIR = 'frontend/source/sass'
+
+JS_DIR = 'frontend/source/js'
+
 register = template.Library()
 
 
@@ -140,6 +144,38 @@ def template_link(context, template_name):
 
     url = template_url(context, template_name)
     return SafeString(f'<code><a href="{url}">{template_name}</a></code>')
+
+
+@register.simple_tag
+def scss(path):
+    '''
+    Link to a .scss (SASS) file relative to the base SASS directory.
+    '''
+
+    abspath = os.path.join(ROOT_DIR, SCSS_DIR, path)
+
+    if not os.path.exists(abspath):
+        raise ValueError(f'{abspath} does not exist')
+
+    url = github_url_for_path(os.path.join(SCSS_DIR, path))
+
+    return SafeString(f'<code><a href="{url}">{path}</a></code>')
+
+
+@register.simple_tag
+def js(path):
+    '''
+    Link to a JavaScript file relative to the base JS directory.
+    '''
+
+    abspath = os.path.join(ROOT_DIR, JS_DIR, path)
+
+    if not os.path.exists(abspath):
+        raise ValueError(f'{abspath} does not exist')
+
+    url = github_url_for_path(os.path.join(JS_DIR, path))
+
+    return SafeString(f'<code><a href="{url}">{path}</a></code>')
 
 
 @register.simple_tag


### PR DESCRIPTION
This just adds more links to sources in the styleguide, to make it easier to hack on 'em when the time comes (or just learn more about them).

It also introduces `{% scss %}` and `{% js %}` template tags that make the display of paths less verbose for SCSS and JS files; while they're displayed relative to the `frontend/source/js|sass` directories, they can be followed to GitHub to learn the absolute path to them.

@hbillings what do you think of this?
