### PR TITLE
adding to update.sh so that things will work with 3.6

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "----- Updating Python Dependencies -----"
-pip install -r requirements-dev.txt
+python -m pip install -r requirements-dev.txt
 
 echo "----- Updating Node Dependencies -----"
 yarn


### PR DESCRIPTION
I was having trouble following calc's installation instructions with python 3.6.  So I am updating the install script from:

pip install -r requirements.txt

to

python -m pip install -r requirements.txt 

So that I can install things.