### PR TITLE
Make /healthcheck/ always return 200

### DIFF
--- a/hourglass/healthcheck.py
+++ b/hourglass/healthcheck.py
@@ -42,10 +42,18 @@ def healthcheck(request):
         **get_database_info(),
     }
 
-    status_code = 200
+    ok = True
 
     if not (results['is_database_synchronized'] and
             results['canonical_url_matches_request_url']):
-        status_code = 500
+        ok = False
 
-    return JsonResponse(results, status=status_code)
+    # We're always returning 200 but indicating whether everything
+    # is *really* ok in the `is_everything_ok` key. We used to
+    # return 500 if the healthcheck failed, but this ended up
+    # causing odd behavior with CloudFront. For more details, see:
+    #
+    # https://github.com/18F/calc/issues/1516
+    results['is_everything_ok'] = ok
+
+    return JsonResponse(results, status=200)

--- a/hourglass/tests/tests.py
+++ b/hourglass/tests/tests.py
@@ -88,11 +88,12 @@ class HealthcheckTests(DjangoTestCase):
         self.assertEqual(actual, expected)
 
     @override_settings(SECURE_SSL_REDIRECT=True)
-    def test_it_returns_500_when_canonical_and_request_url_mismatch(self):
+    def test_it_works_when_canonical_and_request_url_mismatch(self):
         self.assertResponseContains({
             'canonical_url': 'https://testserver/healthcheck/',
             'request_url': 'http://testserver/healthcheck/',
             'canonical_url_matches_request_url': False,
+            'is_everything_ok': False,
         })
 
     def test_it_includes_rq_jobs(self):
@@ -111,22 +112,24 @@ class HealthcheckTests(DjangoTestCase):
             f"{expected_pg_version.major}.{expected_pg_version.minor}",
         )
 
-    def test_it_returns_200_when_all_is_well(self):
+    def test_it_works_when_all_is_well(self):
         res = self.client.get('/healthcheck/')
         self.assertEqual(res.status_code, 200)
         self.assertResponseContains({
             'canonical_url_matches_request_url': True,
             'is_database_synchronized': True,
+            'is_everything_ok': True,
         }, res=res)
 
     @patch.object(healthcheck, 'get_database_info')
-    def test_it_returns_500_when_db_is_not_synchronized(self, mock):
+    def test_it_works_when_db_is_not_synchronized(self, mock):
         mock.return_value = {
             'postgres_version': settings.POSTGRES_VERSION,
             'is_database_synchronized': False,
+            'is_everything_ok': False,
         }
         res = self.client.get('/healthcheck/')
-        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.status_code, 200)
         self.assertResponseContains({
             'is_database_synchronized': False,
         }, res=res)


### PR DESCRIPTION
Fixes #1516.

Note that once we push this to production, we'll want to change the NewRelic monitor such that it searches for the following text in responses:

```
"is_everything_ok": true
```
