### PR TITLE
Use "redis32" for vcap service name

### DIFF
--- a/hourglass/settings_utils.py
+++ b/hourglass/settings_utils.py
@@ -44,7 +44,7 @@ def get_whitelisted_ips(env: Environ=os.environ) -> Optional[List[str]]:
 def load_redis_url_from_vcap_services(name: str,
                                       env: Environ=os.environ) -> None:
     '''
-    Detects if a redis28 service instance with the given name
+    Detects if a redis32 service instance with the given name
     is present in VCAP_SERVICES.
     If it is, then it creates a URL for the instance and sets env['REDIS_URL']
     to that URL. If not, it just returns and does nothing.
@@ -55,7 +55,7 @@ def load_redis_url_from_vcap_services(name: str,
 
     vcap = json.loads(env['VCAP_SERVICES'])
 
-    for entry in vcap.get('redis28', []):
+    for entry in vcap.get('redis32', []):
         if entry['name'] == name:
             creds = entry['credentials']
             url = 'redis://:{password}@{hostname}:{port}'.format(

--- a/hourglass/tests/tests.py
+++ b/hourglass/tests/tests.py
@@ -220,7 +220,7 @@ class RedisUrlTests(unittest.TestCase):
 
     def test_noop_when_name_not_in_vcap(self):
         env = make_vcap_services_env({
-            'redis28': [{
+            'redis32': [{
                 'name': 'a-different-name',
                 'credentials': {
                     'hostname': 'the_host',
@@ -234,7 +234,7 @@ class RedisUrlTests(unittest.TestCase):
 
     def test_redis_url_is_loaded(self):
         env = make_vcap_services_env({
-            'redis28': [{
+            'redis32': [{
                 'name': 'redis-service',
                 'credentials': {
                     'hostname': 'the_host',


### PR DESCRIPTION
Missed this change in #1642. We need to look for a VCAP service with the "redis32" identifier when constructing our `REDIS_URL`. This should fix the currently failing `calc-dev` deployments.