### PR TITLE
Upgrade to python 3.6.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.2
+FROM python:3.6.4
 
 ENV PHANTOMJS_VERSION 1.9.7
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -9,7 +9,7 @@ you may want to check out our alternative [Docker instructions](docker.md).
 You'll need the following tools and services installed to run CALC
 locally:
 
-* [Python 3.6.2](https://www.python.org/)
+* [Python 3.6.4](https://www.python.org/)
 * [Node 6.0](https://nodejs.org/)
 * [yarn](https://yarnpkg.com)
   * Install globally via `npm install -g yarn`

--- a/hourglass/tests/test_configuration.py
+++ b/hourglass/tests/test_configuration.py
@@ -20,7 +20,7 @@ class PythonVersionTests(TestCase):
     same Python version.
     '''
 
-    version = Version('3.6.2')
+    version = Version('3.6.4')
 
     def test_runtime_txt(self):
         with open(path('runtime.txt')) as f:

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.2
+python-3.6.4


### PR DESCRIPTION
`3.6.2` is no longer supported on cloud.gov. This upgrades us to the most recent version that is supported.

closes #1628