### PR TITLE
Prefix excel formula chars with apostrophe in query csv export text

### DIFF
--- a/api/tests/test_rates_csv.py
+++ b/api/tests/test_rates_csv.py
@@ -5,14 +5,15 @@ from .test_rates_api import GetRatesTests
 
 RATES_CSV_PATH = '/api/rates/csv'
 
+
 # TODO: These tests need to be more fully fleshed out
 class GetRatesCSVTests(TestCase):
-  def setUp(self):
-    GetRatesTests.make_test_set()
-    self.path = RATES_CSV_PATH
+    def setUp(self):
+        GetRatesTests.make_test_set()
+        self.path = RATES_CSV_PATH
 
-  def test_prefixes_excel_formula_chars(self):
-    excel_formula_prefixes = ['@', '-', '=', '|', '%']
-    for char in excel_formula_prefixes:
-      resp = self.client.get(f'{self.path}/?q={char}query')
-      self.assertContains(resp, f"'{char}query")
+    def test_prefixes_excel_formula_chars(self):
+        excel_formula_prefixes = ['@', '-', '=', '|', '%']
+        for char in excel_formula_prefixes:
+            resp = self.client.get(f'{self.path}/?q={char}query')
+            self.assertContains(resp, f"'{char}query")

--- a/api/tests/test_rates_csv.py
+++ b/api/tests/test_rates_csv.py
@@ -1,3 +1,4 @@
+import urllib
 
 from django.test import TestCase
 
@@ -12,8 +13,9 @@ class GetRatesCSVTests(TestCase):
         GetRatesTests.make_test_set()
         self.path = RATES_CSV_PATH
 
-    def test_prefixes_excel_formula_chars(self):
-        excel_formula_prefixes = ['@', '-', '=', '|', '%']
+    def test_prefixes_excel_formula_chars_in_query(self):
+        excel_formula_prefixes = ['@', '+', '-', '=', '|', '%']
         for char in excel_formula_prefixes:
-            resp = self.client.get(f'{self.path}/?q={char}query')
+            encoded_query = urllib.parse.quote(f'{char}query')
+            resp = self.client.get(f'{self.path}/?q={encoded_query}')
             self.assertContains(resp, f"'{char}query")

--- a/api/tests/test_rates_csv.py
+++ b/api/tests/test_rates_csv.py
@@ -1,0 +1,18 @@
+
+from django.test import TestCase
+
+from .test_rates_api import GetRatesTests
+
+RATES_CSV_PATH = '/api/rates/csv'
+
+# TODO: These tests need to be more fully fleshed out
+class GetRatesCSVTests(TestCase):
+  def setUp(self):
+    GetRatesTests.make_test_set()
+    self.path = RATES_CSV_PATH
+
+  def test_prefixes_excel_formula_chars(self):
+    excel_formula_prefixes = ['@', '-', '=', '|', '%']
+    for char in excel_formula_prefixes:
+      resp = self.client.get(f'{self.path}/?q={char}query')
+      self.assertContains(resp, f"'{char}query")

--- a/api/views.py
+++ b/api/views.py
@@ -223,6 +223,13 @@ class GetRatesCSV(APIView):
         contracts_all = get_contracts_queryset(request.GET, wage_field)
 
         q = request.query_params.get('q', 'None')
+
+        # if the query starts with special chars that could be interpreted
+        # as parts of a formula by Excel, then prefix the query with
+        # an apostrophe so that Excel instead treats it as plain text
+        if q.startswith(('@', '-', '=', '|', '%')):
+            q = "'" + q
+
         min_education = request.query_params.get(
             'min_education', 'None Specified')
         min_experience = request.query_params.get(

--- a/api/views.py
+++ b/api/views.py
@@ -224,10 +224,12 @@ class GetRatesCSV(APIView):
 
         q = request.query_params.get('q', 'None')
 
-        # if the query starts with special chars that could be interpreted
+        # If the query starts with special chars that could be interpreted
         # as parts of a formula by Excel, then prefix the query with
-        # an apostrophe so that Excel instead treats it as plain text
-        if q.startswith(('@', '-', '=', '|', '%')):
+        # an apostrophe so that Excel instead treats it as plain text.
+        # See https://issues.apache.org/jira/browse/CSV-199
+        # for more information.
+        if q.startswith(('@', '-', '+', '=', '|', '%')):
             q = "'" + q
 
         min_education = request.query_params.get(


### PR DESCRIPTION
The raw query string is written to the CSV export of price search results.
If the query starts with excel formula characters, then when the CSV
is opened in Excel, lots of (potentially bad) stuff can happen as Excel
processes the formula. This PR mitigates this issue by prefixing the query
string with an apostrophe if it starts with an Excel formular character.
That way, Excel will treat the cell content as plain text rather than a formula.

ref: https://github.com/18F/vuln-reports-private/issues/8