### PR TITLE
Sort autocomplete suggestions by length.

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -306,6 +306,8 @@ class GetAutocomplete(APIView):
                  'count': d['count']}
                 for d in data
             ]
+
+            data.sort(key=lambda d: len(d['labor_category']))
             return Response(data)
         else:
             return Response([])


### PR DESCRIPTION
**Note: this is a PR into #1454, not `develop`.**

This is a quick enhancement to #1454 that sorts autocomplete entries according to the length of the suggestion, rather than the number of rows it matches against in the database.  This is because @tram noticed that the new autocomplete behavior automatically chooses the very first suggestion when users press <kbd>Enter</kbd> in autocomplete, rather than the current `develop` branch behavior of submitting whatever the user has typed.  (See also https://github.com/18F/calc/pull/1454#issuecomment-378395834.)

In other words: in the current `develop` branch, if a user types "engineer", the first autocomplete suggestion is "senior engineer" (because that has the most matches in the database).  However, if the user presses <kbd>Enter</kbd>, CALC peforms a search for `Engineer` (i.e., what the user typed), not `senior engineer`.   In #1454, however, it would cause the opposite, which is unexpected.  By sorting the suggestions by length, we restore the expected behavior (though the user can no longer easily see which suggestions have the most results, unfortunately).

## To do

- [ ] Fix broken tests
