### PR TITLE
Store /home in a Docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,4 @@ services:
 volumes:
   node-modules:
   python-venv:
+  home:

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -10,6 +10,7 @@ services:
       # other non-Linux native code compiled on the Docker Host.
       - python-venv:/venv/
       - node-modules:/calc/node_modules/
+      - home:/home/
     environment:
       - DDM_VENV_DIR=/venv
       - DDM_USER_OWNED_DIRS=/venv:/calc/node_modules

--- a/docker_django_management.py
+++ b/docker_django_management.py
@@ -25,6 +25,11 @@
 
     * Friendly warnings are logged if anything seems to be misconfigured.
 
+    Requirements:
+
+    * The docker container this runs in should support the
+      `useradd` command.
+
     To use it:
 
     * Place this script in the same directory as your Django project's
@@ -280,25 +285,40 @@ def entrypoint(argv):  # type: (List[str]) -> None
     '''
 
     if HOST_UID != os.geteuid():
+        user_owned_dirs = []  # type: List[str]
+
         if not does_uid_exist(HOST_UID):
             username = HOST_USER
             while does_username_exist(username):
                 username += '0'
             home_dir = '/home/%s' % username
+            extra_useradd_options = []  # type: List[str]
+
+            if os.path.exists(home_dir):
+                # The home directory already exists; just to be safe,
+                # let's make sure it's owned by our UID.
+                user_owned_dirs.append(home_dir)
+            else:
+                # The home directory doesn't already exist, so tell
+                # useradd to make it for us.
+                extra_useradd_options.append('-m')
+
             subprocess.check_call([
                 'useradd',
                 '-d', home_dir,
-                '-m', username,
+                username,
                 '-u', str(HOST_UID)
-            ])
+            ] + extra_useradd_options)
 
         if USER_OWNED_DIRS:
-            for dirname in USER_OWNED_DIRS.split(os.path.pathsep):
-                subprocess.check_call([
-                    'chown',
-                    '{}:{}'.format(HOST_UID, HOST_UID),
-                    dirname
-                ])
+            user_owned_dirs += USER_OWNED_DIRS.split(os.path.pathsep)
+
+        for dirname in user_owned_dirs:
+            subprocess.check_call([
+                'chown',
+                '{}:{}'.format(HOST_UID, HOST_UID),
+                dirname
+            ])
 
         os.environ['HOME'] = '/home/%s' % pwd.getpwuid(HOST_UID).pw_name
         os.setuid(HOST_UID)


### PR DESCRIPTION
This fixes #1471 by storing `/home` in a Docker volume. It also means that `pip`'s cache should be saved across `docker-compose` runs too, which is nice.

I made `/home` a docker volume instead of `/home/calc_user` because we actually want `useradd` to create the actual home directory in `docker_django_management.py`, as it will automatically copy the skeleton files into it (e.g. `.profile`, `.bashrc`), which can be helpful.
