### PR TITLE
Remove djorm-exp-pgfulltext

### DIFF
--- a/cf.sh
+++ b/cf.sh
@@ -7,8 +7,7 @@ if [ $CF_INSTANCE_INDEX = "0" ]; then
     python manage.py migrate --noinput
 
     echo "----- Updating search field -----"
-    # The '-W ignore is to suppress https://github.com/18F/calc/issues/291.
-    python -W ignore manage.py update_search_field contracts Contract
+    python manage.py update_search_field
 
     echo "----- Initializing Groups -----"
     python manage.py initgroups

--- a/contracts/apps.py
+++ b/contracts/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class DefaultContractsApp(AppConfig):
+    name = 'contracts'
+    verbose_name = 'Contracts'
+
+    def ready(self):
+        from . import signals  # noqa

--- a/contracts/loaders/schedule_70.py
+++ b/contracts/loaders/schedule_70.py
@@ -123,6 +123,4 @@ class Schedule70Loader(object):
             logger.info('updating search field')
             call_command(
                 'update_search_field',
-                cls.model._meta.app_label,
-                cls.model._meta.model_name
             )

--- a/contracts/management/commands/load_data.py
+++ b/contracts/management/commands/load_data.py
@@ -52,7 +52,6 @@ class Command(BaseCommand):
         Contract.objects.bulk_create(contracts)
 
         log.info("Updating search index")
-        call_command('update_search_field',
-                     Contract._meta.app_label, Contract._meta.model_name)
+        call_command('update_search_field')
 
         log.info("End load_data task")

--- a/contracts/management/commands/update_search_field.py
+++ b/contracts/management/commands/update_search_field.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from django.contrib.postgres.search import SearchVector
 
 from contracts.models import Contract
 
@@ -15,5 +14,4 @@ class Command(BaseCommand):
         Contract.objects.bulk_update_normalized_labor_categories()
 
         print("Updating full-text search indexes...")
-        Contract.objects.update(
-            search_index=SearchVector('_normalized_labor_category'))
+        Contract.objects.update_search_index()

--- a/contracts/management/commands/update_search_field.py
+++ b/contracts/management/commands/update_search_field.py
@@ -1,19 +1,19 @@
-from djorm_pgfulltext.management.commands.update_search_field \
-    import Command as UpdateSearchFieldCommand
+from django.core.management.base import BaseCommand
+from django.contrib.postgres.search import SearchVector
 
 from contracts.models import Contract
 
 
-class Command(UpdateSearchFieldCommand):
+class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         '''
-        This just shadows the djorm_pgfulltext command of the same
-        name, modifying it so that we normalize the labor categories
-        before updating the full-text search indexes.
+        This normalizes Contract labor categories
+        and then updates the full-text search indexes.
         '''
 
         print("Updating normalized labor categories...")
         Contract.objects.bulk_update_normalized_labor_categories()
 
         print("Updating full-text search indexes...")
-        super().handle(*args, **kwargs)
+        Contract.objects.update(
+            search_index=SearchVector('_normalized_labor_category'))

--- a/contracts/migrations/0001_initial.py
+++ b/contracts/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import djorm_pgfulltext.fields
+from django.contrib.postgres.search import SearchVectorField
 
 
 class Migration(migrations.Migration):
@@ -41,9 +41,7 @@ class Migration(migrations.Migration):
                     blank=True, max_digits=5, null=True, decimal_places=2)),
                 ('contractor_site', models.CharField(
                     blank=True, max_length=128, null=True)),
-                ('search_index', djorm_pgfulltext.fields.VectorField(
-                    serialize=False, default='', null=True, editable=False,
-                    db_index=True)),
+                ('search_index', SearchVectorField(null=True, db_index=True)),
             ],
             options={
             },

--- a/contracts/migrations/0001_initial.py
+++ b/contracts/migrations/0001_initial.py
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
                     blank=True, max_digits=5, null=True, decimal_places=2)),
                 ('contractor_site', models.CharField(
                     blank=True, max_length=128, null=True)),
-                ('search_index', SearchVectorField(null=True, db_index=True)),
+                ('search_index', SearchVectorField(null=True, db_index=True, editable=False)),
             ],
             options={
             },

--- a/contracts/migrations/0001_initial.py
+++ b/contracts/migrations/0001_initial.py
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
                     blank=True, max_digits=5, null=True, decimal_places=2)),
                 ('contractor_site', models.CharField(
                     blank=True, max_length=128, null=True)),
-                ('search_index', SearchVectorField(null=True, db_index=True, editable=False)),
+                ('search_index', SearchVectorField(default='', db_index=True, editable=False)),
             ],
             options={
             },

--- a/contracts/migrations/0010_auto_20150529_1956.py
+++ b/contracts/migrations/0010_auto_20150529_1956.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import djorm_pgfulltext.fields
 
 
 class Migration(migrations.Migration):
@@ -17,12 +16,6 @@ class Migration(migrations.Migration):
             name='contract_year',
             field=models.DecimalField(
                 null=True, max_digits=1, decimal_places=0, blank=True),
