### PR TITLE
[WIP] Replace .card classes with body classes

### DIFF
--- a/data_capture/templates/data_capture/price_list/step_2.html
+++ b/data_capture/templates/data_capture/price_list/step_2.html
@@ -1,6 +1,6 @@
 {% extends 'data_capture/step.html' %}
 {% load frontend %}
-{% block body_class %}secondary-step card--narrow{% endblock %}
+{% block card_class %}secondary-step card--narrow{% endblock %}
 {% block subtitle %}Enter vendor details{% endblock %}
 
 {% block step_heading %}<h2>Enter details for this price list</h2>

--- a/data_capture/templates/data_capture/price_list/step_3.html
+++ b/data_capture/templates/data_capture/price_list/step_3.html
@@ -1,6 +1,6 @@
 {% extends 'data_capture/step.html' %}
 
-{% block body_class %}secondary-step card--narrow card--no-header{% endblock %}
+{% block card_class %}secondary-step card--narrow card--no-header{% endblock %}
 
 {% block subtitle %}Upload price list{% endblock %}
 {% block step_heading %}

--- a/data_capture/templates/data_capture/price_list/step_3_errors.html
+++ b/data_capture/templates/data_capture/price_list/step_3_errors.html
@@ -1,6 +1,6 @@
 {% extends 'data_capture/step.html' %}
 
-{% block body_class %}secondary-step card--wide card--no-header{% endblock %}
+{% block card_class %}secondary-step card--wide card--no-header{% endblock %}
 
 {% block subtitle %}Errors in price list upload{% endblock %}
 {% block step_heading %}<h2>Review errors</h2>{% endblock %}

--- a/data_capture/templates/data_capture/price_list/step_4.html
+++ b/data_capture/templates/data_capture/price_list/step_4.html
@@ -1,6 +1,6 @@
 {% extends 'data_capture/step.html' %}
 
-{% block body_class %}secondary-step card--wide{% endblock %}
+{% block card_class %}secondary-step card--wide{% endblock %}
 {% block subtitle %}Verify data{% endblock %}
 
 {% block step_heading %}

--- a/data_capture/templates/data_capture/price_list/step_5.html
+++ b/data_capture/templates/data_capture/price_list/step_5.html
@@ -1,5 +1,5 @@
 {% extends 'data_capture/step.html' %}
-{% block body_class %}secondary-step card--narrow card--no-header{% endblock %}
+{% block card_class %}secondary-step card--narrow card--no-header{% endblock %}
 {% block subtitle %}Data submitted for review!{% endblock%}
 {% block step_heading %}<h2>Price list submitted!</h2>{% endblock %}
 

--- a/data_capture/templates/data_capture/replace_price_list/replace_step.html
+++ b/data_capture/templates/data_capture/replace_price_list/replace_step.html
@@ -2,7 +2,7 @@
 
 {% block title %}Replace Price List / {{ step.description|capfirst }}: {% block subtitle %}{% endblock %}{% endblock %}
 
-{% block body_class %}secondary-step {% block card_width_class %}card--wide{% endblock %} card--no-header card--half-padding{% endblock %}
+{% block card_class %}secondary-step {% block card_width_class %}card--wide{% endblock %} card--no-header card--half-padding{% endblock %}
 
 
 {% block steps %}

--- a/data_capture/templates/data_capture/step.html
+++ b/data_capture/templates/data_capture/step.html
@@ -4,7 +4,7 @@
 {% block title %}Add price data to CALC / {{ step.description|capfirst }}: {% block subtitle %}{% endblock %}{% endblock %}
 
 {% block body %}
-  <div class="container {% block body_class %}card--narrow{% endblock %}">
+  <div class="container {% block card_class%}card--narrow{% endblock %}">
     <div class="row">
       <div class="card">
         <div class="card__content">

--- a/data_explorer/templates/base.html
+++ b/data_explorer/templates/base.html
@@ -44,20 +44,24 @@
     {% block head %}
     {% endblock %}
   </head>
-  <body>
+  <body class="{% block body_class %}content--wide{% endblock %}">
     {% include '_banner.html' %}
     <header>
       <div class="container">
