### PR TITLE
Upgrade `dj-email-url` for easy TLS email connections

### DIFF
--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -73,6 +73,9 @@ DEFAULT_FROM_EMAIL = os.environ['DEFAULT_FROM_EMAIL']
 SERVER_EMAIL = os.environ['SERVER_EMAIL']
 HELP_EMAIL = os.environ.get('HELP_EMAIL', DEFAULT_FROM_EMAIL)
 
+# Use a secure TLS connection for SMTP email sending
+EMAIL_USE_TLS = True
+
 API_HOST = os.environ.get('API_HOST', '/api/')
 
 GA_TRACKING_ID = os.environ.get('GA_TRACKING_ID', '')

--- a/hourglass/settings.py
+++ b/hourglass/settings.py
@@ -73,9 +73,6 @@ DEFAULT_FROM_EMAIL = os.environ['DEFAULT_FROM_EMAIL']
 SERVER_EMAIL = os.environ['SERVER_EMAIL']
 HELP_EMAIL = os.environ.get('HELP_EMAIL', DEFAULT_FROM_EMAIL)
 
-# Use a secure TLS connection for SMTP email sending
-EMAIL_USE_TLS = True
-
 API_HOST = os.environ.get('API_HOST', '/api/')
 
 GA_TRACKING_ID = os.environ.get('GA_TRACKING_ID', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Production dependencies
 dj-database-url==0.4.2
-dj-email-url==0.0.10
+dj-email-url==0.1.0
 django-click==1.2.0
 Django==1.11.11
 django-cors-headers==2.0.2


### PR DESCRIPTION
`dj-email-url` v0.1.0 [(changelog)](https://github.com/migonzalvar/dj-email-url#010---2018-03-24) automatically sets `EMAIL_USE_TLS` setting when using the `submission:` "protocol" in the email connection string. This setting is required for `STARTTLS`, which is what we need for use with Amazon SES.