### PR TITLE
[WIP] Fix prod deployments on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,18 +147,18 @@ jobs:
       - deploy:
           name: Deploy to dev
           command: |
-            if [ "${CIRCLE_BRANCH}" == "develop" ]; then
+            if [[ "${CIRCLE_BRANCH}" == "develop" ]]; then
               DEPLOY_ENV=dev ./.circleci/deploy-circle.sh
             fi
       - deploy:
           name: Deploy to staging
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
               DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
             fi
       - deploy:
           name: Deploy to prod
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] && [ "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]; then
+            if [[ "${CIRCLE_BRANCH}" == "master" ]] && [[ "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,12 @@ version: 2
 jobs:
   build_and_test:
     working_directory: ~/calc
+    filters:
+      # Due to how tags work in CircleCI we need to tell this job
+      # to run on any tag
+      # ref: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
+      tags:
+        only: /.*/
     docker:
       - image: circleci/python:3.6
         environment:
@@ -151,8 +157,7 @@ jobs:
     steps:
       - run:
           name: Deploy to dev
-          command: echo "deploying to dev"
-          # command: DEPLOY_ENV=dev ./.circleci/deploy-circle.sh
+          command: DEPLOY_ENV=dev ./.circleci/deploy-circle.sh
 
   deploy_staging:
     machine:
@@ -161,8 +166,7 @@ jobs:
     steps:
       - run:
           name: Deploy to staging
-          command: echo "deploying to staging"
-          # command: DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
+          command: DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
 
   deploy_prod:
     machine:
@@ -171,14 +175,31 @@ jobs:
     steps:
       - run:
           name: Deploy to prod
-          command: echo "deploying to prod"
-          # command: DEPLOY_ENV=prod ./.circleci/deploy-circle.sh
+          command: DEPLOY_ENV=prod ./.circleci/deploy-circle.sh
+
+  deploy_test: # TODO: delete this
+    machine:
+        enabled: true
+    working_directory: ~/calc
+    steps:
+      - run:
+          name: Deploy tag test
+          command: echo "got to the deploy step"
+      - run:
+          name: Deploy to dev
+          command: DEPLOY_ENV=dev ./.circleci/deploy-circle.sh
 
 workflows:
   version: 2
   build-and-deploy:
     jobs:
       - build_and_test
+      - deploy_test: # TODO: delete this
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only: fix-circle-prod-builds
       - deploy_dev:
           requires:
             - build_and_test
@@ -196,6 +217,8 @@ workflows:
             - build_and_test
           filters:
             branches:
-              only: master
+              # Don't run this for any branch name, but ...
+              ignore: /.*/
             tags:
+              # ... only when there is a tag that looks like "v#.#.#"
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build_and_test:
     working_directory: ~/calc
     docker:
       - image: circleci/python:3.6
@@ -144,21 +144,58 @@ jobs:
       # Cron-style builds are not yet supported in CircleCI
       #  if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then py.test production_tests; fi
 
-      - deploy:
+  deploy_dev:
+    machine:
+        enabled: true
+    working_directory: ~/calc
+    steps:
+      - run:
           name: Deploy to dev
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "develop" ]]; then
-              DEPLOY_ENV=dev ./.circleci/deploy-circle.sh
-            fi
-      - deploy:
+          command: echo "deploying to dev"
+          # command: DEPLOY_ENV=dev ./.circleci/deploy-circle.sh
+
+  deploy_staging:
+    machine:
+        enabled: true
+    working_directory: ~/calc
+    steps:
+      - run:
           name: Deploy to staging
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-              DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
-            fi
-      - deploy:
+          command: echo "deploying to staging"
+          # command: DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
+
+  deploy_prod:
+    machine:
+        enabled: true
+    working_directory: ~/calc
+    steps:
+      - run:
           name: Deploy to prod
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]] && [[ "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
-            fi
+          command: echo "deploying to prod"
+          # command: DEPLOY_ENV=prod ./.circleci/deploy-circle.sh
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build_and_test
+      - deploy_dev:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only: develop
+      - deploy_staging:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only: master
+      - deploy_prod:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/hourglass/tests/test_configuration.py
+++ b/hourglass/tests/test_configuration.py
@@ -37,7 +37,7 @@ class PythonVersionTests(TestCase):
             data = yaml.safe_load(f)
             # In CircleCI we can only specify down to the minor number
             self.assertEqual(
-                str(data['jobs']['build']['docker'][0]['image']),
+                str(data['jobs']['build_and_test']['docker'][0]['image']),
                 f"circleci/python:{self.version.major}.{self.version.minor}")
 
     def test_docs_setup_md(self):
@@ -64,7 +64,7 @@ class PostgresVersionTests(TestCase):
             data = yaml.safe_load(f)
             # In Circle we can only specify down to the minor number
             self.assertEqual(
-                str(data['jobs']['build']['docker'][1]['image']),
+                str(data['jobs']['build_and_test']['docker'][1]['image']),
                 f"circleci/postgres:{self.version.major}.{self.version.minor}")
 
 


### PR DESCRIPTION
Unfortunately the way we were attempting to do production deploys in Circle like we were doing in Travis won't work as easily. I think we have to switch to a `workflows`-based build process.

Before merge:
- [ ] change repo settings to make `ci/circleci: build_and_test` a required status check and remove the `ci/circleci` status check