### PR TITLE
Add app-level service bindings in each manifest

### DIFF
--- a/manifests/manifest-dev.yml
+++ b/manifests/manifest-dev.yml
@@ -1,5 +1,5 @@
 ---
-services:
+services: &services
 - calc-db
 - calc-env
 - calc-redis32
@@ -8,6 +8,7 @@ applications:
   instances: 1
   memory: 1G
   disk_quota: 1024M
+  services: *services
   routes:
     - route: calc-dev.app.cloud.gov
   buildpack: python_buildpack
@@ -24,6 +25,7 @@ applications:
   health-check-type: none
   instances: 1
   memory: 512M
+  services: *services
   buildpack: python_buildpack
   command: python manage.py rqworker default
   stack: cflinuxfs2
@@ -33,6 +35,7 @@ applications:
   health-check-type: none
   instances: 1
   memory: 256M
+  services: *services
   buildpack: python_buildpack
   command: python manage.py rqscheduler
   stack: cflinuxfs2

--- a/manifests/manifest-prod.yml
+++ b/manifests/manifest-prod.yml
@@ -1,5 +1,5 @@
 ---
-services:
+services: &services
 - calc-db
 - calc-env
 - calc-redis32
@@ -8,6 +8,7 @@ applications:
   instances: 2
   memory: 1G
   disk_quota: 1024M
+  services: *services
   routes:
     - route: calc.gsa.gov
     - route: calc-prod.app.cloud.gov
@@ -25,6 +26,7 @@ applications:
   health-check-type: none
   instances: 1
   memory: 512M
+  services: *services
   buildpack: python_buildpack
   command: python manage.py rqworker default
   stack: cflinuxfs2
@@ -34,6 +36,7 @@ applications:
   health-check-type: none
   instances: 1
   memory: 512M
+  services: *services
   buildpack: python_buildpack
   command: python manage.py rqscheduler
   stack: cflinuxfs2

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -1,5 +1,5 @@
 ---
-services:
+services: &services
 - calc-db
 - calc-env
 - calc-redis32
@@ -8,6 +8,7 @@ applications:
   instances: 1
   memory: 1G
   disk_quota: 1024M
+  services: *services
   routes:
     - route: calc-staging.app.cloud.gov
   buildpack: python_buildpack
@@ -24,6 +25,7 @@ applications:
   health-check-type: none
   instances: 1
   memory: 512M
+  services: *services
   buildpack: python_buildpack
   command: python manage.py rqworker default
   stack: cflinuxfs2
@@ -33,6 +35,7 @@ applications:
   health-check-type: none
   instances: 1
   memory: 256M
+  services: *services
   buildpack: python_buildpack
   command: python manage.py rqscheduler
   stack: cflinuxfs2


### PR DESCRIPTION
This should make it so our service instances are automatically bound to each Cloud Foundry app in each space.

Previously, service instances were manually bound and would have to be manually re-bound if they were disconnected. This change makes it so the binding is enforced with each deployment.