### PR TITLE
Add `type="button"` to ProposedPrice's "Go" button

### DIFF
--- a/frontend/source/js/data-explorer/components/proposed-price.jsx
+++ b/frontend/source/js/data-explorer/components/proposed-price.jsx
@@ -4,18 +4,14 @@ import { connect } from 'react-redux';
 import { setProposedPrice } from '../actions';
 
 export class ProposedPrice extends React.Component {
-  static handleGoClick(e) {
-    // Don't do anything for now; the legacy front-end caused the
-    // proposed price to be displayed on this histogram when this was
-    // clicked, but since we do that on a per-keystroke basis, there's
-    // no need to do it here. At the same time, though, we're concerned
-    // that removing the "Go" button could make things even more confusing
-    // than they already are, so for now we'll do a no-op.
-    //
-    // Note also that we *do* need to prevent the default behavior here, or
-    // else the form will be submitted.
-    e.preventDefault();
-  }
+  // Note that the 'Go' button in this component does not
+  // actually do anything.
+  // In the legacy Data Explorer code, clicking the Go button
+  // would show the proposed price on the histogram, but we now
+  // do that on a per-keystroke basis.
+  // We were concerned that removing the 'Go' button could make
+  // things even more confusing than they already are, so for now
+  // we'll do a no-op.
 
   constructor(props) {
     super(props);
@@ -84,8 +80,8 @@ export class ProposedPrice extends React.Component {
           onChange={this.handleChange}
         />
         <button
+          type="button"
           className="button-primary go"
-          onClick={ProposedPrice.handleGoClick}
         >Go</button>
       </div>
     );

--- a/frontend/source/js/data-explorer/tests/__snapshots__/proposed-price.test.jsx.snap
+++ b/frontend/source/js/data-explorer/tests/__snapshots__/proposed-price.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`<ProposedPrice> matches snapshot 1`] = `
   />
   <button
     className="button-primary go"
-    onClick={[Function]}
+    type="button"
   >
     Go
   </button>

--- a/hourglass/settings_utils.py
+++ b/hourglass/settings_utils.py
@@ -77,7 +77,7 @@ def is_running_tests(argv: List[str]=sys.argv) -> bool:
 
     if basename == 'manage.py' and first_arg == 'test':
         return True
-    if basename == 'py.test':
+    if basename == 'py.test' or basename == 'pytest':
         return True
 
     return False


### PR DESCRIPTION
Using `type="button"` obviates the need to call `e.preventDefault()` on that button's click handler.

Also make a slight unrelated modification to `is_running_tests()` to return `True` when `py.test` is called as `pytest` (no period).

Closes #1515