### PR TITLE
Upgrade to mypy 0.501

### DIFF
--- a/data_capture/schedules/base.py
+++ b/data_capture/schedules/base.py
@@ -13,6 +13,7 @@ from ..models import SubmittedPriceList
 
 if False:
     from django.forms import Form  # NOQA
+    from typing import List  # NOQA
 
 min_price_validator = MinValueValidator(
     FEDERAL_MIN_CONTRACT_RATE,

--- a/docker_django_management.py
+++ b/docker_django_management.py
@@ -98,7 +98,7 @@ if sys.platform != 'win32':
 
 if False:
     # This is just needed so mypy will work; it's never executed.
-    from typing import Iterator, Any  # NOQA
+    from typing import Iterator, Any, List  # NOQA
 
 MY_DIR = os.path.abspath(os.path.dirname(__file__))
 HOST_UID = os.stat(MY_DIR).st_uid

--- a/frontend/tests/sauce_connect.py
+++ b/frontend/tests/sauce_connect.py
@@ -6,7 +6,7 @@ import pexpect
 
 if False:
     # This is just needed so mypy will work; it's never executed.
-    from typing import Optional  # NOQA
+    from typing import Optional, Dict, List  # NOQA
 
 MY_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,29 +5,8 @@ strict_optional = True
 check_untyped_defs = True
 warn_incomplete_stub = True
 warn_unused_ignores = True
-disallow_untyped_defs = True
+disallow_untyped_defs = False
 disallow_untyped_calls = True
-
-[mypy-decimal]
-disallow_untyped_defs = False
-
-[mypy-csv]
-disallow_untyped_defs = False
-
-[mypy-time]
-# Weird, apparently typeshed's own annotations for `time`
-# have some untyped stuff that mypy complains about.
-disallow_untyped_defs = False
-
-[mypy-xml]
-# Weird, apparently typeshed's own annotations for this module
-# have some untyped stuff that mypy complains about.
-disallow_untyped_defs = False
-
-[mypy-xml.etree.ElementTree]
-# Weird, apparently typeshed's own annotations for this module
-# have some untyped stuff that mypy complains about.
-disallow_untyped_defs = False
 
 [mypy-data_capture.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,7 +25,9 @@ disallow_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-data_capture.*]
-silent_imports = True
+ignore_missing_imports = True
+follow_imports = skip
 
 [mypy-contracts.*]
-silent_imports = True
+ignore_missing_imports = True
+follow_imports = skip

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,6 +19,11 @@ disallow_untyped_defs = False
 # have some untyped stuff that mypy complains about.
 disallow_untyped_defs = False
 
+[mypy-xml]
+# Weird, apparently typeshed's own annotations for this module
+# have some untyped stuff that mypy complains about.
+disallow_untyped_defs = False
+
 [mypy-xml.etree.ElementTree]
 # Weird, apparently typeshed's own annotations for this module
 # have some untyped stuff that mypy complains about.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ defusedxml==0.5.0
 rq==0.7.1
 django-rq==0.9.4
 rq-scheduler==0.7.0
-mypy-lang==0.4.6
+mypy==0.501
 pytz==2016.10
 Markdown==2.6.8
 cg-django-uaa==0.0.1


### PR DESCRIPTION
This upgrades us to mypy 0.501.

* `silent_imports` has been replaced by `ignore_missing_imports=True; follow_imports=skip`
* Previously, annotations specified in comments auto-imported built-in typings like `Dict` and `List`, but this is no longer the case, so we have to import them explicitly.

The biggest hassle here is actually just the fact that mypy changed its pypi entry from `mypy-lang` to `mypy`: this means that when you run `pip install -r requirements.txt` (or `./update.sh`) it will actually install `mypy` *on top of* `mypy-lang`.  By itself, this isn't horrible, because the `mypy` CLI will overwrite the command of the same name provided by `mypy-lang`.

However, what *does* suck is that if you switch back to a different branch that *doesn't* use this new version of mypy, running `pip install` won't re-install the old version of mypy, because it thinks it's still installed. So it won't do anything, and then your mypy tests will fail because it's running the new version of mypy but without the fixes to files contained in this PR.

*Phew*. Anyways, super annoying. If you want to switch back to a different branch after merging this you might want to run `pip uninstall mypy mypy-lang` followed by `pip install -r requirements.txt` just to make sure you've got the right version of mypy for your branch.

I guess once we merge this in, we should just advise folks with WIP PRs to merge `develop` back into their PRs ASAP or they will run into annoying problems with this.
