### PR TITLE
Keep a long-lived WebDriver instance through the whole test run

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,9 +28,6 @@ ensure that the back-end and front-end integrate properly. The
 following environment variables may be useful when configuring these
 tests:
 
-* `WD_SOCKET_TIMEOUT` specifies the default socket timeout to use for
-  requests before giving up, in seconds.
-
 * `WD_CHROME_ARGS` are command-line flags to pass to Chrome,
   e.g. `--headless --no-sandbox --disable-setuid-sandbox`.
 


### PR DESCRIPTION
For some reason, on local dev instances (but strangely not CircleCI) instantiating a WebDriver instance more than once during a test run caused a socket timeout.  This appears to fix things, at least on my machine, by keeping one long-lived WebDriver instance around for the whole test run, and shutting it down when the process exits.

To try it out without running the whole test suite, try:

```
pytest frontend/tests/test_qunit.py data_capture/tests/test_integration.py frontend/tests/test_selenium.py
```
