### PR TITLE
Switch to 3-tiered branch deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,18 +147,18 @@ jobs:
       - deploy:
           name: Deploy to dev
           command: |
-            if [ "${CIRCLE_BRANCH}" == "develop" ]; then
+            if [[ "${CIRCLE_BRANCH}" == "develop" ]]; then
               DEPLOY_ENV=dev ./.circleci/deploy-circle.sh
             fi
       - deploy:
           name: Deploy to staging
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
               DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
             fi
       - deploy:
           name: Deploy to prod
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] && [ "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]; then
-              DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
+            if [[ "${CIRCLE_BRANCH}" == "master" ]] && [[ "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              DEPLOY_ENV=prod ./.circleci/deploy-circle.sh
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,12 +153,12 @@ jobs:
       - deploy:
           name: Deploy to staging
           command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+            if [[ "${CIRCLE_BRANCH}" == "staging" ]]; then
               DEPLOY_ENV=staging ./.circleci/deploy-circle.sh
             fi
       - deploy:
           name: Deploy to prod
           command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]] && [[ "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
               DEPLOY_ENV=prod ./.circleci/deploy-circle.sh
             fi

--- a/docs/release.md
+++ b/docs/release.md
@@ -29,7 +29,7 @@ To release version 0.0.4 of CALC:
     git push -u https://github.com/18F/calc.git v0.0.4-rc
     ```
 
-3.  [Issue a PR][pr] to merge your branch into `master` titled
+3.  [Issue a PR][pr] to merge your branch into `staging` titled
     "Tag and release v0.0.4". Paste in the latest changes from the
     topmost "Unreleased" section of `CHANGELOG.md` into the
     description of the PR so stakeholders know what's changed. If you're
@@ -43,7 +43,8 @@ To release version 0.0.4 of CALC:
 4.  Make sure that all automated QA services (CircleCI, etc) think
     the PR looks good.
 
-5.  Wait for the stakeholders to sign-off on the release.
+5.  Wait for the stakeholders to sign-off on the release if there are
+    functional or product changes.
 
 6.  Update the version number in `hourglass/version.py` to `0.0.4` and then
     run:
@@ -63,22 +64,37 @@ To release version 0.0.4 of CALC:
     git push
     ```
 
-8.  Merge the PR into `master` via the **Create a merge commit** merge
+8.  Merge the PR into `staging` via the **Create a merge commit** merge
     strategy (i.e., do *not* squash or rebase). Once CircleCI is finished,
-    the site will be deployed to staging.
+    the site will be deployed to [staging][staging].
 
 9.  Visit the [staging instance][staging] and make sure all is functioning as
     expected.
 
-10. Tag the release and push it to the official repository, which will trigger
-    CircleCI to deploy the site to [production][production]:
+10. If all is good in staging, checkout the `staging` branch locally:
+
+    ```
+    git checkout staging
+    git pull https://github.com/18F/calc.git staging
+    ```
+
+11. Tag the release and push it to the official repository:
 
     ```
     git tag -a v0.0.4 -F tag-message-v0.0.4.txt
     git push https://github.com/18F/calc.git v0.0.4
     ```
 
-11. Merge `v0.0.4-rc` into `develop` on the official repository:
+12. In GitHub, open a PR from `staging` to `master` and wait for all status
+    checks to successfully pass. Have another developer review and approve
+    the PR.
+
+13. Once the PR from `staging` to `master` is approved, merge it via the
+    **Create a merge commit** merge strategy (i.e., do *not* squash or rebase).
+    Once CircleCI is finished, the site will be deployed to
+    [production][production].
+
+14. Merge `v0.0.4-rc` into `develop` on the official repository:
 
     ```
     git checkout develop


### PR DESCRIPTION
- Update `release.md` to follow new 3-tiered branch-based deployments (`develop`, `staging`, and `master`)
- Use double square brackets because they behave a little nicer in bash
- use `DEPLOY_ENV=prod` for prod deploy (it was erroneously set to `staging` previously)

I also created a new `staging` branch in the repo, branched off the current `master` branch. I setup branch protection and a required CircleCi build status check, like we have on `master` and `develop`.

This deployment process change is necessary because CircleCI doesn't work off of tags like Travis does (we used to use a version tag to trigger production releases).