### PR TITLE
Add 'coverage' dir to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,5 +3,6 @@
 /static/
 htmlcov/
 vendor/
+coverage/
 
 frontend/static/frontend/built/


### PR DESCRIPTION
When running `eslint` I noticed it started spewing all kinds of errors about files in the `coverage` directory, which I think was added in #1653 when we enabled jest coverage reporting.  So this adds that directory to our `.estlintignore`.
