### PR TITLE
Run production_tests when in travis cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ install:
 - pip install -r requirements-dev.txt
 - npm install -g gulp-cli yarn@0.21.3
 - yarn --pure-lockfile
-before_script:
-  - export TRAVIS_EVENT_TYPE="cron"
 script:
 - phantomjs --version
 - python manage.py ultratest flake8 eslint mypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ install:
 - pip install -r requirements-dev.txt
 - npm install -g gulp-cli yarn@0.21.3
 - yarn --pure-lockfile
+before_script:
+  - export TRAVIS_EVENT_TYPE="cron"
 script:
 - phantomjs --version
 - python manage.py ultratest flake8 eslint mypy
@@ -27,6 +29,11 @@ script:
 - bandit -r .
 - npm test
 - python frontend/tests/sauce_connect.py py.test --ignore=frontend/tests/test_selenium.py --cov
+- |
+  if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then
+    # run production tests
+    py.test production_tests
+  fi
 after_success:
 - codeclimate-test-reporter
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,8 @@ script:
 - bandit -r .
 - npm test
 - python frontend/tests/sauce_connect.py py.test --ignore=frontend/tests/test_selenium.py --cov
-- |
-  if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then
-    # run production tests
-    py.test production_tests
-  fi
+  # Run production tests if we're in a Travis cron run
+- if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then py.test production_tests; fi
 after_success:
 - codeclimate-test-reporter
 env:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,5 +1,7 @@
 ## Monitoring
 
+### Healthcheck
+
 CALC has an endpoint at `/healthcheck/` which always
 returns a `200 OK` response of type `application/json`. The
 returned object has the following keys:
@@ -36,4 +38,12 @@ returned object has the following keys:
 For more details on the `/healthcheck/` endpoint, see
 [hourglass/healthcheck.py](../hourglass/healthcheck.py).
 
+### Production tests
+
+CALC has a suite of tests in [production_tests](../production_tests/) for
+checking that the production site is properly configured.
+
+These tests are run as part of our daily [Travis cron][travis-cron] build.
+
 [rq]: http://python-rq.org/
+[travis-cron]: https://docs.travis-ci.com/user/cron-jobs/


### PR DESCRIPTION
Closes #1331 
Ref #1521

This PR sets up Travis to run `py.test production_tests` when it is doing its daily cron run.

To Do:
- [x] test it works by faking the `TRAVIS_EVENT_TYPE`
- [x] remove setting of `TRAVIS_EVENT_TYPE` in `before_script`