### PR TITLE
Fix update_search_field args

### DIFF
--- a/cf.sh
+++ b/cf.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
+
+set -e
+
 if [ $CF_INSTANCE_INDEX = "0" ]; then
     echo "----- Migrating Database -----"
     python manage.py migrate --noinput
 
     echo "----- Updating search field -----"
     # The '-W ignore is to suppress https://github.com/18F/calc/issues/291.
-    python -W ignore manage.py update_search_field contracts
+    python -W ignore manage.py update_search_field contracts Contract
 
     echo "----- Initializing Groups -----"
     python manage.py initgroups

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -312,7 +312,7 @@ class Contract(models.Model):
 
         # Note also that any logic changes to this code should
         # eventually be followed-up with
-        # `manage.py update_search_field contracts`. Otherwise,
+        # `manage.py update_search_field contracts Contract`. Otherwise,
         # all pre-existing contracts will still have search
         # index information corresponding to the old logic.
 

--- a/data_capture/admin.py
+++ b/data_capture/admin.py
@@ -132,9 +132,7 @@ class CustomUserAdmin(UserAdmin):
         ('Important dates', {'fields': ('last_login', 'date_joined')}),
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        UserAdmin.list_display = ('email', 'is_staff')
+    list_display = ('email', 'is_staff')
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/update.sh
+++ b/update.sh
@@ -13,7 +13,7 @@ python manage.py migrate --noinput
 
 echo "----- Updating search field -----"
 # The '-W ignore is to suppress https://github.com/18F/calc/issues/291.
-python -W ignore manage.py update_search_field contracts
+python -W ignore manage.py update_search_field contracts Contract
 
 echo "----- Initializing Groups -----"
 python manage.py initgroups


### PR DESCRIPTION
Fixes #1546 

- Updates all `update_search_field` calls to include `Contract` as the `"model"` arg
- Adds `set -e` to `cf.sh` so that it will properly fail deployments when a subcommand has an error
- Unrelated change: Minor code cleanup suggested by @cmc333333 to move the `list_display` fields of `CustomUserAdmin` in `data_capture/admin.py` up to the class definition instead of in the constructor. Don't know what I was thinking there 😝 

Note that I thought about modifying our shadowed `update_search_field` to itself add the model param into the `kwargs` that get passed to the original `update_search_field`, but thought that was a little too whacky. 

