### PR TITLE
Guard against null or undefined result in autocomplete response handler

### DIFF
--- a/frontend/source/js/data-explorer/autocomplete.js
+++ b/frontend/source/js/data-explorer/autocomplete.js
@@ -42,8 +42,8 @@ export function destroy(el) {
   $(el).autoComplete('destroy');
 }
 
-export function processResults(error, result) {
-  if (error || !result || !result.length) {
+export function processResults(result) {
+  if (!result || !result.length) {
     return [];
   }
   const categories = result.slice(0, 20).map(d => ({
@@ -82,7 +82,8 @@ export function initialize(el, {
         },
       }, (error, result) => {
         autoCompReq = null;
-        const categories = processResults(error, result);
+        if (error) { return done([]); }
+        const categories = processResults(result);
         return done(categories);
       });
     },

--- a/frontend/source/js/data-explorer/autocomplete.js
+++ b/frontend/source/js/data-explorer/autocomplete.js
@@ -70,7 +70,9 @@ export function initialize(el, {
         },
       }, (error, result) => {
         autoCompReq = null;
-        if (error) { return done([]); }
+        if (error || !result || !result.length) {
+          return done([]);
+        }
         const categories = result.slice(0, 20).map(d => ({
           term: d.labor_category,
           count: d.count,

--- a/frontend/source/js/data-explorer/autocomplete.js
+++ b/frontend/source/js/data-explorer/autocomplete.js
@@ -42,6 +42,18 @@ export function destroy(el) {
   $(el).autoComplete('destroy');
 }
 
+export function processResults(error, result) {
+  if (error || !result || !result.length) {
+    return [];
+  }
+  const categories = result.slice(0, 20).map(d => ({
+    term: d.labor_category,
+    count: d.count,
+  }));
+
+  return categories;
+}
+
 export function initialize(el, {
   api,
   getQueryType,
@@ -70,13 +82,7 @@ export function initialize(el, {
         },
       }, (error, result) => {
         autoCompReq = null;
-        if (error || !result || !result.length) {
-          return done([]);
-        }
-        const categories = result.slice(0, 20).map(d => ({
-          term: d.labor_category,
-          count: d.count,
-        }));
+        const categories = processResults(error, result);
         return done(categories);
       });
     },

--- a/frontend/source/js/data-explorer/tests/autocomplete.test.js
+++ b/frontend/source/js/data-explorer/tests/autocomplete.test.js
@@ -6,26 +6,20 @@ describe('autocomplete.processResults', () => {
     { labor_category: 'chimney sweep', count: 2, unused: 'bloop' },
   ];
 
-  it('should return [] on error', () => {
-    const r = processResults('an error', makeResults());
-    expect(r).toBeInstanceOf(Array);
-    expect(r.length).toBe(0);
-  });
-
   it('should return [] if result undefined', () => {
-    const r = processResults(null, undefined);
+    const r = processResults(undefined);
     expect(r).toBeInstanceOf(Array);
     expect(r.length).toBe(0);
   });
 
   it('should return [] if result is empty', () => {
-    const r = processResults(null, []);
+    const r = processResults([]);
     expect(r).toBeInstanceOf(Array);
     expect(r.length).toBe(0);
   });
 
   it('should return formatted categories', () => {
-    const r = processResults(null, makeResults());
+    const r = processResults(makeResults());
     expect(r).toEqual(expect.arrayContaining([
       { term: 'barista', count: 5 },
       { term: 'chimney sweep', count: 2 },
@@ -38,7 +32,7 @@ describe('autocomplete.processResults', () => {
     for (let i = 0; i < 30; i++) {
       lotsOfResults.push({ labor_category: `${i}`, count: i });
     }
-    const r = processResults(null, lotsOfResults);
+    const r = processResults(lotsOfResults);
     expect(r.length).toBe(20);
   });
 });

--- a/frontend/source/js/data-explorer/tests/autocomplete.test.js
+++ b/frontend/source/js/data-explorer/tests/autocomplete.test.js
@@ -1,0 +1,44 @@
+import { processResults } from '../autocomplete';
+
+describe('autocomplete.processResults', () => {
+  const makeResults = () => [
+    { labor_category: 'barista', count: 5, unused: 'blah' },
+    { labor_category: 'chimney sweep', count: 2, unused: 'bloop' },
+  ];
+
+  it('should return [] on error', () => {
+    const r = processResults('an error', makeResults());
+    expect(r).toBeInstanceOf(Array);
+    expect(r.length).toBe(0);
+  });
+
+  it('should return [] if result undefined', () => {
+    const r = processResults(null, undefined);
+    expect(r).toBeInstanceOf(Array);
+    expect(r.length).toBe(0);
+  });
+
+  it('should return [] if result is empty', () => {
+    const r = processResults(null, []);
+    expect(r).toBeInstanceOf(Array);
+    expect(r.length).toBe(0);
+  });
+
+  it('should return formatted categories', () => {
+    const r = processResults(null, makeResults());
+    expect(r).toEqual(expect.arrayContaining([
+      { term: 'barista', count: 5 },
+      { term: 'chimney sweep', count: 2 },
+    ]));
+    expect(r.length).toBe(2);
+  });
+
+  it('should default to 20 max categories', () => {
+    const lotsOfResults = [];
+    for (let i = 0; i < 30; i++) {
+      lotsOfResults.push({ labor_category: `${i}`, count: i });
+    }
+    const r = processResults(null, lotsOfResults);
+    expect(r.length).toBe(20);
+  });
+});


### PR DESCRIPTION
Closes #1484

The majority of the errors captured by New Relic in #1484 (the first two bars in the chart shown there) are due to `result` being null or undefined. This PR extracts the autocomplete result processing logic to a tested function, and guards against null/empty/undefined results.