### PR TITLE
Remove model arg in calls to update_search_field

### DIFF
--- a/cf.sh
+++ b/cf.sh
@@ -8,7 +8,7 @@ if [ $CF_INSTANCE_INDEX = "0" ]; then
 
     echo "----- Updating search field -----"
     # The '-W ignore is to suppress https://github.com/18F/calc/issues/291.
-    python -W ignore manage.py update_search_field contracts Contract
+    python -W ignore manage.py update_search_field contracts
 
     echo "----- Initializing Groups -----"
     python manage.py initgroups

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -312,7 +312,7 @@ class Contract(models.Model):
 
         # Note also that any logic changes to this code should
         # eventually be followed-up with
-        # `manage.py update_search_field contracts Contract`. Otherwise,
+        # `manage.py update_search_field contracts`. Otherwise,
         # all pre-existing contracts will still have search
         # index information corresponding to the old logic.
 

--- a/update.sh
+++ b/update.sh
@@ -13,7 +13,7 @@ python manage.py migrate --noinput
 
 echo "----- Updating search field -----"
 # The '-W ignore is to suppress https://github.com/18F/calc/issues/291.
-python -W ignore manage.py update_search_field contracts Contract
+python -W ignore manage.py update_search_field contracts
 
 echo "----- Initializing Groups -----"
 python manage.py initgroups


### PR DESCRIPTION
PR against #1548 that removes specification of the `model` arg to calls to `update_search_field`, which was added in #1547.

Note that even with this change I am still seeing this output when running `manage.py update_search_field contract`, as in `update.sh`:

```
----- Updating search field -----
Connection to database established.
Updating normalized labor categories...
Updating full-text search indexes...
Processing model <class 'contracts.models.Contract'>...Done
Processing model <class 'contracts.models.Contract_Deferred_business_size_contract_end_con3c5191c64f6bb1853aab160e8583eb47'>...Done
```