### PR TITLE
[WIP] Enable django.contrib.admindocs in DEBUG mode

### DIFF
--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -367,3 +367,8 @@ DEBUG_TOOLBAR_PANELS = [
     'debug_toolbar.panels.redirects.RedirectsPanel',
     'data_capture.panels.ScheduledJobsPanel',
 ]
+
+if DEBUG:
+    INSTALLED_APPS += (
+        'django.contrib.admindocs',
+    )

--- a/hourglass/urls.py
+++ b/hourglass/urls.py
@@ -40,7 +40,9 @@ tests_url = url(r'^tests/$', TemplateView.as_view(template_name='tests.html'),
 if settings.DEBUG:
     import debug_toolbar
 
-    urlpatterns += [
+    urlpatterns = [
+        url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    ] + urlpatterns + [
         url(r'^__debug__/', include(debug_toolbar.urls)),
         tests_url,
     ]


### PR DESCRIPTION
This enables [the Django admin documentation generator](https://docs.djangoproject.com/en/1.10/ref/contrib/admin/admindocs/) on development (`DEBUG`) instances of CALC.

It adds a "Documentation" option under the site admin:

> ![admindocs](https://cloud.githubusercontent.com/assets/124687/23462787/45897752-fe5d-11e6-9f2d-b93e94149de5.png)

And as can be seen from the above screenshot, it links to auto-generated documentation on template tags and filters, models, and views.

Since our Django admin skin wasn't created to take this kind of content into consideration, though, the styling on the individual pages isn't that great.  For example, while I *think* the tags and filters docs are supposed to have a right-hand TOC sidebar that lists all the tags and filters, it shows up at the very bottom of the page on our admin site, which isn't very helpful.

So I guess if we do decide to integrate this, we should think about:

- [ ] making at least a few styling tweaks to our admin templates so these docs don't look horrible;
- [ ] overriding [`admin_doc/index.html`](https://github.com/django/django/blob/master/django/contrib/admindocs/templates/admin_doc/index.html) so it links to our `/docs/` and `/styleguide/`, and add links from those places to these admin docs.

@jseppi @hbillings do you think this would be useful? Or nah?
