### PR TITLE
Add API support for quote-delimited labor category param (`q`)

### DIFF
--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -151,6 +151,50 @@ class ContractsTest(TestCase):
         resp = self.c.get(self.path, {'q': 'legal  advice '})
         self.assertEqual(resp.status_code, 200)
 
+    def test_search_results_with_quoted_comma_strings(self):
+        self.make_test_set()
+        resp = self.c.get(self.path, {'q': '"designer, extra cool"'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertResultsEqual(resp.data['results'],
+                                [{'idv_piid': "ABC456",
+                                  'vendor_name': "Big Bob's Design Corral",
+                                  'labor_category': "Designer, Extra Cool",
+                                  'education_level': 'Bachelors',
+                                  'min_years_experience': 5,
+                                  'hourly_rate_year1': 24.0,
+                                  'current_price': 24.0,
+                                  'schedule': None,
+                                  'contractor_site': None,
+                                  'business_size': None}])
+
+    def test_multi_search_results_with_quoted_comma_strings(self):
+        self.make_test_set()
+        resp = self.c.get(self.path,
+                          {'q': 'legal, "designer, extra cool"'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertResultsEqual(resp.data['results'],
+                                [{'idv_piid': 'ABC123',
+                                  'vendor_name': 'ACME Corp.',
+                                  'labor_category': 'Legal Services',
+                                  'education_level': None,
+                                  'min_years_experience': 10,
+                                  'hourly_rate_year1': 18.0,
+                                  'current_price': 18.0,
+                                  'schedule': None,
+                                  'contractor_site': None,
+                                  'business_size': None},
+                                 {'idv_piid': "ABC456",
+                                  'vendor_name': "Big Bob's Design Corral",
+                                  'labor_category': "Designer, Extra Cool",
+                                  'education_level': 'Bachelors',
+                                  'min_years_experience': 5,
+                                  'hourly_rate_year1': 24.0,
+                                  'current_price': 24.0,
+                                  'schedule': None,
+                                  'contractor_site': None,
+                                  'business_size': None},
+                                 ])
+
     def test_filter_by_price__exact(self):
         self.make_test_set()
         resp = self.c.get(self.path, {'price': 18})
@@ -174,7 +218,17 @@ class ContractsTest(TestCase):
         self.assertEqual(resp.status_code, 200)
 
         self.assertResultsEqual(resp.data['results'],
-                                [{'idv_piid': 'ABC234',
+                                [{'idv_piid': "ABC456",
+                                  'vendor_name': "Big Bob's Design Corral",
+                                  'labor_category': "Designer, Extra Cool",
+                                  'education_level': 'Bachelors',
+                                  'min_years_experience': 5,
+                                  'hourly_rate_year1': 24.0,
+                                  'current_price': 24.0,
+                                  'schedule': None,
+                                  'contractor_site': None,
+                                  'business_size': None},
+                                 {'idv_piid': 'ABC234',
                                   'vendor_name': 'Numbers R Us',
                                   'labor_category': 'Accounting, CPA',
                                   'education_level': 'Masters',
@@ -183,7 +237,8 @@ class ContractsTest(TestCase):
                                   'current_price': 50.0,
                                   'schedule': None,
                                   'contractor_site': None,
-                                  'business_size': None}])
+                                  'business_size': None},
+                                 ])
 
     def test_filter_by_price__lte(self):
         self.make_test_set()
@@ -743,6 +798,16 @@ class ContractsTest(TestCase):
                                     'schedule': None,
                                     'contractor_site': None,
                                     'business_size': None},
+                                 {'idv_piid': "ABC456",
+                                    'vendor_name': "Big Bob's Design Corral",
+                                    'labor_category': "Designer, Extra Cool",
+                                    'education_level': 'Bachelors',
+                                    'min_years_experience': 5,
+                                    'hourly_rate_year1': 24.0,
+                                    'current_price': 24.0,
+                                    'schedule': None,
+                                    'contractor_site': None,
+                                    'business_size': None},
                                  {'idv_piid': 'ABC123',
                                     'vendor_name': 'ACME Corp.',
                                     'labor_category': 'Legal Services',
@@ -752,7 +817,8 @@ class ContractsTest(TestCase):
                                     'current_price': 18.0,
                                     'schedule': None,
                                     'contractor_site': None,
-                                    'business_size': None}])
+                                    'business_size': None},
+                                 ])
 
         # sort the price descending, too, to make sure we're not just randomly
         # passing the first test
@@ -790,6 +856,16 @@ class ContractsTest(TestCase):
                                     'schedule': 'MOBIS',
                                     'contractor_site': None,
                                     'business_size': None},
+                                 {'idv_piid': "ABC456",
+                                    'vendor_name': "Big Bob's Design Corral",
+                                    'labor_category': "Designer, Extra Cool",
+                                    'education_level': 'Bachelors',
+                                    'min_years_experience': 5,
+                                    'hourly_rate_year1': 24.0,
+                                    'current_price': 24.0,
+                                    'schedule': None,
+                                    'contractor_site': None,
+                                    'business_size': None},
                                  {'idv_piid': 'ABC123',
                                     'vendor_name': 'ACME Corp.',
                                     'labor_category': 'Legal Services',
@@ -799,7 +875,8 @@ class ContractsTest(TestCase):
                                     'current_price': 18.0,
                                     'schedule': None,
                                     'contractor_site': None,
-                                    'business_size': None}])
+                                    'business_size': None},
+                                 ])
 
     def test_query_type__match_phrase(self):
         self.make_test_set()
