### PR TITLE
Fix the focus ring around the logo

### DIFF
--- a/data_explorer/templates/_header.html
+++ b/data_explorer/templates/_header.html
@@ -1,6 +1,8 @@
 {% load staticfiles %}
 <div class="base-header row">
-  <a class="logo-container columns eight" href="{% url 'index' %}"><img class="logo" src="{% static 'frontend/images/calc_logo_white.svg' %}" alt="CALC: Contract Awarded Labor Category Tool"></a>
+  <div class="logo-container columns eight">
+    <a href="{% url 'index' %}"><img class="logo" src="{% static 'frontend/images/calc_logo_white.svg' %}" alt="CALC: Contract Awarded Labor Category Tool"></a>
+  </div>
   <div class="columns four">
     {% if user.is_authenticated %}
       <div id="usermenu">


### PR DESCRIPTION
Instead of setting the columns on the `a` tag, which leads to a too-large focus ring, set them on a div that contains the `a` tag.