### PR TITLE
Fix convert_to_tsquery regex to accept numeric chars

### DIFF
--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -85,6 +85,12 @@ class ContractsTest(TestCase):
                                   'contractor_site': None,
                                   'business_size': None}])
 
+    def test_search_results_with_numeric_query(self):
+        self.make_test_set()
+        resp = self.c.get(self.path, {'q': '12345'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertResultsEqual(resp.data['results'], [])
+
     def test_multi_word_search_results__hit(self):
         self.make_test_set()
         resp = self.c.get(self.path, {'q': 'legal services'})

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -32,10 +32,13 @@ def convert_to_tsquery(query):
 
         >>> convert_to_tsquery('interpretation services')
         'interpretation:* & services:*'
+
+        >>> convert_to_tsquery('123')
+        '123:*'
     """
 
     # remove all non-alphanumeric or whitespace chars
-    pattern = re.compile('[^a-zA-Z\s]')
+    pattern = re.compile('[^a-zA-Z0-9\s]')
     query = pattern.sub('', query)
     query_parts = query.split()
     # remove empty strings and add :* to use prefix matching on each chunk


### PR DESCRIPTION
Fixes #1475

The problem was that the regex in `convert_to_tsquery` was stripping out numeric characters, even though the comment right above it said that it should only strip _non_-alphanumeric chars.