### PR TITLE
Running test_forms by itself works

### DIFF
--- a/data_capture/tests/test_forms.py
+++ b/data_capture/tests/test_forms.py
@@ -11,6 +11,9 @@ from ..models import SubmittedPriceList
 
 @override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE])
 class Step1FormTests(TestCase):
+    def setUp(self):
+        registry._init()
+
     def make_form(self, contract_number='GS-BOOP'):
         return Step1Form({
             'contract_number': contract_number,


### PR DESCRIPTION
Fixes #1522.  The problem with running this test on its own was that `registry._init()` wasn't being called, which was unfortunate because its pre-existing state used the old version of `DATA_CAPTURE_SCHEDULES`, which was overridden by `Step1FormTests`.
