### PR TITLE
Use TypeScript's checkJs functionality on whitelisted files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
       - run:
           name: Run linters and static analysis
           command: |
-            python manage.py ultratest flake8 eslint mypy bandit
+            python manage.py ultratest flake8 eslint mypy bandit typescript
       - run:
           name: Build front end and run front end tests
           command: |

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,6 @@ htmlcov/
 vendor/
 
 frontend/static/frontend/built/
+
+# TypeScript checks these files, so ignore them.
+frontend/source/js/common/dap-hacks.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,3 @@ vendor/
 coverage/
 
 frontend/static/frontend/built/
-
-# TypeScript checks these files, so ignore them.
-frontend/source/js/common/dap-hacks.js

--- a/frontend/source/js/common/dap-hacks.d.ts
+++ b/frontend/source/js/common/dap-hacks.d.ts
@@ -1,0 +1,10 @@
+interface Window {
+  /**
+   * This is a private function used by the DAP script. It
+   * happens to be attached to the global `window` object,
+   * which allows us to call it.
+   * 
+   * Yes, this is horrible.
+   */
+  _initAutoTracker: Function|undefined
+}

--- a/frontend/source/js/common/dap-hacks.js
+++ b/frontend/source/js/common/dap-hacks.js
@@ -2,13 +2,19 @@
 
 export const IS_SUPPORTED = 'MutationObserver' in window;
 
