### PR TITLE
Limit autocomplete results on server-side

### DIFF
--- a/api/tests/test_autocomplete_api.py
+++ b/api/tests/test_autocomplete_api.py
@@ -1,0 +1,55 @@
+from itertools import cycle
+from django.test import TestCase
+
+from ..views import GetAutocomplete
+from contracts.mommy_recipes import get_contract_recipe
+
+
+class GetAutocompleteTests(TestCase):
+    '''
+    Tests for the autocomplete endpoint
+    TODO: More tests are needed:
+        - different query_type params
+        - 'count' property of returned results
+        - ordering of results
+    '''
+
+    path = '/api/search/'
+
+    def make_test_contracts(self, quantity=1):
+        labor_cat_names = [f"test_{i}" for i in range(0, quantity)]
+        get_contract_recipe().make(
+            _quantity=quantity,
+            labor_category=cycle(labor_cat_names)
+        )
+
+    def test_path_works(self):
+        res = self.client.get(self.path)
+        self.assertEqual(res.status_code, 200)
+
+    def test_returns_empty_if_no_query(self):
+        get_contract_recipe().make(
+            labor_category='test'
+        )
+        res = self.client.get(self.path)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json(), [])
+
+    def test_returns_json_results(self):
+        self.make_test_contracts()
+        res = self.client.get(self.path + '?q=te')
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0], {
+            'labor_category': 'test_0',
+            'count': 1,
+        })
+
+    def test_limits_results_length_to_MAX_RESULTS(self):
+        quantity = GetAutocomplete.MAX_RESULTS * 2
+        self.make_test_contracts(quantity)
+        res = self.client.get(self.path + '?q=test')
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertEqual(len(data), GetAutocomplete.MAX_RESULTS)

--- a/api/tests/test_rates_api.py
+++ b/api/tests/test_rates_api.py
@@ -14,7 +14,7 @@ RATES_API_PATH = '/api/rates/'
 class ContractsPaginationTest(TestCase):
 
     def setUp(self):
-        ContractsTest.make_test_set()
+        GetRatesTests.make_test_set()
         self.path = RATES_API_PATH
 
     def absolute_uri(self, path=''):
@@ -41,7 +41,7 @@ class ContractsPaginationTest(TestCase):
         self.assertEqual(resp.status_code, 404)
 
 
-class ContractsTest(TestCase):
+class GetRatesTests(TestCase):
     """ tests for the /api/rates endpoint """
     BUSINESS_SIZES = ('small business', 'other than small business')
 

--- a/api/views.py
+++ b/api/views.py
@@ -267,6 +267,8 @@ class GetRatesCSV(APIView):
 
 class GetAutocomplete(APIView):
 
+    MAX_RESULTS = 20
+
     def get(self, request, format=None):
         """
         Query Params:
@@ -283,8 +285,13 @@ class GetAutocomplete(APIView):
                 data = Contract.objects.filter(labor_category__icontains=q)
             else:
                 data = Contract.objects.multi_phrase_search(q)
+
             data = data.values('_normalized_labor_category').annotate(
                 count=Count('_normalized_labor_category')).order_by('-count')
+
+            # limit data to MAX_RESULTS
+            data = data[:self.MAX_RESULTS]
+
             data = [
                 {'labor_category': d['_normalized_labor_category'],
                  'count': d['count']}

--- a/frontend/source/js/data-explorer/autocomplete.js
+++ b/frontend/source/js/data-explorer/autocomplete.js
@@ -46,7 +46,7 @@ export function processResults(result) {
   if (!result || !result.length) {
     return [];
   }
-  const categories = result.slice(0, 20).map(d => ({
+  const categories = result.map(d => ({
     term: d.labor_category,
     count: d.count,
   }));

--- a/frontend/source/js/data-explorer/tests/autocomplete.test.js
+++ b/frontend/source/js/data-explorer/tests/autocomplete.test.js
@@ -26,13 +26,4 @@ describe('autocomplete.processResults', () => {
     ]));
     expect(r.length).toBe(2);
   });
-
-  it('should default to 20 max categories', () => {
-    const lotsOfResults = [];
-    for (let i = 0; i < 30; i++) {
-      lotsOfResults.push({ labor_category: `${i}`, count: i });
-    }
-    const r = processResults(lotsOfResults);
-    expect(r.length).toBe(20);
-  });
 });


### PR DESCRIPTION
This PR limits the server-side autocomplete results to a maximum of 20 results. It also adds a few tests for the autocomplete (`/api/search`) endpoint since there were no tests at all. This will result in speed/efficiency increases for our servers and for all clients.

I don't know how to do "real" profiling, but a quick test using `"en"` as the query reduced network request time on my LOCAL dev environment from about `1.7 seconds` down to `400ms`.

Background:

While looking around through our [New Relic transaction monitoring](https://rpm.newrelic.com/accounts/987071/applications/5976077/transactions), I noticed that the autocomplete methods take kind of a long time:

<img width="355" alt="screen shot 2017-03-21 at 11 35 37 am" src="https://cloud.githubusercontent.com/assets/697848/24158520/8e89ff08-0e2a-11e7-85c1-b1e835c13d14.png">

I took a quick look at the code and noticed that the our autocomplete API method (at `/api/search`) returns ALL results it finds, but the client-side JavaScript code limits the results shown to just 20. This is pretty inefficient, from the server-side, through the wire, to the client. For example, an autocomplete search for `"en"` would return a payload containing over 7000 results, which then have to be JSON parsed (a blocking operation) by the client.