### PR TITLE
Ensure sphinx docs build on Windows without errors, and rebuild docs when changelog changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ release-*-instructions.txt
 release-*-instructions.html
 jest/*
 Dockerfile.cloud
+docs/changelog.md
 docs/_build
 docs/static
 data_capture_uploaded_files/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,6 +8,7 @@ SPHINXPROJ    = CALC
 SOURCEDIR     = .
 BUILDDIR      = _build
 DJANGODIR     = static
+ROOTDIR       = ..
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -23,6 +24,8 @@ html: Makefile
 # it's easier for now (especially since our docs build really fast) to
 # wipe out the build directory between rebuilds.
 	rm -rf $(BUILDDIR)
+
+	cp $(ROOTDIR)/CHANGELOG.md $(SOURCEDIR)/changelog.md
 
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,1 +1,0 @@
-../CHANGELOG.md

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,7 @@ const dirs = {
     style: 'frontend/source/sass/',
     scripts: 'frontend/source/js/',
     sphinx: 'docs/',
+    root: './',
   },
   dest: {
     style: {
@@ -46,6 +47,7 @@ const paths = {
   sass: '**/*.scss',
   js: '**/*.@(js|jsx)',
   sphinx: '*.@(md|py|rst)',
+  changelog: 'CHANGELOG.md',
 };
 
 const bundles = {
@@ -120,7 +122,10 @@ gulp.task('build', ['sass', 'js', 'sphinx']);
 
 // watch files for changes
 gulp.task('watch', ['set-watching', 'sass', 'js', 'sphinx'], () => {
-  gulp.watch(path.join(dirs.src.sphinx, paths.sphinx), ['sphinx']);
+  gulp.watch([
+    path.join(dirs.src.sphinx, paths.sphinx),
+    path.join(dirs.src.root, paths.changelog),
+  ], ['sphinx']);
   gulp.watch(path.join(dirs.src.style, paths.sass), ['sass']);
 
   if (!('ESLINT_CHILL_OUT' in process.env)) {


### PR DESCRIPTION
Right now our `docs` directory contains `changelog.md`, which is a symlink to the changelog in our repo's root directory.  However, symlinks aren't easily supported across current versions of Windows, which means the docs build, but not with the changelog in them (and with loads of annoying error output complaining about it).

This fixes things so that the changelog gets copied over to the `docs` directory at build time.  It also watches the changelog in the root directory, so that if that changes, the Sphinx docs are rebuilt (I don't think the watch logic accounts for this).
