### PR TITLE
Add 'Cache-Control: no-cache' for /admin/ routes

### DIFF
--- a/hourglass/middleware.py
+++ b/hourglass/middleware.py
@@ -13,6 +13,9 @@ class ComplianceMiddleware:
     to 200 responses, but not to error responses.
 
     Otherwise, the headers will be added to all responses.
+
+    We also want to ensure that /admin/ routes are never cached, so we'll
+    add appropriate headers for those routes.
     '''
 
     def process_response(self, request, response):
@@ -21,6 +24,9 @@ class ComplianceMiddleware:
 
             response["X-Content-Type-Options"] = "nosniff"
             response["X-XSS-Protection"] = "1; mode=block"
+
+        if request.path.startswith("/admin/"):
+            response["Cache-Control"] = "no-cache"
 
         return response
 

--- a/hourglass/tests/tests.py
+++ b/hourglass/tests/tests.py
@@ -73,6 +73,16 @@ class ComplianceTests(DjangoTestCase):
         self.assertHasHeaders(res)
 
 
+class AdminCacheControlTests(DjangoTestCase):
+    def test_no_cache_on_admin_routes(self):
+        res = self.client.get('/admin/')
+        self.assertEqual(res.get('Cache-Control'), 'no-cache')
+
+    def test_no_cache_control_header_on_non_admin_routes(self):
+        res = self.client.get('/blarg')
+        self.assertEqual(res.get('Cache-Control'), None)
+
+
 @override_settings(SECURE_SSL_REDIRECT=False)
 class HealthcheckTests(DjangoTestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #1590.