### PR TITLE
Specify Python at minor version instead of patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.4
+FROM python:3.6
 
 ENV PHANTOMJS_VERSION 1.9.7
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6.4
 
 ENV PHANTOMJS_VERSION 1.9.7
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -9,7 +9,7 @@ you may want to check out our alternative [Docker instructions](docker.md).
 You'll need the following tools and services installed to run CALC
 locally:
 
-* [Python 3.6.4](https://www.python.org/)
+* [Python 3.6](https://www.python.org/)
 * [Node 6.0](https://nodejs.org/)
 * [yarn](https://yarnpkg.com)
   * Install globally via `npm install -g yarn`

--- a/hourglass/tests/test_configuration.py
+++ b/hourglass/tests/test_configuration.py
@@ -31,6 +31,8 @@ class PythonVersionTests(TestCase):
 
     def test_dockerfile(self):
         with open(path('Dockerfile')) as f:
+            # We specify the patch version in our Dockerfile, but this
+            # test will just check down to the minor version level
             self.assertIn(f'FROM python:{self.python_version}', f.read())
 
     def test_circle_yml(self):

--- a/hourglass/tests/test_configuration.py
+++ b/hourglass/tests/test_configuration.py
@@ -20,29 +20,29 @@ class PythonVersionTests(TestCase):
     same Python version.
     '''
 
-    version = Version('3.6.4')
+    # We only need to use down to the minor version specifier.
+    python_version = '3.6'
 
     def test_runtime_txt(self):
         with open(path('runtime.txt')) as f:
-            self.assertEqual(f.read().strip(),
-                             'python-{}'.format(self.version))
+            self.assertEqual(
+                f.read().strip(),
+                f'python-{self.python_version}.x')
 
     def test_dockerfile(self):
         with open(path('Dockerfile')) as f:
-            self.assertIn('FROM python:{}'.format(self.version),
-                          f.read())
+            self.assertIn(f'FROM python:{self.python_version}', f.read())
 
     def test_circle_yml(self):
         with open(path('.circleci/config.yml')) as f:
             data = yaml.safe_load(f)
-            # In CircleCI we can only specify down to the minor number
             self.assertEqual(
                 str(data['jobs']['build']['docker'][0]['image']),
-                f"circleci/python:{self.version.major}.{self.version.minor}")
+                f'circleci/python:{self.python_version}')
 
     def test_docs_setup_md(self):
         with open(path('docs', 'setup.md')) as f:
-            self.assertIn(f'Python {self.version}', f.read())
+            self.assertIn(f'Python {self.python_version}', f.read())
 
 
 class PostgresVersionTests(TestCase):

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.4
+python-3.6.x


### PR DESCRIPTION
Closes #1630. See issue for details.
