### PR TITLE
Fix double underline on card footer

### DIFF
--- a/data_explorer/templates/about.html
+++ b/data_explorer/templates/about.html
@@ -89,7 +89,6 @@
     </div><!--content-->
   </div><!--card-->
 </div><!--row-->
-<div class="card__footer"></div>
 
 </div>
 {% endblock %}

--- a/frontend/source/sass/components/_page.scss
+++ b/frontend/source/sass/components/_page.scss
@@ -103,7 +103,6 @@ footer {
 }
 
 .card .content:first-child h2:first-child {
-  // The first header on a card has too much space.
   margin-top: 0;
 }
 

--- a/hourglass/templates/admin/base.html
+++ b/hourglass/templates/admin/base.html
@@ -96,11 +96,11 @@
             {% block sidebar %}{% endblock %}
           </div>
         </div>
+        <div class="row card__footer">
+          {% block card_footer %}{% endblock %}
+        </div>
       </div>
     </main>
-  <div class="row card__footer">
-    {% block card_footer %}{% endblock %}
-  </div>
   <!-- END Content -->
 
   {% block footer %}


### PR DESCRIPTION
Closes #1741.
Some card classes were not in the correct DOM order, leading to double underlines.