### PR TITLE
Remove hardcoded border radius 

### DIFF
--- a/frontend/source/sass/admin/changelists.scss
+++ b/frontend/source/sass/admin/changelists.scss
@@ -13,7 +13,7 @@ th.action-checkbox-column {
 
 .filter-block {
   background: #f1f1f1;
-  border-radius: 4px;
+  border-radius: $border-radius;
   margin-bottom: 0;
   padding: 1rem 2rem;
   h2,

--- a/frontend/source/sass/admin/overrides.scss
+++ b/frontend/source/sass/admin/overrides.scss
@@ -242,7 +242,7 @@ thead a:focus {
 /* same as filter-block in changelists.css */
 .sidebar {
   background: $color-gray-lightest;
-  border-radius: 4px;
+  border-radius: $border-radius;
   margin-bottom: 0;
   padding: 1rem 2rem;
   h2,

--- a/frontend/source/sass/components/_buttons.scss
+++ b/frontend/source/sass/components/_buttons.scss
@@ -33,7 +33,7 @@ button,
   }
   &.button-footer {
     background-color: $color-white;
-    border-radius: 4px;
+    border-radius: $border-radius;
     color: $color-gray-medium-dark;
 
     &:hover,

--- a/frontend/source/sass/components/_labels.scss
+++ b/frontend/source/sass/components/_labels.scss
@@ -8,7 +8,7 @@
   font-weight: normal;
   padding: $space-1x;
   text-transform: uppercase;
-  border-radius: 4px;
+  border-radius: $border-radius;
   background-color: $color-gray-lightest;
   color: $color-gray;
   &:before {

--- a/frontend/source/sass/components/_tables.scss
+++ b/frontend/source/sass/components/_tables.scss
@@ -180,7 +180,7 @@ td.error {
         bottom: 95%;
         left: 0;
         background-color: $color-secondary-lightest;
-        border-radius: 4px;
+        border-radius: $border-radius;
       }
     }
   }
@@ -204,7 +204,7 @@ td.error {
         bottom: 95%;
         left: 0;
         background-color: $color-secondary-lightest;
-        border-radius: 4px;
+        border-radius: $border-radius;
       }
     }
   }

--- a/frontend/source/sass/components/_usermenu.scss
+++ b/frontend/source/sass/components/_usermenu.scss
@@ -17,7 +17,7 @@ $usermenu-width: 150px;
     font-size: $medium-font-size;
     font-weight: $font-weight-bold;
     background: $color-gray-lightest;
-    border-radius: 4px;
+    border-radius: $border-radius;
     list-style: none;
     padding: $space-2x $space-3x;
 


### PR DESCRIPTION
There were a bunch of `4px` border radius settings that were hardcoded because our `$border-radius` variable used to be zero. This fixes 'em. 

Closes #1426.