-      {% include '_header.html' %}
-      {# Extended header should be placed in this block in descendant templates #}
-      {% block header_extension %}{% endblock %}
-      {% include '_nav.html' %}
+        <div class="content">
+        {% include '_header.html' %}
+        {# Extended header should be placed in this block in descendant templates #}
+        {% block header_extension %}{% endblock %}
+        {% include '_nav.html' %}
+        </div>
       </div>
     </header>
 
     <main id="main">
-    {% block body %}
-    {% endblock %}
+      <div class="container">
+      {% block body %}
+      {% endblock %}
+      </div>
     </main>
 
     {% block modals %}{% endblock modals %}

--- a/data_explorer/templates/index.html
+++ b/data_explorer/templates/index.html
@@ -33,8 +33,8 @@
 {% endblock header_extension %}
 
 {% block body %}
-<div data-embed-jsx-app-here class="card--narrow"> <!--change to card--wide-->
-  <div class="card">
+<div data-embed-jsx-app-here class="card">
+  <div class="content">
     <noscript>
       Please enable JavaScript to use this page's functionality.
     </noscript>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,192 +1,167 @@
 # API
 
-## Access from third-party code
+CALC's back end exposes a public API for its labor rates data. This API is used by CALC's front end Data Explorer application, and can also be accessed by any third-party application over the public internet.
 
-If you want to write a third-party app that uses the
-API from CALC's production instance, you can
-do so by first signing up for an [api.data.gov API key][apikey].
+# Local development vs. deployed instances
 
-Then, follow the documentation below, but instead of accessing
-the API root at `http://localhost:8000/api/`, you will
-want to use `https://api.data.gov/gsa/calc/`.
+When developing CALC locally, the API is served from the relative URL prefix `/api/` (for example `http://localhost:8000/api/rates`).
 
-[apikey]: https://api.data.gov/signup/
+In its deployed instances (development, staging, and production), CALC's public API is fronted by an [API Umbrella][] instance on [api.data.gov](https://api.data.gov) which proxies all API requests to CALC. This allows CALC to not have to concern itself with details like rate limiting. The production CALC API is available at `https://api.data.gov/gsa/calc/`.
 
-## Access from CALC front end code
-
-In production, CALC's public API is actually fronted by
-an [API Umbrella][] instance on api.data.gov which proxies all
-API requests to CALC. This allows CALC to not have to concern itself
-with details like API keys and rate limiting.
-
-However, this means that front end code can't simply make requests
-against `/api/`, as the documentation below might imply.
-Instead, a global called `API_HOST` is available to all front end
-JS code on every CALC page. When developing locally, it will be
-set to `/api/`, but on CALC's development, staging, and
-production deployments it will be an absolute URL.
-
-Thus, all API requests made from front end CALC code should use
-`API_HOST` as the base URL for all API requests.
+In order to ensure that API requests work both in local development and in deployed instances, CALC's front end code should not simply make requests against the relative `/api/` URLs. Instead, a global JavaScript variable called `API_HOST` is available for use as a prefix to requests. When developing locally, it will be set to `/api/`, but on CALC's development, staging, and production deployments it will be an absolute URL.
 
 [API Umbrella]: https://apiumbrella.io/
 
 ## API endpoints
 
-The following documentation assumes you're trying to access the API
-via a tool like `curl` on a local development instance of CALC at
-`http://localhost:8000/`. If your context or environment is
-different, you will need to use a different base URL, as documented
-previously.
+The following documentation assumes you're trying to access the API from the production instance via a tool like `curl` at `https://api.data.gov/gsa/calc/`. In development, use `http://localhost:8000/api/` or rely on the `API_HOST` variable.
 
 ### `/rates/`
 
-You can access rate information at `/rates/`.
+You can access labor rate information at `/rates/`.
+
+```
+https://api.data.gov/gsa/calc/rates/
+```
 
 #### Labor Categories
-You can search for prices of specific labor categories by using the `q`
-parameter. For example:
+
+You can search for prices of specific labor categories by using the `q` parameter. For example:
 
 ```
-http://localhost:8000/api/rates/?q=accountant
+https://api.data.gov/gsa/calc/rates/?q=accountant
 ```
 
-You can change the way that labor categories are searched by using the
-`query_type` parameter, which can be either:
+You can change the way that labor categories are searched by using the `query_type` parameter, which can be either:
 
-* `match_words` (the default), which matches all words in the query;
+* `match_all` (the default), which matches all words in the query;
 * `match_phrase`, which matches the query as a phrase; or
 * `match_exact`, which matches labor categories exactly
 
 You can search for multiple labor categories separated by a comma.
 
 ```
-http://localhost:8000/api/rates/?q=trainer,instructor
+https://api.data.gov/gsa/calc/rates/?q=trainer,instructor
 ```
 
-If any of the labor categories you'd like included in your search has a comma,
-you can surround that labor category with quotation marks:
+If any of the labor categories you'd like included in your search has a comma, you can surround that labor category with quotation marks:
 
 ```
-http://localhost:8000/api/rates/?q="engineer, senior",instructor
+https://api.data.gov/gsa/calc/rates/?q="engineer, senior",instructor
 ```
 
 All of the query types are case-insensitive.
 
 #### Education and Experience Filters
-###### Experience
-You can also filter by the minimum years of
-experience and maximum years of experience. For example:
+
+##### Experience
+
+You can also filter by the minimum years of experience and maximum years of experience. For example:
 
 ```
-http://localhost:8000/api/rates/?&min_experience=5&max_experience=10&q=technical
+https://api.data.gov/gsa/calc/rates/?&min_experience=5&max_experience=10&q=technical
 ```
 
 Or, you can filter with a single, comma-separated range.
-For example, if you wanted results with more than five years and less
-than ten years of experience:
+For example, if you wanted results with more than five years and less than ten years of experience:
 
 ```
-http://localhost:8000/api/rates/?experience_range=5,10
+https://api.data.gov/gsa/calc/rates/?experience_range=5,10
 ```
 
-###### Education
-The valid values for the education endpoints are `HS` (high school), `AA` (associates),
-`BA` (bachelors), `MA` (masters), and `PHD` (Ph.D).
+##### Education
 
-There are two ways to filter based on education, `min_education` and `education`.
+There are two ways to filter based on education: `min_education` and `education`.
 
-To filter by specific education levels, use `education`. It accepts one or more
-education values as defined above:
+These filters accept one or more (comma-separated) education values:
 
-```
-http://localhost:8000/api/rates/?education=AA,BA
-```
-
-You can also get all results that match and exceed the selected education level
-by using `min_education`. The following example will return results that have
-an education level of MA or PHD:
+* `HS` (high school),
+* `AA` (associates),
+* `BA` (bachelors),
+* `MA` (masters), and
+* `PHD` (Ph.D).
 
 ```
-http://localhost:8000/api/rates/?min_education=MA
+https://api.data.gov/gsa/calc/rates/?education=AA,BA
 ```
 
-The default pagination is set to 200. You can paginate using the `page`
-parameter:
+Use `min_education` to get all results that meet and exceed the selected education.
+The following example will return results that have an education level of `MA` or `PHD`:
 
 ```
-http://localhost:8000/api/rates/?q=translator&page=2
+https://api.data.gov/gsa/calc/rates/?min_education=MA
+```
+
+The default pagination is set to 200. You can paginate using the `page` parameter:
+
+```
+https://api.data.gov/gsa/calc/rates/?q=translator&page=2
 ```
 
 #### Price Filters
-You can filter by price with any of the `price` (exact match), `price__lte`
-(price is less than or equal to) or `price__gte` (price is greater than or
-equal to) parameters:
+
+You can filter by price with any of the `price` (exact match), `price__lte` (price is less than or equal to) or `price__gte` (price is greater than or equal to) parameters:
 
 ```
-http://localhost:8000/api/rates/?price=95
-http://localhost:8000/api/rates/?price__lte=95
-http://localhost:8000/api/rates/?price__gte=95
+https://api.data.gov/gsa/calc/rates/?price=95
+https://api.data.gov/gsa/calc/rates/?price__lte=95
+https://api.data.gov/gsa/calc/rates/?price__gte=95
 ```
 
-The `price__lte` and `price__gte` parameters may be used together to search for
-a price range:
+The `price__lte` and `price__gte` parameters may be used together to search for a price range:
 
 ```
-http://localhost:8000/api/rates/?price__gte=95&price__lte=105
+https://api.data.gov/gsa/calc/rates/?price__gte=95&price__lte=105
 ```
 
 #### Excluding Records
-You can also exclude specific records from the results by passing in an `exclude` parameter and a comma separated list of ids:
-```
-http://localhost:8000/api/rates/?q=environmental+technician&exclude=875173,875749
-```
 
-The `id` attribute is available in api response.
+You can also exclude specific records from the results by passing in an `exclude` parameter and a comma-separated list of ids:
+
+```
+https://api.data.gov/gsa/calc/rates/?q=environmental+technician&exclude=875173,875749
+```
 
 #### Other Filters
+
 Other parameters allow you to filter by:
- * The contract schedule of the transaction.
- * The contract SIN of the transaction.
- * Whether or not the vendor is a small business (valid values: `s` [small] and
-`o` [other]).
- * Whether or not the vendor works on the contractor or customer site.
 
-Here is an example with all four parameters (`schedule`, `sin`, `site`, and
-`business_size`) included:
+* The contract schedule of the transaction.
+* The contract SIN of the transaction.
+* Whether or not the vendor is a small business (valid values: `s` [small] and `o` [other]).
+* Whether or not the vendor works on the contractor or customer site.
+
+Here is an example with all four parameters (`schedule`, `sin`, `site`, and `business_size`) included:
 
 ```
-http://localhost:8000/api/rates/?schedule=mobis&sin=874&site=customer&business_size=s
+https://api.data.gov/gsa/calc/rates/?schedule=mobis&sin=874&site=customer&business_size=s
 ```
 
-For schedules, there are 8 different values that will return results (case
-insensitive):
+For schedules, there are 8 different values that will return results (case-insensitive):
 
- - Environmental
- - AIMS
- - Logistics
- - Language Services
- - PES
- - MOBIS
- - Consolidated
- - IT Schedule 70
+* Environmental
+* AIMS
+* Logistics
+* Language Services
+* PES
+* MOBIS
+* Consolidated
+* IT Schedule 70
 
-For SIN codes, there are several possible codes. They will contain the following
-numbers for their corresponding schedules:
+For SIN codes, there are several possible codes. They will contain the following numbers for their corresponding schedules:
 
- - 899 - Environmental
- - 541 - AIMS
- - 87405 - Logistics
- - 73802 - Language Services
- - 871 - PES
- - 874 - MOBIS
- - 132 - IT Schedule 70
+* 899 - Environmental
+* 541 - AIMS
+* 87405 - Logistics
+* 73802 - Language Services
+* 871 - PES
+* 874 - MOBIS
+* 132 - IT Schedule 70
 
-For site, there are only 3 values (also case insensitive):
+For site, there are three values (also case-insensitive):
 
- - Customer
- - Contractor
- - both
+* customer
+* contractor
+* both
 
-And the `small_business` parameter can be either `s` for small business, or `o`
-for other than small business.
+And the `small_business` parameter can be either `s` for small business, or `o` for other than small business.

--- a/frontend/source/js/data-explorer/components/app.jsx
+++ b/frontend/source/js/data-explorer/components/app.jsx
@@ -57,7 +57,7 @@ class App extends React.Component {
 
     return {
       search: true,
-      card: true,
+      content: true,
       loaded,
       loading,
       error,

--- a/frontend/source/sass/admin/changelists.scss
+++ b/frontend/source/sass/admin/changelists.scss
@@ -13,7 +13,7 @@ th.action-checkbox-column {
 
 .filter-block {
   background: #f1f1f1;
-  border-radius: 4px;
+  border-radius: $border-radius;
   margin-bottom: 0;
   padding: 1rem 2rem;
   h2,

--- a/frontend/source/sass/admin/overrides.scss
+++ b/frontend/source/sass/admin/overrides.scss
@@ -250,7 +250,7 @@ thead a:focus {
 /* same as filter-block in changelists.css */
 .sidebar {
   background: $color-gray-lightest;
-  border-radius: 4px;
+  border-radius: $border-radius;
   margin-bottom: 0;
   padding: 1rem 2rem;
   h2,

--- a/frontend/source/sass/base/_typography.scss
+++ b/frontend/source/sass/base/_typography.scss
@@ -63,7 +63,7 @@ h6 {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: $font-sans;
+  font-family: $font-sans; // WDS override
 
   &[id][tabindex="-1"]:focus {
     // The tabindex="-1" has only been provided to work around a
@@ -79,6 +79,10 @@ h1, h2, h3, h4, h5, h6 {
 
     outline: none;
   }
+}
+
+table caption a {
+  font-family: $font-sans; // WDS override for h5 mixin that gets applied here for some reason
 }
 
 p {

--- a/frontend/source/sass/base/_variables.scss
+++ b/frontend/source/sass/base/_variables.scss
@@ -4,9 +4,6 @@
 // Set the base path for assets (used for font and image paths)
 $asset-path: '../vendor/uswds/' !default;
 
-/* #092d39: used for header background fallback */
-/* #D2F6FF used for info alert bg */
-
 // Color
 $color-primary:              #2D6580;
 $color-primary-darker:       #274E60;
@@ -65,7 +62,6 @@ $small-line-height: 1.3;
 
 $font-family-main: 'Libre Franklin', 'Helvetica', 'Arial', sans-serif;
 $font-sans: $font-family-main;
-$font-serif: $font-family-main;
 $font-family-mono: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 $font-weight-bold: 700;
 $font-weight-normal: 400;

--- a/frontend/source/sass/components/_buttons.scss
+++ b/frontend/source/sass/components/_buttons.scss
@@ -34,7 +34,7 @@ button,
 
   &.button-footer {
     background-color: $color-white;
-    border-radius: 4px;
+    border-radius: $border-radius;
     color: $color-white;
 
     &:hover,

--- a/frontend/source/sass/components/_labels.scss
+++ b/frontend/source/sass/components/_labels.scss
@@ -8,7 +8,7 @@
   font-weight: normal;
   padding: $space-1x;
   text-transform: uppercase;
-  border-radius: 4px;
+  border-radius: $border-radius;
   background-color: $color-gray-lightest;
   color: $color-gray;
   &:before {

--- a/frontend/source/sass/components/_page.scss
+++ b/frontend/source/sass/components/_page.scss
@@ -19,6 +19,45 @@ main {
   font-size: $h3-font-size;
 }
 
+/* Top level classes go in {% body_class %} */
+.content--narrow {
+  header,
+  main,
+  footer {
+    @include span-columns(8);
+    @include shift(2);
+  }
+}
+
+.content--wide {
+  header,
+  main,
+  footer {
+    // Theoretically .container can be used anywhere. We only target top-level ones.
+    > .container {
+      // .row can also be used anywhere; target just top-level classes.
+      > .row,
+      .card {
+        @include span-columns(12);
+        .content {
+          @include span-columns(10 of 12);
+          @include shift-in-context(1 of 12);
+        }
+      }
+      .card:last-child {
+        margin-bottom: $space-10x; //hacky spacing hackity hack
+      }
+    }
+    .card__footer {
+      margin-top: -$space-10x; //ugh this is dumb
+      @include span-columns(8);
+      @include shift(2);
+    }
+  }
+}
+
+
+
 .card {
   background-color: $color-white;
   padding: $space-8x 0;

--- a/frontend/source/sass/components/_tables.scss
+++ b/frontend/source/sass/components/_tables.scss
@@ -180,7 +180,7 @@ td.error {
         bottom: 95%;
         left: 0;
         background-color: $color-secondary-lightest;
-        border-radius: 4px;
+        border-radius: $border-radius;
       }
     }
   }
@@ -204,7 +204,7 @@ td.error {
         bottom: 95%;
         left: 0;
         background-color: $color-secondary-lightest;
-        border-radius: 4px;
+        border-radius: $border-radius;
       }
     }
   }

--- a/frontend/source/sass/components/_usermenu.scss
+++ b/frontend/source/sass/components/_usermenu.scss
@@ -17,7 +17,7 @@ $usermenu-width: 150px;
     font-size: $medium-font-size;
     font-weight: $font-weight-bold;
     background: $color-gray-lightest;
-    border-radius: 4px;
+    border-radius: $border-radius;
     list-style: none;
     padding: $space-2x $space-3x;
 


### PR DESCRIPTION
**NOTE** This PR is against `er-nav-and-card-gridding`, not `develop`.

The `.card` model was originally only supposed to apply to data capture, but ended up needing to be used on the whole site. Because the original model only applied to content widths, the header and footer would have needed to be brought in line manually. @ericronne ran into this while implementing his new styles. This rejiggers the original thing into something more reusable.