### PR TITLE
Upgrade to Django 1.9.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 dj-database-url==0.4.2
 dj-email-url==0.0.10
 django-click==1.2.0
-Django==1.9.12
+Django==1.9.13
 django-cors-headers==2.0.2
 django-debug-toolbar==1.6
 djangorestframework==3.5.3


### PR DESCRIPTION
Closes #1526

Security release notes: https://www.djangoproject.com/weblog/2017/apr/04/security-releases/