### PR TITLE
Add UnicodeContractSearchTestCase

### DIFF
--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -409,6 +409,19 @@ class ContractSearchTestCase(BaseContractSearchTestCase):
         ])
 
 
+class UnicodeContractSearchTestCase(BaseContractSearchTestCase):
+    CATEGORIES = [
+        '\u5982',
+        '\u679c',
+    ]
+
+    def test_search_finds_thing(self):
+        results = Contract.objects.search('\u5982')
+        self.assertCategoriesEqual(results, [
+            '\u5982',
+        ])
+
+
 class NormalizedContractSearchTestCase(BaseContractSearchTestCase):
     CATEGORIES = [
         'Jr. Language Interpreter',


### PR DESCRIPTION
This just lifts the unicode contract search test from #1500, which will help ensure there's no regressions when we eventually migrate to Django 1.10's native full-text search.
