### PR TITLE
Make top-level styleguide headings sticky

### DIFF
--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -9,6 +9,10 @@
 
 h3.styleguide-section {
   border-bottom: 1px solid lightgray;
+  position: sticky;
+  top: 0;
+  background: white;
+  z-index: 100;
 }
 
 .styleguide-section a {


### PR DESCRIPTION
Yesterday I found out about [`position: sticky`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Sticky_positioning) and thought it might be useful for our styleguide, especially in sections that are really long, where one might forget what top-level section they're in or something.

This CSS feature seems to gracefully degrade nicely since browsers that don't support sticky positioning will just show the headings like they've always looked.