### PR TITLE
Use updated djorm-ext-pgfulltext

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Django==1.9.13
 django-cors-headers==2.0.2
 django-debug-toolbar==1.6
 djangorestframework==3.5.3
-git+git://github.com/18F/djorm-ext-pgfulltext@eabba50831ab48509e2ce4fcb4e32a7f1f1aec05
+git+git://github.com/18F/djorm-ext-pgfulltext@7ce6606dcb2c4fdd235439b6adcadeb143974a62
 gunicorn==19.6.0
 newrelic==2.78.0.57
 psycopg2==2.6.2


### PR DESCRIPTION
This is an alternative fix for #1546 that modifies our fork of djorm-ext-pgfulltext to use a fix for the regression that caused #1546 (whereby `model` became a required arg instead of an optional one), which was done in https://github.com/18F/djorm-ext-pgfulltext/pull/3/commits/7ce6606dcb2c4fdd235439b6adcadeb143974a62.

Note that this isn't mutually exclusive from #1547, since that PR just explicitly passes `model` in as an arg. I think this fix is nice because it keeps our fork of djorm-ext-pgfulltext still working the same way as it always has, though.