### PR TITLE
Add DEBUG_HTTPS setting

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -16,6 +16,11 @@ string), the boolean is true; otherwise, it's false.
 * `DEBUG` is a boolean value that indicates whether debugging is enabled
   (this should always be false in production).
 
+* `DEBUG_HTTPS` is a boolean value that indicates whether the
+  site should consider itself to be served over HTTPS while
+  debugging is enabled. This can be useful if you want to develop
+  with SSL enabled.
+
 * `HIDE_DEBUG_UI` is a boolean value that indicates whether to hide
   various development and debugging affordances in the UI, such as the
   [Django Debug Toolbar][]. This can be useful when demoing or user testing

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -32,7 +32,7 @@ load_redis_url_from_vcap_services('calc-redis')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = 'DEBUG' in os.environ
 
-DEBUG_HTTPS = 'DEBUG_HTTPS' in os.environ
+DEBUG_HTTPS = 'DEBUG_HTTPS' in os.environ and not is_running_tests()
 
 HIDE_DEBUG_UI = 'HIDE_DEBUG_UI' in os.environ
 

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -32,6 +32,8 @@ load_redis_url_from_vcap_services('calc-redis')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = 'DEBUG' in os.environ
 
+DEBUG_HTTPS = 'DEBUG_HTTPS' in os.environ
+
 HIDE_DEBUG_UI = 'HIDE_DEBUG_UI' in os.environ
 
 if is_running_tests():
@@ -285,6 +287,9 @@ DATABASES['default'] = dj_database_url.config()
 POSTGRES_VERSION = '9.4.7'
 
 SECURE_SSL_REDIRECT = not DEBUG
+
+if DEBUG and DEBUG_HTTPS:
+    SECURE_SSL_REDIRECT = True
 
 if 'FORCE_DISABLE_SECURE_SSL_REDIRECT' in os.environ:
     SECURE_SSL_REDIRECT = False

--- a/hourglass/site_utils.py
+++ b/hourglass/site_utils.py
@@ -19,7 +19,8 @@ def absolutify_url(url):
 
     protocol = 'https'
     host = Site.objects.get_current().domain
-    if settings.DEBUG or not settings.SECURE_SSL_REDIRECT:
+    if ((settings.DEBUG and not settings.DEBUG_HTTPS) or
+            not settings.SECURE_SSL_REDIRECT):
         protocol = 'http'
     return f"{protocol}://{host}{url}"
 

--- a/hourglass/tests/test_site_utils.py
+++ b/hourglass/tests/test_site_utils.py
@@ -41,3 +41,11 @@ class SiteUtilsTests(TestCase):
             absolutify_url('/blap'),
             'http://example.com/blap'
         )
+
+    @override_settings(DEBUG=True, DEBUG_HTTPS=True,
+                       SECURE_SSL_REDIRECT=True)
+    def test_absolutify_url_works_when_debug_https_is_true(self):
+        self.assertEqual(
+            absolutify_url('/blap'),
+            'https://example.com/blap'
+        )


### PR DESCRIPTION
This adds a new setting, `DEBUG_HTTPS`, which allows the site to be served in debug mode over HTTPS.

It's primarily of importance to the site's notion of its "canonical url" when no `request` object is present: until now, we've always assumed that if `DEBUG` is true, the protocol for the canonical URL should be `http`, but setting `DEBUG_HTTPS` essentially forces it to be `https`.

I needed to add support for this to #997 because we're now putting the price list analysis deployment behind cloud.gov's SSL-terminating reverse proxy, and I figured this kind of functionality might be useful for local development too.
