### PR TITLE
Support fuzzy column titles

### DIFF
--- a/data_capture/schedules/base.py
+++ b/data_capture/schedules/base.py
@@ -20,7 +20,7 @@ min_price_validator = MinValueValidator(
             '(${0:.2f})'.format(FEDERAL_MIN_CONTRACT_RATE))
 
 
-hour_regex = re.compile(r'^hour(ly)?$', flags=re.IGNORECASE)
+hour_regex = re.compile(r'^hour(ly|s)?$', flags=re.IGNORECASE)
 
 hourly_rates_only_validator = RegexValidator(
     hour_regex, 'Value must be "Hour" or "Hourly"')

--- a/data_capture/schedules/spreadsheet_utils.py
+++ b/data_capture/schedules/spreadsheet_utils.py
@@ -3,6 +3,33 @@ import re
 from django.core.exceptions import ValidationError
 
 
+class ColumnTitle:
+    def __init__(self, canonical_name, alternatives=None):
+        self.canonical_name = canonical_name
+        self.alternatives = alternatives or []
+
+    @staticmethod
+    def normalize(s):
+        return re.sub(r'\s+', '', str(s).lower())
+
+    def matches(self, value):
+        normval = self.normalize(value)
+        if self.normalize(self.canonical_name) == normval:
+            return True
+        for alt in self.alternatives:
+            if isinstance(alt, str):
+                if self.normalize(alt) == normval:
+                    return True
+            else:
+                # Assume it's a compiled regular expression.
+                if alt.match(value):
+                    return True
+        return False
+
+    def __str__(self):
+        return self.canonical_name
+
+
 def safe_cell_str_value(sheet, rownum, colnum, coercer=None):
     val = ''
 
@@ -21,18 +48,17 @@ def safe_cell_str_value(sheet, rownum, colnum, coercer=None):
 
 
 def generate_column_index_map(heading_row, field_title_map):
-    def normalize(s):
-        return re.sub(r'\s+', '', str(s).lower())
-
-    def find_col(col_name):
+    def find_col(col_title):
         for idx, cell in enumerate(heading_row):
-            if normalize(cell.value) == normalize(col_name):
+            if col_title.matches(cell.value):
                 return idx
         raise ValidationError('Column heading "{}" was not found.'.format(
-            col_name))
+            col_title))
 
     col_idx_map = {}
     for field, title in field_title_map.items():
+        if isinstance(title, str):
+            title = ColumnTitle(title)
         col_idx_map[field] = find_col(title)
 
     return col_idx_map

--- a/data_capture/tests/test_spreadsheet_utils.py
+++ b/data_capture/tests/test_spreadsheet_utils.py
@@ -1,11 +1,12 @@
 import copy
+import re
 
 from unittest.mock import Mock, MagicMock
-from django.test import TestCase
+from django.test import SimpleTestCase as TestCase
 from django.core.exceptions import ValidationError
 
 from ..schedules.spreadsheet_utils import (
-    generate_column_index_map, safe_cell_str_value)
+    generate_column_index_map, safe_cell_str_value, ColumnTitle)
 
 
 class SafeCellStrValueTests(TestCase):
@@ -40,6 +41,18 @@ class SafeCellStrValueTests(TestCase):
         self.assertEqual(safe_cell_str_value(s, 1, 1, int), '5')
 
 
+class TestColumnTitle(TestCase):
+    def test_str_alternatives_match(self):
+        title = ColumnTitle('zzz', ['HEADING 3'])
+        self.assertTrue(title.matches('  heading 3'))
+        self.assertFalse(title.matches('  heading 4'))
+
+    def test_regex_alternatives_match(self):
+        title = ColumnTitle('zzz', [re.compile(r'BOP.*')])
+        self.assertTrue(title.matches('BOPkfie'))
+        self.assertFalse(title.matches('blergBOPkfie'))
+
+
 class TestGenerateColumnIndexMap(TestCase):
     def setUp(self):
         self.heading_row = [
@@ -51,7 +64,7 @@ class TestGenerateColumnIndexMap(TestCase):
         self.field_title_map = {
             'field_1': 'heading 1',
             'field_2': 'heading 2',
-            'field_3': 'heading 3',
+            'field_3': ColumnTitle('heading 3'),
         }
 
     def test_generate_column_index_map_works(self):


### PR DESCRIPTION
This fixes some problems with the health IT price list that was uploaded earlier today, which has a header row that looks like this:

> <img width="1358" alt="screen shot 2017-03-13 at 6 28 20 pm" src="https://cloud.githubusercontent.com/assets/124687/23879414/ea46ac4e-081a-11e7-966d-0f6d8a1910d7.png">

It does this by adding a new class called `ColumnTitle` which allows us to specify the canonical name for a column heading (in case we need to display it to the user) as well as possible alternatives, which could be strings or compiled regular expressions.

Other things:

* It also allows the unit of issue to be **Hours** (this is what it is in the health IT price list).

* If the header row can't be found, it will now raise a validation error complaining about not being able to find the `SIN(s) PROPOSED` column header, instead of `Could not find Labor Categories price table`, which is what the health IT price list was producing earlier, and which is not very helpful as it doesn't give users any clue as to how they might move forward.

Stuff to do later (not done in this PR):

* The uploaded price list specifies "associate" as a degree type, which we complain about.  It'd be nice if we could support that.
