### PR TITLE
Upgrade cf cli in Travis to latest recommended version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
   - TRAVIS_NODE_VERSION=6.5.0
   - NPM_CONFIG_ENGINE_STRICT=true
   - PHANTOMJS_TIMEOUT=15
-  - CF_CLI_VERSION=6.22.2
+  - CF_CLI_VERSION=6.25.0
   - SKIP_STATIC_ASSET_BUILDING=yup
   - DEBUG=yup
   - DATABASE_URL=postgres://postgres@localhost/hourglass


### PR DESCRIPTION
From the cloud.gov newsletter, we should be using [v6.25.0](https://github.com/cloudfoundry/cli/releases/tag/v6.25.0)