### PR TITLE
Use `yarn` instead of `npm run` everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,9 @@ jobs:
           name: Display versions
           command: |
             echo $(node --version)
+            echo $(npm --version)
             echo $(yarn --version)
             echo $(phantomjs --version)
-            echo $(npm --version)
             echo $(pwd)
       - run:
           name: Run linters and static analysis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ integration, such as [linter-pep8](https://atom.io/packages/linter-pep8) for Ato
 For front end JavaScript, we use [eslint][] to lint our source files.
 We recommend using an editor plugin (such as [linter-eslint][] for Atom)
 to automatically lint JavaScript files. If you do not wish to use an editor plugin,
-you can run `npm run eslint` from the command line.
+you can run `yarn eslint` from the command line.
 
 CALC also provides a custom Django management command to run all linters and unit tests:
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -24,7 +24,7 @@ pipeline.
 If you just want to build the assets once without watching for changes, run:
 
 ```sh
-npm run gulp -- build
+yarn gulp build
 ```
 
 ## Developing the front end
@@ -32,10 +32,10 @@ npm run gulp -- build
 Different parts of CALC are constructed in different ways, so
 developing the front end depends on which part you want to change.
 
-We use [yarn][] to manage our node dependencies. `yarn`, in addition to being
-faster than using `npm install`, has the benefit of locking dependency
-versions via a `yarn.lock` file. Read the [yarn workflow docs][] if you are not
-familiar with how to use it.
+We use [yarn][] to manage our node dependencies and run node tasks.
+`yarn`, in addition to being faster than using `npm install`, has the
+benefit of locking dependency versions via a `yarn.lock` file.
+Read the [yarn workflow docs][] if you are not familiar with how to use it.
 
 ### Data explorer
 
@@ -49,19 +49,19 @@ The explorer's test suite uses [Jest][], and the tests are located in
 To run all the tests, run:
 
 ```
-npm run test
+yarn test
 ```
 
 You can also run the tests in a continuous "watch" mode, which re-runs
 tests as you change your code:
 
 ```
-npm run test:watch
+yarn test:watch
 ```
 
 Finally, you can also run `jest` directly. If you're using Docker,
 this can be done via `docker-compose run app jest`; otherwise you can
-use `npm run test --`, followed by any
+use `yarn test`, followed by any
 [Jest CLI options](https://facebook.github.io/jest/docs/cli.html).
 
 ### Data capture

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -13,7 +13,7 @@ locally:
   * If not using the [Docker-based development workflow](docker.md), make sure your system `python` command runs Python 3. You can check this by running `python --version`.
 * [Node 6.0](https://nodejs.org/)
 * [yarn](https://yarnpkg.com)
-  * Install globally via `npm install -g yarn`
+  * Install globally via `npm install -g yarn` or via another method described at [https://yarnpkg.com/lang/en/docs/install/](https://yarnpkg.com/lang/en/docs/install/).
 * [Postgres 9.5](https://www.postgresql.org/)
   * It's easiest to have a local instance of it running on its default
     port, as this requires no extra configuration on the CALC side.
@@ -87,7 +87,7 @@ In another terminal, you will also need to run `gulp` to watch and rebuild
 static assets:
 
 ```sh
-npm run gulp
+yarn gulp
 ```
 
 ### Starting the task runner

--- a/frontend/tests/utils.py
+++ b/frontend/tests/utils.py
@@ -14,5 +14,5 @@ def build_static_assets():
     global _static_assets_built
 
     if not _static_assets_built:
-        subprocess.check_call(['npm', 'run', 'gulp', '--', 'build'])
+        subprocess.check_call(['yarn', 'gulp', 'build'])
         _static_assets_built = True

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,7 +128,7 @@ gulp.task('sphinx', (cb) => {
 
 // production build task
 // will need to run before collectstatic
-// `npm run gulp -- build` or `gulp run build` if gulp-cli is installed globally
+// `yarn gulp build` or `gulp run build` if gulp-cli is installed globally
 gulp.task('build', ['sass', 'js', 'sphinx']);
 
 // watch files for changes

--- a/meta/management/commands/ultratest.py
+++ b/meta/management/commands/ultratest.py
@@ -104,11 +104,11 @@ TestType = namedtuple('TestType', ['name', 'cmd'])
 
 TESTTYPES = [
     TestType(name='flake8', cmd='flake8 --exclude=node_modules,migrations .'),
-    TestType(name='eslint', cmd='npm run failable-eslint'),
+    TestType(name='eslint', cmd='yarn failable-eslint'),
     TestType(name='bandit', cmd='bandit -r .'),
     TestType(name='mypy', cmd='mypy @mypy-files.txt'),
-    TestType(name='typescript', cmd='npm run typescript'),
-    TestType(name='jest', cmd='npm test'),
+    TestType(name='typescript', cmd='yarn typescript'),
+    TestType(name='jest', cmd='yarn test'),
     TestType(name='py.test',
              cmd='py.test --cov-report xml --cov-report term --cov'),
 ]

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "failable-eslint": "eslint --max-warnings 0 --ext .jsx --ext .js .",
     "typescript": "tsc",
     "test": "jest",
-    "test:watch": "npm test -- --watch"
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We switched to `yarn` a while back but didn't update various docs and tooling to use it in place of `npm` or `npm run`.

Closes #1541.