### PR TITLE
Use querystring module in place of custom functions

### DIFF
--- a/frontend/source/js/data-explorer/components/export-data.jsx
+++ b/frontend/source/js/data-explorer/components/export-data.jsx
@@ -1,7 +1,7 @@
+import * as qs from 'querystring';
+
 import React from 'react';
 import { connect } from 'react-redux';
-
-import { joinQuery } from '../util';
 
 import { getRatesParameters } from '../rates-request';
 
@@ -25,7 +25,7 @@ ExportData.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    querystring: joinQuery(getRatesParameters(state)),
+    querystring: `?${qs.stringify(getRatesParameters(state))}`,
   };
 }
 

--- a/frontend/source/js/data-explorer/history.js
+++ b/frontend/source/js/data-explorer/history.js
@@ -18,6 +18,7 @@ import {
 
 import {
   autobind,
+  parseQueryString,
 } from './util';
 
 import {
@@ -46,7 +47,7 @@ export default class StoreHistorySynchronizer {
   }
 
   reflectToStore(store) {
-    const qsFields = querystring.parse(
+    const qsFields = parseQueryString(
       this.window.location.search.substring(1)); // substring after '?' char
 
     const state = store.getState();

--- a/frontend/source/js/data-explorer/history.js
+++ b/frontend/source/js/data-explorer/history.js
@@ -10,14 +10,14 @@
  * easily share their searches with others.
  */
 
+import * as querystring from 'querystring';
+
 import {
   setState,
 } from './actions';
 
 import {
   autobind,
-  parseQuery,
-  joinQuery,
 } from './util';
 
 import {
@@ -46,7 +46,9 @@ export default class StoreHistorySynchronizer {
   }
 
   reflectToStore(store) {
-    const qsFields = parseQuery(this.window.location.search);
+    const qsFields = querystring.parse(
+      this.window.location.search.substring(1)); // substring after '?' char
+
     const state = store.getState();
     const changes = {};
 
@@ -85,9 +87,9 @@ export default class StoreHistorySynchronizer {
           allFields,
         );
 
-        const qs = joinQuery(nonDefaultFields);
+        const qs = querystring.stringify(nonDefaultFields);
 
-        this.window.history.pushState(null, null, qs);
+        this.window.history.pushState(null, null, `?${qs}`);
         this.onLocationChanged();
       }
 

--- a/frontend/source/js/data-explorer/tests/util.test.js
+++ b/frontend/source/js/data-explorer/tests/util.test.js
@@ -11,9 +11,22 @@ describe('util.formatFriendlyPrice()', () => {
 });
 
 describe('util.getLastCommaSeparatedTerm()', () => {
-  expect(util.getLastCommaSeparatedTerm('foo')).toBe('foo');
-  expect(util.getLastCommaSeparatedTerm('foo,bar')).toBe('bar');
-  expect(util.getLastCommaSeparatedTerm('foo, bar')).toBe('bar');
-  expect(util.getLastCommaSeparatedTerm('foo , bar')).toBe('bar');
-  expect(util.getLastCommaSeparatedTerm('foo bar')).toBe('foo bar');
+  it('works', () => {
+    expect(util.getLastCommaSeparatedTerm('foo')).toBe('foo');
+    expect(util.getLastCommaSeparatedTerm('foo,bar')).toBe('bar');
+    expect(util.getLastCommaSeparatedTerm('foo, bar')).toBe('bar');
+    expect(util.getLastCommaSeparatedTerm('foo , bar')).toBe('bar');
+    expect(util.getLastCommaSeparatedTerm('foo bar')).toBe('foo bar');
+  });
+});
+
+describe('util.parseQueryString()', () => {
+  it('works', () => {
+    expect(util.parseQueryString('a=1&b=cow')).toEqual({ a: '1', b: 'cow' });
+  });
+
+  it('uses first value of a repeated param', () => {
+    expect(util.parseQueryString('z=yes&z=no')).toEqual({ z: 'yes' });
+    expect(util.parseQueryString('x=&x=')).toEqual({ x: '' });
+  });
 });

--- a/frontend/source/js/data-explorer/util.js
+++ b/frontend/source/js/data-explorer/util.js
@@ -1,5 +1,6 @@
 /* global event */
 
+import * as querystring from 'querystring';
 import classNames from 'classnames';
 import { format } from 'd3-format';
 
@@ -69,4 +70,19 @@ export function getLastCommaSeparatedTerm(term) {
 export function stripTrailingComma(str) {
   // Removes trailing comma and whitespace from given string
   return str.replace(/,\s*$/, '');
+}
+
+export function parseQueryString(str) {
+  const qsObj = querystring.parse(str);
+
+  // querystring.parse will create array values if a querystring param name
+  // is repeated. We'll just take the first value of any such array.
+  Object.keys(qsObj).forEach((key) => {
+    const val = qsObj[key];
+    if (Array.isArray(val)) {
+      qsObj[key] = val[0];
+    }
+  });
+
+  return qsObj;
 }

--- a/frontend/source/js/data-explorer/util.js
+++ b/frontend/source/js/data-explorer/util.js
@@ -57,32 +57,6 @@ export function parsePrice(value, defaultValue = 0) {
   return floatValue;
 }
 
-// http://stackoverflow.com/a/13419367
-export function parseQuery(qstr) {
-  const query = {};
-  const a = qstr.substr(1).split('&');
-
-  for (let i = 0; i < a.length; i++) {
-    const b = a[i].split('=');
-    query[decodeURIComponent(b[0])] = decodeURIComponent(
-      (b[1] || '').replace(/\+/g, ' '),
-    );
-  }
-
-  return query;
-}
-
-export function joinQuery(query) {
-  const parts = Object.keys(query).map((name) => {
-    const encName = encodeURIComponent(name);
-    const encValue = encodeURIComponent(query[name]);
-
-    return `${encName}=${encValue}`;
-  }).join('&');
-
-  return `?${parts}`;
-}
-
 export function filterActive(isActive, otherClasses = '') {
   return classNames(isActive ? 'filter_active' : '', otherClasses);
 }

--- a/frontend/source/js/tests/data-explorer_tests.js
+++ b/frontend/source/js/tests/data-explorer_tests.js
@@ -1,9 +1,5 @@
 /* global QUnit document $ */
 import { appendHighlightedTerm } from '../data-explorer/autocomplete';
-import {
-  parseQuery,
-  joinQuery,
-} from '../data-explorer/util';
 
 QUnit.module('data-explorer');
 
@@ -40,28 +36,4 @@ QUnit.test('appendHighlightedTerm() works', (assert) => {
       'superduperman',
       '{{{').html(),
     'superduperman');
-});
-
-QUnit.test('parseQuery() works', (assert) => {
-  assert.deepEqual(
-    parseQuery('?foo=bar'),
-    { foo: 'bar' },
-    'parses a single value with ? prefix');
-  assert.deepEqual(
-    parseQuery('?foo=bar&baz=qux'),
-    { foo: 'bar', baz: 'qux' },
-    'parses two values');
-  assert.deepEqual(
-    parseQuery('?foo=foo+bar'),
-    { foo: 'foo bar' },
-    'parses "+" as space');
-  assert.deepEqual(
-    parseQuery('?foo=foo%20bar'),
-    { foo: 'foo bar' },
-    'parses "%20" as spaces');
-});
-
-QUnit.test('joinQuery() works', (assert) => {
-  assert.equal(joinQuery({ foo: 'bar', baz: 'quux hi' }),
-               '?foo=bar&baz=quux%20hi');
 });


### PR DESCRIPTION
Replaces our custom `parseQuery` and `joinQuery` with node's `querystring` module methods `parse` and `stringify`.