### PR TITLE
Yet another alternate fix for #1498 (unwrapping approach)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Django==1.9.12
 django-cors-headers==2.0.2
 django-debug-toolbar==1.6
 djangorestframework==3.5.3
-git+git://github.com/18F/djorm-ext-pgfulltext@1ad8bddf06201e3c89b1e4a483f819297710ec6a
+git+git://github.com/18F/djorm-ext-pgfulltext@179c45929288e6b14f3067489c1ba8f9e158a974
 gunicorn==19.6.0
 newrelic==2.78.0.57
 psycopg2==2.6.2


### PR DESCRIPTION
All the work is in https://github.com/18F/djorm-ext-pgfulltext/pull/2, this just points `requirements.txt` at it.