-            preserve_default=True,
-        ),
-        migrations.AlterField(
-            model_name='contract',
-            name='search_index',
-            field=djorm_pgfulltext.fields.VectorField(),
             preserve_default=True,
         ),
     ]

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -283,7 +283,7 @@ class Contract(models.Model):
 
     _normalized_labor_category = models.TextField(db_index=True, blank=True)
 
-    search_index = SearchVectorField(null=True, db_index=True)
+    search_index = SearchVectorField(null=True, db_index=True, editable=False)
 
     upload_source = models.ForeignKey(
         BulkUploadContractSource,

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from django.db import models, connection
 from django.contrib.auth.models import User
 from django.db.models.expressions import Value
-from django.contrib.postgres.search import SearchVectorField
+from django.contrib.postgres.search import SearchVectorField, SearchVector
 
 
 EDUCATION_CHOICES = (
@@ -119,6 +119,10 @@ class CurrentContractManager(models.Manager):
     def search(self, *args, **kwargs):
         return self.get_queryset().search(*args, **kwargs)
 
+    def update_search_index(self):
+        return self.update(
+            search_index=SearchVector('_normalized_labor_category'))
+
     def get_queryset(self):
         return ContractsQuerySet(self.model, using=self._db)\
             .filter(current_price__gt=0)\
@@ -147,6 +151,10 @@ class ContractsQuerySet(models.QuerySet):
 
     def search(self, query):
         return self.filter(search_index=query)
+
+    def update_search_index(self):
+        return self.update(
+            search_index=SearchVector('_normalized_labor_category'))
 
     def order_by(self, *args, **kwargs):
         edu_sort_sql = """

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -294,7 +294,7 @@ class Contract(models.Model):
 
     _normalized_labor_category = models.TextField(db_index=True, blank=True)
 
-    search_index = SearchVectorField(null=True, db_index=True, editable=False)
+    search_index = SearchVectorField(default='', db_index=True, editable=False)
 
     upload_source = models.ForeignKey(
         BulkUploadContractSource,

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -116,6 +116,9 @@ class CurrentContractManager(models.Manager):
     def multi_phrase_search(self, *args, **kwargs):
         return self.get_queryset().multi_phrase_search(*args, **kwargs)
 
+    def search(self, *args, **kwargs):
+        return self.get_queryset().search(*args, **kwargs)
+
     def get_queryset(self):
         return ContractsQuerySet(self.model, using=self._db)\
             .filter(current_price__gt=0)\

--- a/contracts/signals.py
+++ b/contracts/signals.py
@@ -1,0 +1,10 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import Contract
+
+
+@receiver(post_save, sender=Contract)
+def on_contract_save(sender, instance=None, **kwargs):
+    if instance:
+        Contract.objects.filter(pk=instance.id).update_search_index()

--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from decimal import Decimal
 from itertools import cycle
 
+from django.db import connection
 from django.test import TestCase, SimpleTestCase
 from contracts.mommy_recipes import get_contract_recipe
 
@@ -441,3 +442,23 @@ class NormalizedContractSearchTestCase(BaseContractSearchTestCase):
             'Jr. Language Interpreter',
             'Junior Language Interpreter',
         ])
+
+
+class SearchIndexTests(TestCase):
+    GET_SCHEMA_SQL = """
+    SELECT column_name, data_type, column_default, is_nullable
+      FROM information_schema.columns
+      WHERE table_name = 'contracts_contract'
+        AND column_name = 'search_index'
+    """
+
+    def test_schema_is_what_we_expect(self):
+        with connection.cursor() as cursor:
+            cursor.execute(self.GET_SCHEMA_SQL)
+            row = cursor.fetchone()
+            self.assertEqual(row, (
+                'search_index',
+                'tsvector',
+                None,
+                'YES',
+            ))

--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -460,5 +460,5 @@ class SearchIndexTests(TestCase):
                 'search_index',
                 'tsvector',
                 None,
-                'YES',
+                'NO',
             ))

--- a/data_capture/jobs.py
+++ b/data_capture/jobs.py
@@ -47,7 +47,7 @@ def _process_bulk_upload(upload_source):
     contracts_logger.info("Updating full-text search indexes.")
 
     # Update search field on Contract models
-    Contract._fts_manager.update_search_field()
+    Contract.objects.update_search_index()
 
     # Update the upload_source
     upload_source.has_been_loaded = True

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -16,6 +16,9 @@ string), the boolean is true; otherwise, it's false.
 * `DEBUG` is a boolean value that indicates whether debugging is enabled
   (this should always be false in production).
 
+* `DEBUG_LOG_SQL` is a boolean value that indicates whether SQL
+  statements sent to the database should be logged to the console.
+
 * `DEBUG_HTTPS` is a boolean value that indicates whether the
   site should consider itself to be served over HTTPS while
   debugging is enabled. This can be useful if you want to develop

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -129,6 +129,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.humanize',
     'django.contrib.sites',
+    'django.contrib.postgres',
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'debug_toolbar',
@@ -138,7 +139,6 @@ INSTALLED_APPS = (
     'contracts',
     'data_capture.apps.{}'.format(DATA_CAPTURE_APP_CONFIG),
     'api',
-    'djorm_pgfulltext',
     'rest_framework',
     'corsheaders',
     'uaa_client',
@@ -303,6 +303,19 @@ LOGGING = {
         },
     },
 }
+
+DEBUG_LOG_SQL = 'DEBUG_LOG_SQL' in os.environ
+
+if DEBUG_LOG_SQL:
+    LOGGING['handlers']['debug_console'] = {
+        'level': 'DEBUG',
+        'class': 'logging.StreamHandler',
+        'formatter': 'verbose'
+    }
+    LOGGING['loggers']['django.db.backends'] = {
+        'handlers': ['debug_console'],
+        'level': 'DEBUG',
+    }
 
 DATABASES = {}
 DATABASES['default'] = dj_database_url.config()

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -13,7 +13,7 @@ import os
 import dj_database_url
 import dj_email_url
 from dotenv import load_dotenv
-from typing import Tuple  # NOQA
+from typing import Tuple, Any, Dict  # NOQA
 
 from .settings_utils import (load_cups_from_vcap_services,
                              load_redis_url_from_vcap_services,
@@ -236,7 +236,7 @@ REST_FRAMEWORK = {
     ),
 }
 
-LOGGING = {
+LOGGING: Dict[str, Any] = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -136,7 +136,7 @@ INSTALLED_APPS = (
     'django_rq',
 
     'data_explorer',
-    'contracts',
+    'contracts.apps.DefaultContractsApp',
     'data_capture.apps.{}'.format(DATA_CAPTURE_APP_CONFIG),
     'api',
     'rest_framework',

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Django==1.11.11
 django-cors-headers==2.0.2
 django-debug-toolbar==1.6
 djangorestframework==3.5.3
-git+git://github.com/18F/djorm-ext-pgfulltext@7ce6606dcb2c4fdd235439b6adcadeb143974a62
 gunicorn==19.6.0
 newrelic==2.78.0.57
 psycopg2==2.6.2

--- a/update.sh
+++ b/update.sh
@@ -12,8 +12,7 @@ echo "----- Migrating Database -----"
 python manage.py migrate --noinput
 
 echo "----- Updating search field -----"
-# The '-W ignore is to suppress https://github.com/18F/calc/issues/291.
-python -W ignore manage.py update_search_field contracts Contract
+python manage.py update_search_field
 
 echo "----- Initializing Groups -----"
 python manage.py initgroups


### PR DESCRIPTION
This fixes #1645.

Implementing the fix involved some reading of [`djorm_pgfulltext`'s source code](https://github.com/18F/djorm-ext-pgfulltext/), as well as of [`django.contrib.postgres.search`](https://docs.djangoproject.com/en/2.0/_modules/django/contrib/postgres/search/).  A few things djorm-ext-pgfulltext made easy aren't supported out-of-the-box by Django's full-text-search, so I had to implement a solution.

## Notes

* `manage.py update_search_field` no longer delegates to a `djorm_pgfulltext` command.  It was easier to just hard-code the auto-updating of the `Contracts` model, so I removed the `<app-name> <model-name>` arguments to the command.

* Doing this work required examining the underlying SQL Django was sending to the database.  Hacking this into `settings.py` was cumbersome, so I added a boolean environment variable called `DEBUG_LOG_SQL` that can be used to toggle it, which should make future debugging easier too.

* Django's [`SearchQuery`](https://docs.djangoproject.com/en/2.0/ref/contrib/postgres/search/#searchquery) full-text search queries only translate to SQL as [`plainto_tsquery`](https://www.postgresql.org/docs/8.3/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES), whereas our search code has always been using `to_tsquery`.  As far as I can tell, `plainto_tsquery` doesn't let us specify to search for words that are _prefixes_ of labor category names.  For instance, searching for `eng` via a `plainto_tsquery` will only find results like "senior eng", but not "senior engineer".  So I had to implement a [custom `Value` subclass](https://docs.djangoproject.com/en/2.0/ref/models/expressions/#value-expressions) that used `to_tsquery` instead.

* There's no easy built-in way to tell Django to auto-update [`SearchVectorField`](https://docs.djangoproject.com/en/2.0/ref/contrib/postgres/search/#searchvectorfield)s on model save (in contrast, djorm-ext-pgfulltext did this kind of thing automatically for us).  In fact, Django's documentation tells us to just install a postgres trigger, which is kind of annoying, since we're not really creating new models very often for that to be a necessity.  Anyways, I dug into how djorm-ext-pgfulltext did things, which was via a post-save signal, and replicated the strategy in our own code.

* I made modifications to the initial migration of the `Contracts` model instead of adding a custom migration; this is because the initial migration included an import of `djorm_pgfulltext`, which I had to remove in order to decouple us from that package. And it's OK that I did this, because the underlying postgres database field remains unchanged: it's still just a `tsvector` under-the-hood.
