### PR TITLE
List price list analysis finders in settings.py

### DIFF
--- a/data_capture/analysis/finders.py
+++ b/data_capture/analysis/finders.py
@@ -14,6 +14,11 @@ class ContractFinder(metaclass=abc.ABCMeta):
     a certain criteria.
     '''
 
+    def __init__(self, min_years_experience: int,
+                 education_level: str) -> None:
+        self.min_years_experience = min_years_experience
+        self.education_level = education_level
+
     @abc.abstractmethod
     def filter_queryset(self, qs: QuerySet) -> QuerySet:
         '''
@@ -52,19 +57,7 @@ class ContractFinder(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
 
-class BaseEduAndExpFinder(ContractFinder):
-    '''
-    Abstract base class for finders that match based on minimum
-    years of experience and education level.
-    '''
-
-    def __init__(self, min_years_experience: int,
-                 education_level: str) -> None:
-        self.min_years_experience = min_years_experience
-        self.education_level = education_level
-
-
-class ExactEduAndExpFinder(BaseEduAndExpFinder):
+class ExactEduAndExpFinder(ContractFinder):
     '''
     Finds contracts that are exactly equal to a given
     education level, and around a given experience level.
@@ -100,7 +93,7 @@ class ExactEduAndExpFinder(BaseEduAndExpFinder):
         return self.education_level
 
 
-class GteEduAndExpFinder(BaseEduAndExpFinder):
+class GteEduAndExpFinder(ContractFinder):
     '''
     Finds contracts that are greater than or equal to a given
     minimum experience and education level.

--- a/data_capture/tests/test_analysis.py
+++ b/data_capture/tests/test_analysis.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from django.test import TestCase as DjangoTestCase
+from django.test import TestCase as DjangoTestCase, override_settings
 from django.db import connection
 
 from contracts.mommy_recipes import get_contract_recipe
@@ -22,6 +22,10 @@ from ..analysis.vocabulary import (
 from ..analysis.export import AnalysisExport, COMPARABLES_NOT_FOUND
 
 
+@override_settings(PRICE_LIST_ANALYSIS_FINDERS=[
+    'data_capture.analysis.finders.ExactEduAndExpFinder',
+    'data_capture.analysis.finders.GteEduAndExpFinder',
+])
 class BaseDbTestCase(DjangoTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -361,3 +361,7 @@ DEBUG_TOOLBAR_PANELS = [
     'debug_toolbar.panels.redirects.RedirectsPanel',
     'data_capture.panels.ScheduledJobsPanel',
 ]
+
+PRICE_LIST_ANALYSIS_FINDERS = [
+    'data_capture.analysis.finders.GteEduAndExpFinder',
+]


### PR DESCRIPTION
Fixes #1452.

I got the impression that Kelly had mixed feelings about the externally-imposed rationale for #1452, so as a way to satisfy the requirements while still leaving the architecture fairly flexible (and our unit tests unbroken), I added a `PRICE_LIST_ANALYSIS_FINDERS` setting which is a list of class names to use for broadening the contract search. That way we can use the finder(s) our current clients want for this particular project, but change things up later if we want.
