### PR TITLE
restrict CORS to /api/ routes

### DIFF
--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -203,6 +203,8 @@ USE_TZ = True
 
 # django cors headers
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/api/.*$'  # only allow CORS for /api/ routes
+CORS_ALLOW_METHODS = ('GET', 'OPTIONS',)  # only allow read-only methods
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/


### PR DESCRIPTION
and only allow read-only methods (GET and OPTIONS).

Fixes #1583.