@@ -869,16 +946,20 @@ class ContractsTest(TestCase):
         self.assertEqual(resp.data['maximum'], 50.0)
 
     def test_average_price_no_args(self):
-        self.make_test_set()
+        contracts = self.make_test_set()
         resp = self.c.get(self.path, {})
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.data['average'], (16.0 + 18.0 + 50.0) / 3)
+        avg = 0
+        for c in contracts:
+            avg = avg + c.current_price
+        avg = avg / len(contracts)
+        self.assertEqual(resp.data['average'], avg)
 
     def test_first_std_deviation_no_args(self):
         self.make_test_set()
         resp = self.c.get(self.path, {})
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(int(resp.data['first_standard_deviation']), 15)
+        self.assertEqual(int(resp.data['first_standard_deviation']), 13)
 
     def test_histogram_length(self):
         self.make_test_set()
@@ -897,7 +978,7 @@ class ContractsTest(TestCase):
         resp = self.c.get(self.path, {'histogram': 2})
         self.assertEqual(resp.status_code, 200)
         self.assertResultsEqual(resp.data['wage_histogram'], [
-            {'count': 2, 'min': 16.0, 'max': 33.0},
+            {'count': 3, 'min': 16.0, 'max': 33.0},
             {'count': 1, 'min': 33.0, 'max': 50.0}
         ])
 
@@ -937,41 +1018,53 @@ class ContractsTest(TestCase):
 
     @staticmethod
     def make_test_set():
-        mommy.make(
-            Contract,
-            id=1,
-            idv_piid="ABC123",
-            piid="123",
-            vendor_name="ACME Corp.",
-            labor_category="Legal Services",
-            min_years_experience=10,
-            hourly_rate_year1=18.00,
-            current_price=18.00,
-        )
-        mommy.make(
-            Contract,
-            id=2,
-            idv_piid="ABC234",
-            piid="234",
-            vendor_name="Numbers R Us",
-            labor_category="Accounting, CPA",
-            education_level='MA',
-            min_years_experience=5,
-            hourly_rate_year1=50.00,
-            current_price=50.00,
-        )
-        mommy.make(
-            Contract,
-            id=3,
-            idv_piid="ABC345",
-            piid="345",
-            vendor_name="Word Power Co.",
-            labor_category="Writer/Editor",
-            education_level='BA',
-            min_years_experience=1,
-            hourly_rate_year1=16.00,
-            current_price=16.00,
-        )
+        test_contract_params = [
+            dict(
+                id=1,
+                idv_piid="ABC123",
+                piid="123",
+                vendor_name="ACME Corp.",
+                labor_category="Legal Services",
+                min_years_experience=10,
+                hourly_rate_year1=18.00,
+                current_price=18.00
+            ),
+            dict(
+                id=2,
+                idv_piid="ABC234",
+                piid="234",
+                vendor_name="Numbers R Us",
+                labor_category="Accounting, CPA",
+                education_level='MA',
+                min_years_experience=5,
+                hourly_rate_year1=50.00,
+                current_price=50.00,
+            ),
+            dict(
+                id=3,
+                idv_piid="ABC345",
+                piid="345",
+                vendor_name="Word Power Co.",
+                labor_category="Writer/Editor",
+                education_level='BA',
+                min_years_experience=1,
+                hourly_rate_year1=16.00,
+                current_price=16.00,
+            ),
+            dict(
+                id=4,
+                idv_piid="ABC456",
+                piid="456",
+                vendor_name="Big Bob's Design Corral",
+                labor_category="Designer, Extra Cool",
+                education_level='BA',
+                min_years_experience=5,
+                hourly_rate_year1=24.00,
+                current_price=24.00,
+            )
+        ]
+
+        return [mommy.make(Contract, **p) for p in test_contract_params]
 
     def assertResultsEqual(self, results, expected, just_expected_fields=True):
         dict_results = [dict(x) for x in results]

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,13 @@ You can search for multiple labor categories separated by a comma.
 http://localhost:8000/api/rates/?q=trainer,instructor
 ```
 
+If any of the labor categories you'd like included in your search has a comma,
+you can surround that labor category with quotation marks:
+
+```
+http://localhost:8000/api/rates/?q="engineer, senior",instructor
+```
+
 All of the query types are case-insenstive.
 
 #### Education and Experience Filters

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,7 +71,7 @@ you can surround that labor category with quotation marks:
 http://localhost:8000/api/rates/?q="engineer, senior",instructor
 ```
 
-All of the query types are case-insenstive.
+All of the query types are case-insensitive.
 
 #### Education and Experience Filters
 ###### Experience


### PR DESCRIPTION
Pulled this from #1467.

This adjusts up our api to parse the `q` param in "csv-style," i.e. allowing quotation-mark-delimited individual terms within the comma-separated list. For example, the api can now handle a query like `q="Driver, Heavy Truck", Engineer` as two distinct labor category terms: `"Driver, Heavy Truck"` and `"Engineer"`.

Ref #960 and #1459 