-const DEFAULT_INIT_AUTO_TRACKER_NAME = '_initAutoTracker';
-
 /**
  * Here we notify DAP about new links we've added to the page, so that
  * it can auto-track them. For more background, see:
  *
  *   https://github.com/digital-analytics-program/gov-wide-code/pull/47
+ */
+
+/**
+ * This returns all the <a> elements in a NodeList. It also searches
+ * through the descendants of nodes in the list and returns them.
+ * 
+ * @param {NodeList} list The list of nodes to filter/descend through.
+ * @return {HTMLAnchorElement[]} The <a> elements in the list.
  */
 
 export function findLinksInNodeList(list) {
@@ -17,10 +23,8 @@ export function findLinksInNodeList(list) {
   for (let i = 0; i < list.length; i++) {
     const node = list[i];
 
-    if (node.nodeType === node.ELEMENT_NODE) {
-      const nodeName = node.nodeName && node.nodeName.toLowerCase();
-
-      if (nodeName === 'a') {
+    if (node instanceof HTMLElement) {
+      if (node instanceof HTMLAnchorElement) {
         links.push(node);
       } else {
         const innerLinks = node.querySelectorAll('a');
@@ -47,11 +51,18 @@ export function findLinksInNodeList(list) {
  * see:
  *
  *   https://github.com/digital-analytics-program/gov-wide-code/pull/48
+ * 
+ * @param initAutoTracker {Function} A function that initializes DAP's
+ *   auto-tracker, using `getElementsByTagName('a')` to return all the
+ *   links on a page.
+ * @param links {HTMLElement[]} The list of links which
+ *   `getElementsByTagName()` will temporarily be monkeypatched to return.
  */
 
 export function hackilyNotifyAutoTrackerOfNewLinks(initAutoTracker, links) {
   const oldGet = window.document.getElementsByTagName;
 
+  // @ts-ignore   TypeScript, please forgive us for doing this.
   window.document.getElementsByTagName = () => links;
 
   try {
@@ -61,11 +72,22 @@ export function hackilyNotifyAutoTrackerOfNewLinks(initAutoTracker, links) {
   }
 }
 
+/**
+ * This function observes the document for mutations; whenever new links
+ * are added, it lets DAP know about them, so that their clicks can
+ * be tracked.
+ * 
+ * @param {HTMLElement} parentEl The parent element to observe. Defaults
+ *   to the topmost <html> element.
+ * @param {Function} getInitAutoTracker A function that returns either DAP's
+ *   private `_initAutoTracker` function, or `undefined` if DAP hasn't
+ *   been loaded.
+ */
 export function observe(
   parentEl = window.document.documentElement,
-  getInitAutoTracker = () => window[DEFAULT_INIT_AUTO_TRACKER_NAME],
+  getInitAutoTracker = () => window._initAutoTracker,
 ) {
-  const observer = new window.MutationObserver((mutations) => {
+  const observer = new MutationObserver((mutations) => {
     const initAutoTracker = getInitAutoTracker();
 
     if (window.document.readyState === 'loading' ||

--- a/frontend/source/js/common/dap-hacks.js
+++ b/frontend/source/js/common/dap-hacks.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global window */
+/* eslint-env browser */
 
 export const IS_SUPPORTED = 'MutationObserver' in window;
 
@@ -13,7 +13,7 @@ export const IS_SUPPORTED = 'MutationObserver' in window;
 /**
  * This returns all the <a> elements in a NodeList. It also searches
  * through the descendants of nodes in the list and returns them.
- * 
+ *
  * @param {NodeList} list The list of nodes to filter/descend through.
  * @return {HTMLAnchorElement[]} The <a> elements in the list.
  */
@@ -52,7 +52,7 @@ export function findLinksInNodeList(list) {
  * see:
  *
  *   https://github.com/digital-analytics-program/gov-wide-code/pull/48
- * 
+ *
  * @param initAutoTracker {Function} A function that initializes DAP's
  *   auto-tracker, using `getElementsByTagName('a')` to return all the
  *   links on a page.
@@ -77,7 +77,7 @@ export function hackilyNotifyAutoTrackerOfNewLinks(initAutoTracker, links) {
  * This function observes the document for mutations; whenever new links
  * are added, it lets DAP know about them, so that their clicks can
  * be tracked.
- * 
+ *
  * @param {HTMLElement} parentEl The parent element to observe. Defaults
  *   to the topmost <html> element.
  * @param {Function} getInitAutoTracker A function that returns either DAP's
@@ -86,7 +86,7 @@ export function hackilyNotifyAutoTrackerOfNewLinks(initAutoTracker, links) {
  */
 export function observe(
   parentEl = window.document.documentElement,
-  getInitAutoTracker = () => window._initAutoTracker,
+  getInitAutoTracker = () => window._initAutoTracker, // eslint-disable-line no-underscore-dangle
 ) {
   const observer = new MutationObserver((mutations) => {
     const initAutoTracker = getInitAutoTracker();

--- a/frontend/source/js/common/dap-hacks.js
+++ b/frontend/source/js/common/dap-hacks.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global window */
 
 export const IS_SUPPORTED = 'MutationObserver' in window;

--- a/frontend/source/js/common/usermenu.js
+++ b/frontend/source/js/common/usermenu.js
@@ -10,14 +10,14 @@ function enableUsermenu() {
     return;
   }
 
-  trigger.setAttribute('aria-haspopup', true);
-  trigger.setAttribute('aria-expanded', false);
+  trigger.setAttribute('aria-haspopup', true.toString());
+  trigger.setAttribute('aria-expanded', false.toString());
   trigger.setAttribute('aria-label', openLabel);
 
   trigger.addEventListener('click', (e) => {
     menu.classList.toggle('is-open');
     const isOpen = menu.classList.contains('is-open');
-    trigger.setAttribute('aria-expanded', isOpen);
+    trigger.setAttribute('aria-expanded', isOpen.toString());
     trigger.setAttribute('aria-label', isOpen ? closeLabel : openLabel);
     e.preventDefault();
   });

--- a/frontend/source/js/common/usermenu.js
+++ b/frontend/source/js/common/usermenu.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global document */
 
 function enableUsermenu() {

--- a/meta/management/commands/ultratest.py
+++ b/meta/management/commands/ultratest.py
@@ -107,6 +107,7 @@ TESTTYPES = [
     TestType(name='eslint', cmd='npm run failable-eslint'),
     TestType(name='bandit', cmd='bandit -r .'),
     TestType(name='mypy', cmd='mypy @mypy-files.txt'),
+    TestType(name='typescript', cmd='npm run typescript'),
     TestType(name='jest', cmd='npm test'),
     TestType(name='py.test',
              cmd='py.test --cov-report xml --cov-report term --cov'),

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^2.7.4",
     "sinon": "2.1.0",
+    "typescript": "^2.7.2",
     "vinyl-named": "^1.1.0",
     "webpack": "^2.2.1",
     "webpack-stream": "^3.2.0",
@@ -60,6 +61,7 @@
     "gulp": "gulp",
     "eslint": "eslint --ext .jsx --ext .js . || true",
     "failable-eslint": "eslint --max-warnings 0 --ext .jsx --ext .js .",
+    "typescript": "tsc",
     "test": "jest",
     "test:watch": "npm test -- --watch"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true,
+    "checkJs": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "preserveConstEnums": true,
+  },
+  "include": [
+    "frontend/source/js/common/usermenu.js",
+    "frontend/source/js/common/dap-hacks.js",
+    "frontend/source/js/common/dap-hacks.d.ts",
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "allowJs": true,
     "noEmit": true,
-    "checkJs": true,
     "strict": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
@@ -10,8 +9,6 @@
     "preserveConstEnums": true,
   },
   "include": [
-    "frontend/source/js/common/usermenu.js",
-    "frontend/source/js/common/dap-hacks.js",
-    "frontend/source/js/common/dap-hacks.d.ts",
+    "frontend/source/js/**/*.js"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6438,6 +6438,10 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+
 ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"


### PR DESCRIPTION
This is an attempt to fix #1527 by using [TypeScript's `--checkJs` mode](https://github.com/Microsoft/TypeScript/wiki/Type-Checking-JavaScript-Files), which allows us to type-check JS files without needing to integrate TypeScript into our static asset build pipeline (to strip out type information).  It's basically a much more powerful alternative to eslint (well except for the part of eslint that overlaps with prettier).

There are reasons this could be a bad idea, though, so feel free to criticize and close this PR unmerged.

Right now we just type-check two JS files, `dap-hacks.js` and `usermenu.js`.

## Notes

* Use of TypeScript's `--checkJs` mode doesn't prohibit us from actually using "real" TypeScript in the future. I just thought this might be a quick, easy way to dip our toes into TypeScript.

* The original `dap-hacks.js` had a few workarounds to make eslint happy with it.  But because eslint and TypeScript are doing similar things, and because both linters really have different methods of appeasement for the weird things `dap-hacks.js` does, I've just forcibly told eslint to ignore this file for now. It's not a great solution but meh.

* A new file, `dap-hacks.d.ts` has been added. The `.d.ts` extension means it's a **TypeScript Declaration File** that just adds type annotations for pre-existing third-party code.  In this case, it's adding type annotations for the DAP script.  I don't think we should have to normally add `.d.ts` files to our repo, the DAP hacks script is just a really weird edge case.

## Notes about doing this with Visual Studio Code

* Not only are the JSDoc comments we add to our files parsed by TypeScript and used as type annotations, but their actual documentation shows up in tooltips in VS Code, which is nice:

    > ![2018-03-26_17-42-59](https://user-images.githubusercontent.com/124687/37934750-363be7a0-311d-11e8-9ec3-e804d86befb8.png)

* One kind of cool thing about VS Code's TypeScript (or perhaps just its built-in JS) add-on is that, if you have an existing function and start writing a comment above it, as long as you start the comment with `/**`, VS Code will automatically parse the function's declaration and include JSDoc comments for all the parameters.  This made adding JSDoc docs to the functions pretty easy!
