### PR TITLE
Run aXe-core on data explorer, fix a11y violation.

### DIFF
--- a/frontend/source/js/data-explorer/components/query-type.jsx
+++ b/frontend/source/js/data-explorer/components/query-type.jsx
@@ -41,7 +41,7 @@ export function QueryType({ queryType, setQueryType, idPrefix }) {
   };
 
   return (
-    <div>
+    <div role="group" aria-label="Labor category query type">
       {input(QUERY_TYPE_MATCH_ALL)}
       {input(QUERY_TYPE_MATCH_PHRASE)}
       {input(QUERY_TYPE_MATCH_EXACT)}

--- a/frontend/source/js/data-explorer/tests/__snapshots__/query-type.test.jsx.snap
+++ b/frontend/source/js/data-explorer/tests/__snapshots__/query-type.test.jsx.snap
@@ -1,5 +1,7 @@
 exports[`<QueryType> matches snapshot 1`] = `
-<div>
+<div
+  aria-label="Labor category query type"
+  role="group">
   <span>
     <input
       checked={false}

--- a/frontend/tests/axe.py
+++ b/frontend/tests/axe.py
@@ -1,0 +1,72 @@
+'''
+    This module provides functionality to validate the accessibility
+    properties of a web page using WebDriver and aXe-core.
+
+    For more details on aXe, see https://www.deque.com/products/axe/.
+'''
+
+from pathlib import Path
+import pprint
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent
+
+AXE_JS = ROOT_DIR / 'node_modules' / 'axe-core' / 'axe.js'
+
+IGNORED_VIOLATIONS = [
+    # We should eventually enable these, but for now we'll disable
+    # them because it's easier. Better *some* a11y testing than none
+    # at all!
+    'color-contrast',
+]
+
+axe_js = None
+
+
+def get_axe_js():
+    '''
+    Return the contents of the aXe-core JavaScript.
+    '''
+
+    global axe_js
+
+    if axe_js is None:
+        axe_js = AXE_JS.read_text()
+
+    return axe_js
+
+
+def run_and_validate(webdriver):
+    '''
+    Run aXe-core on the current web page loaded by the given
+    WebDriver instance. Raise an exception if there are any
+    accessibility issues with the page and log any violations to
+    stdout.
+    '''
+
+    result = webdriver.execute_async_script(
+        get_axe_js() +
+        r'''
+        var callback = arguments[arguments.length - 1];
+        axe.run(function(err, results) {
+          callback({
+            error: err && err.toString(),
+            results: results
+          });
+        });
+        ''')
+
+    error = result['error']
+    if error is not None:
+        raise Exception(f'axe.run() failed: {error}')
+
+    violations = [
+        v for v in result['results']['violations']
+        if v['id'] not in IGNORED_VIOLATIONS
+    ]
+    if violations:
+        pprint.pprint(violations)
+        print("For more details, please install the aXe browser extension.")
+        print("Learn more at: https://www.deque.com/products/axe/")
+
+        raise Exception('axe.run() found violations: ' +
+                        ', '.join(v['id'] for v in violations))

--- a/frontend/tests/test_selenium.py
+++ b/frontend/tests/test_selenium.py
@@ -29,6 +29,7 @@ import os
 import socket
 from datetime import datetime
 
+from . import axe
 from .utils import build_static_assets
 
 
@@ -504,6 +505,10 @@ class DataExplorerTests(SeleniumTestCase):
 
         self.assertIsNone(re.search(r'AIMS\d+', driver.page_source))
         self.assertIsNotNone(re.search(r'MOBIS\d+', driver.page_source))
+
+    def test_index_accessibility(self):
+        self.load_and_wait()
+        axe.run_and_validate(self.driver)
 
     def test_schedule_column_is_open_by_default(self):
         get_contract_recipe().make(_quantity=5)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "An estimator for hourly rates on professional services contracts",
   "dependencies": {
     "a11y-dialog": "2.5.2",
+    "axe-core": "^2.1.7",
     "babel-core": "^6.23.1",
     "babel-jest": "^18.0.0",
     "babel-loader": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,6 +234,10 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axe-core@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.1.7.tgz#4f66f2b3ee3b58ec2d3db4339dd124c5b33b79c3"
+
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"


### PR DESCRIPTION
This introduces the [aXe accessibility testing tool](https://www.deque.com/products/axe/) to CALC's testing regimen by running it on the data explorer. Right now we're ignoring the handful of color contrast issues on the page because I'd like a designer's help fixing those and I just wanted to focus on introducing aXe for now.

The one violation I *did* fix is in regards to the fact that the radios under the labor category search weren't grouped in an accessible way.