### PR TITLE
Add named 'pgdata' volume to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "${DOCKER_EXPOSED_PORT}:${DOCKER_EXPOSED_PORT}"
   db:
     image: postgres:9.4
+    volumes:
+      - pgdata:/var/lib/postgresql/data/
     environment:
       - POSTGRES_DB=calc
       - POSTGRES_USER=calc_user
@@ -39,3 +41,4 @@ volumes:
   node-modules:
   python-venv:
   home:
+  pgdata:


### PR DESCRIPTION
The default [postgres `Dockerfile`](https://github.com/docker-library/postgres/blob/5159417968c6a08e2ed784498cba28f22a74b03e/9.6/Dockerfile) contains the following line:

```dockerfile
VOLUME /var/lib/postgresql/data
```

By default, this volume will be given a name that looks like a bunch of random hex digits.  This makes it really hard to introspect, though, and difficult to just wipe out entirely if you want to reset your db without wiping out your other calc volumes (like `node-modules` etc).

This PR names the volume `pgdata`, which means that docker-compose will call it `calc_pgdata` (assuming that your calc checkout is in a directory called `calc`).  This means running `docker volume ls` gives you something like this:

```
DRIVER              VOLUME NAME
local               calc_home
local               calc_node-modules
local               calc_pgdata
local               calc_python-venv
```

This makes it a lot easier to introspect into the container using `docker volume inspect calc_pgdata`, or remove it entirely using `docker volume rm calc_pgdata`.

The only major downside of doing this, I think, is that our developers will likely lose their current pgdata volume, as docker-compose will have it mapped to some randomly-named volume. But as long as we give them a heads-up I think this is a good idea for the long-term.
