### PR TITLE
Add load_data test.

### DIFF
--- a/contracts/tests/test_load_data.py
+++ b/contracts/tests/test_load_data.py
@@ -1,0 +1,18 @@
+import pathlib
+from django.core.management import call_command
+from django.test import TestCase
+
+from contracts.models import Contract
+
+MY_DIR = pathlib.Path(__file__).resolve().parent
+
+
+class LoadS70TestCase(TestCase):
+    sample_filename = MY_DIR.parent / 'docs' / 'hourly_prices_sample.csv'
+
+    def test_loads_sample(self):
+        call_command(
+            'load_data',
+            filename=self.sample_filename
+        )
+        self.assertEquals(Contract.objects.count(), 79)


### PR DESCRIPTION
I know we might be getting rid of the `load_data` command (see #1028), but since it's still around, I figured we might as well test it.  I noticed its code didn't seem to be called by the test suite when working on #1466.

This adds a simple test that runs the command on sample data, but I'm confused about something: there are 100 rows, and when running, the command says that it processed 100 rows and skipped none, yet only 79 `Contract` models have been added to the database. Why is that?

At first I thought it might be because some of the contracts might be expired, so perhaps those aren't being added to the db, but after using `freezegun` to alter the current date, it didn't seem to affect things.

@jseppi any ideas?
