### PR TITLE
Prepare CALC for migration to Django 1.11

### DIFF
--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -1,0 +1,3 @@
+import django
+
+USE_NEW_FORM_API = django.VERSION[0] >= 1 and django.VERSION[1] >= 11

--- a/frontend/date.py
+++ b/frontend/date.py
@@ -6,6 +6,8 @@ from django.forms import MultiWidget, NumberInput
 from django.forms.fields import MultiValueField, IntegerField
 from django.template.loader import render_to_string
 
+from . import USE_NEW_FORM_API
+
 
 FieldNames = namedtuple('FieldNames', ['year', 'month', 'day'])
 
@@ -46,7 +48,11 @@ class SplitDateWidget(MultiWidget):
         if not isinstance(value, list):
             value = self.decompress(value)
 
-        final_attrs = self.build_attrs(attrs)
+        if USE_NEW_FORM_API:
+            final_attrs = self.build_attrs(self.attrs, attrs)
+        else:
+            final_attrs = self.build_attrs(attrs)
+
         id_ = final_attrs.get('id')
         widget_infos = []
         for i, widget in enumerate(self.widgets):

--- a/frontend/templates/frontend/input_option.html
+++ b/frontend/templates/frontend/input_option.html
@@ -1,0 +1,1 @@
+{% include "django/forms/widgets/input.html" %}<label for="{{ widget.attrs.id }}"> {{ widget.label }}</label>

--- a/frontend/widgets.py
+++ b/frontend/widgets.py
@@ -1,43 +1,57 @@
 from django import forms
 from django.utils.html import format_html
 
+from . import USE_NEW_FORM_API
 
-class LabelInputSiblingRenderer():
-    def render(self, name=None, value=None, attrs=None):
-        # This is mostly just a copy-paste of our superclass method, it
-        # just tweaks the HTML structure to be USWDS-friendly.
-        if self.id_for_label:
-            label_for = format_html(' for="{}"', self.id_for_label)
-        else:
-            raise ValueError('USWDS-style inputs must have "id" attributes')
-        attrs = dict(self.attrs, **attrs) if attrs else self.attrs
-        return format_html(
-            '{}<label{}>{}</label>', self.tag(attrs), label_for,
-            self.choice_label,
-        )
+if not USE_NEW_FORM_API:
+    class LabelInputSiblingRenderer():
+        def render(self, name=None, value=None, attrs=None):
+            # This is mostly just a copy-paste of our superclass method, it
+            # just tweaks the HTML structure to be USWDS-friendly.
+            if self.id_for_label:
+                label_for = format_html(' for="{}"', self.id_for_label)
+            else:
+                raise ValueError('USWDS-style inputs must have "id" '
+                                 'attributes')
+            attrs = dict(self.attrs, **attrs) if attrs else self.attrs
+            return format_html(
+                '{}<label{}>{}</label>', self.tag(attrs), label_for,
+                self.choice_label,
+            )
 
+    class UswdsCheckboxInput(LabelInputSiblingRenderer,
+                             forms.widgets.CheckboxChoiceInput):
+        pass
 
-class UswdsCheckboxInput(LabelInputSiblingRenderer,
-                         forms.widgets.CheckboxChoiceInput):
-    pass
+    class UswdsRadioChoiceInput(LabelInputSiblingRenderer,
+                                forms.widgets.RadioChoiceInput):
+        pass
 
+    class UswdsRadioFieldRenderer(forms.widgets.ChoiceFieldRenderer):
+        choice_input_class = UswdsRadioChoiceInput
 
-class UswdsRadioChoiceInput(LabelInputSiblingRenderer,
-                            forms.widgets.RadioChoiceInput):
-    pass
+    class UswdsRadioSelect(forms.widgets.RadioSelect):
+        renderer = UswdsRadioFieldRenderer
 
+    class UswdsCheckboxFieldRenderer(forms.widgets.ChoiceFieldRenderer):
+        choice_input_class = UswdsCheckboxInput
 
-class UswdsRadioFieldRenderer(forms.widgets.ChoiceFieldRenderer):
-    choice_input_class = UswdsRadioChoiceInput
+    class UswdsCheckbox(forms.widgets.CheckboxSelectMultiple):
+        renderer = UswdsCheckboxFieldRenderer
+else:
+    # We're using the new form API, which makes this easier.
 
+    class IdRequiredWidget:
+        def get_context(self, name, value, attrs):
+            context = super().get_context(name, value, attrs)
+            if 'id' not in context['widget']['attrs']:
+                raise ValueError('USWDS-style inputs must have "id" '
+                                 'attributes')
+            return context
 
-class UswdsRadioSelect(forms.widgets.RadioSelect):
-    renderer = UswdsRadioFieldRenderer
+    class UswdsRadioSelect(IdRequiredWidget, forms.widgets.RadioSelect):
+        option_template_name = 'frontend/input_option.html'
 
-
-class UswdsCheckboxFieldRenderer(forms.widgets.ChoiceFieldRenderer):
-    choice_input_class = UswdsCheckboxInput
-
-
-class UswdsCheckbox(forms.widgets.CheckboxSelectMultiple):
-    renderer = UswdsCheckboxFieldRenderer
+    class UswdsCheckbox(IdRequiredWidget,
+                        forms.widgets.CheckboxSelectMultiple):
+        option_template_name = 'frontend/input_option.html'


### PR DESCRIPTION
This prepares us for #1346 by making all our tests pass on Django 1.11.  As with #1544, it doesn't actually _upgrade_ us to Django 1.11, it just makes changes required for tests to pass under the new version, without breaking our current use of Django 1.9.

However, unlike #1544, the breaking changes in Django 1.11 related to [template-based widget rendering](https://docs.djangoproject.com/en/1.11/releases/1.11/#template-based-widget-rendering) are backwards-incompatible with earlier versions of Django. So I had to add branching logic that detects what version of Django we're on. 😞 

So to fully test both conditional branches, you need to run the test suite, then manually change `requirements.txt` to use Django 1.11, and run the tests again.

I'm not sure how I feel about the branching logic--or rather, I'm not sure whether we should just close this PR unmerged and later crib from it when we're ready to actually migrate to Django 1.11.

One advantage of keeping the branching logic, though, is that it better prepares our USWDS widgets for being reused by other Django projects. If we were to factor out the USWDS widgets into a separate third-party package, for example, it would probably be a good idea to keep the branching logic, so that clients could use it regardless of their Django version. As first-party CALC code, though, I'm not sure how much sense it makes to keep the branching logic.
