### PR TITLE
Don't eslint on file change if ESLINT_CHILL_OUT is set

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -110,6 +110,10 @@ string), the boolean is true; otherwise, it's false.
   will be sent messages whenever certain kinds of
   [events](../slackbot/signals.py) occur in the app.
 
+* `ESLINT_CHILL_OUT` is a boolean; if true, it will change the behavior
+  of gulp's watch mode such that it doesn't run `eslint` every time a
+  file changes.
+
 [RoboBrowser]: http://robobrowser.readthedocs.io/
 [`SECRET_KEY`]: https://docs.djangoproject.com/en/1.8/ref/settings/#secret-key
 [`DEFAULT_FROM_EMAIL`]: https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-DEFAULT_FROM_EMAIL

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,10 @@ gulp.task('build', ['sass', 'js', 'sphinx']);
 gulp.task('watch', ['set-watching', 'sass', 'js', 'sphinx'], () => {
   gulp.watch(path.join(dirs.src.sphinx, paths.sphinx), ['sphinx']);
   gulp.watch(path.join(dirs.src.style, paths.sass), ['sass']);
-  gulp.watch(path.join(dirs.src.scripts, paths.js), ['lint']);
+
+  if (!('ESLINT_CHILL_OUT' in process.env)) {
+    gulp.watch(path.join(dirs.src.scripts, paths.js), ['lint']);
+  }
 
   // Note: wepback bundles set up their own watch handling
   // so we don't want to re-trigger them here, ref #437


### PR DESCRIPTION
This fixes #1511 by not running eslint every time a file changes if `ESLINT_CHILL_OUT` is set.