### PR TITLE
Prepare CALC for migration to Django 1.10

### DIFF
--- a/hourglass/templates/admin/base.html
+++ b/hourglass/templates/admin/base.html
@@ -24,13 +24,13 @@
 
 <body class="{% if is_popup %}popup {% endif %}card--wide{% block bodyclass %}{% endblock %}">
 
-  {% include "../../data_explorer/templates/_banner.html" %}
+  {% include "_banner.html" %}
 
   {% if not is_popup %}
   <header>
     <div class="container">
-    {% include "../../data_explorer/templates/_header.html" %}
-    {% include "../../data_explorer/templates/_nav.html" %}
+    {% include "_header.html" %}
+    {% include "_nav.html" %}
     </div>
   </header>
   <!-- Header -->
@@ -99,7 +99,7 @@
   <!-- END Content -->
 
   {% block footer %}
-    {% include "../../data_explorer/templates/_footer.html" %}
+    {% include "_footer.html" %}
   {% endblock %}
 
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Django==1.9.13
 django-cors-headers==2.0.2
 django-debug-toolbar==1.6
 djangorestframework==3.5.3
-git+git://github.com/18F/djorm-ext-pgfulltext@179c45929288e6b14f3067489c1ba8f9e158a974
+git+git://github.com/18F/djorm-ext-pgfulltext@eabba50831ab48509e2ce4fcb4e32a7f1f1aec05
 gunicorn==19.6.0
 newrelic==2.78.0.57
 psycopg2==2.6.2

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -20,12 +20,12 @@ def get_existing_filename_upload_form():
         js = forms.FileField(widget=UploadWidget(
             required=False,
             existing_filename='boop.csv',
-        ))
+        ), required=False)
         no_js = forms.FileField(widget=UploadWidget(
             degraded=True,
             required=False,
             existing_filename='boop.csv',
-        ))
+        ), required=False)
 
     return MyForm()
 


### PR DESCRIPTION
This PR *prepares* CALC for migration to Django 1.10--by which I mean that it makes low-impact, backwards-compatible changes to ensure that CALC's test suite passes on Django 1.10, but it doesn't actually *upgrade* CALC's version of Django. This is because we're about to put CALC on hiatus and might not be able to address any problems that might arise from actually migrating. But we do want to make it *easy* to migrate if we (or another team that inherits this project) need to upgrade once Django 1.9 reaches end-of-life. This will make it easier to eventually make our way to 1.11 (#1346), which is the next long-term support (LTS) release.

This is coupled with the changes made in our fork of djorm-ext-pgfulltext at https://github.com/18F/djorm-ext-pgfulltext/pull/3, so if we merge this PR, we should also merge that one. (If you need to make local edits to that fork and test them with CALC, you can follow the instructions at https://github.com/18F/calc/pull/1466#issuecomment-284104266.)
