### PR TITLE
[WIP EXPERIMENT] Add fullpage_example template tag

### DIFF
--- a/styleguide/fullpage_example.py
+++ b/styleguide/fullpage_example.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from django.utils.safestring import SafeString
+from django.shortcuts import render
+from django.urls import reverse
+
+
+MY_DIR = Path(__file__).parent.resolve()
+
+EXAMPLES_DIR = MY_DIR / 'templates' / 'styleguide_fullpage_examples'
+
+REGEX = r'([0-9A-Za-z_\-]+)'
+
+
+def get_html_source(name):
+    filename = EXAMPLES_DIR / f'{name}.html'
+    return SafeString(filename.read_text())
+
+
+def get_url(name):
+    return reverse('styleguide:fullpage_example', args=(name,))
+
+
+def view(request, name):
+    html = get_html_source(name)
+    return render(request, 'styleguide_fullpage_example.html', {
+        'html': html,
+    })

--- a/styleguide/templates/styleguide.html
+++ b/styleguide/templates/styleguide.html
@@ -110,27 +110,9 @@
 
   <p>By default, the cards are too wide for text-only and most form-based sections, so you may need to use the <code>content--skinny</code> body class.</p>
 
-  {% example %}
-  <div class="content--skinny"><!-- goes on BODY in actuality -->
-    <main class="clearfix"><!-- fixes a styleguide display issue -->
-      <div class="container">
-        <div class="card">
-          <div class="content">
-            <h2>Section of great importance!</h2>
-            <p>Some compelling content goes here.</p>
-          </div>
-        </div>
-        <div class="card">
-          <div class="content">
-            <p>Thrilling, isn't it?</p>
-          </div>
-        </div>
-      </div>
-    </main>
-  </div>
-  {% endexample %}
+  {% fullpage_example "content-skinny" %}
 
-  <p>The data capture {% pathname "data_capture\templates\data_capture\step.html" %} template is set up to expect step headings to occur in their own card; however, the designs for some steps call for a single-card look. To create this look, use the <code>card--collapse-header</code> class on <code>main</code>, which will remove the bottom border of the heading card and reduce the amount of padding applied to the second card.</p>
+  <p>The data capture {% pathname "data_capture/templates/data_capture/step.html" %} template is set up to expect step headings to occur in their own card; however, the designs for some steps call for a single-card look. To create this look, use the <code>card--collapse-header</code> class on <code>main</code>, which will remove the bottom border of the heading card and reduce the amount of padding applied to the second card.</p>
 
   {% example %}
     <main class="card--collapse-header clearfix"><!-- clearfix just fixes a styleguide display issue -->

--- a/styleguide/templates/styleguide_fullpage_example.html
+++ b/styleguide/templates/styleguide_fullpage_example.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+{% load staticfiles %}
+<link rel="stylesheet" href="{% static 'frontend/built/style/main.min.css' %}"/>
+<style>
+#djDebugToolbarHandle {
+    display: none !important;
+}
+</style>
+{{ html }}

--- a/styleguide/templates/styleguide_fullpage_example_iframe.html
+++ b/styleguide/templates/styleguide_fullpage_example_iframe.html
@@ -1,0 +1,12 @@
+<div class="styleguide-example">
+  <div class="rendering">
+    <h3 class="example-heading">
+        Example
+        <a href="{{ url }}" target="_blank" title="Open in new tab"></a>
+    </h3>
+    <div style="height: 475px; overflow: hidden;">
+      <iframe src="{{ url }}" style="width: 132.5%; transform: scale(0.75); transform-origin: 0 0; height: 600px; border: 1px solid gray"></iframe>
+    </div>
+  </div>
+  <pre><code class="language-html">{% filter force_escape %}{{ html }}{% endfilter %}</pre></code>
+</div>

--- a/styleguide/templates/styleguide_fullpage_examples/content-skinny.html
+++ b/styleguide/templates/styleguide_fullpage_examples/content-skinny.html
@@ -1,0 +1,17 @@
+<body class="content--skinny">
+  <main>
+    <div class="container">
+      <div class="card">
+        <div class="content">
+          <h2>Section of great importance!</h2>
+          <p>Some compelling content goes here.</p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="content">
+          <p>Thrilling, isn't it?</p>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>

--- a/styleguide/templatetags/styleguide.py
+++ b/styleguide/templatetags/styleguide.py
@@ -9,6 +9,8 @@ from django.utils.module_loading import import_string
 from django.utils.html import escape
 from django.utils.text import slugify
 
+from styleguide import fullpage_example as _fullpage_example
+
 
 BASE_GITHUB_URL = 'https://github.com/18F/calc'
 
@@ -233,6 +235,15 @@ def pathname(name):
         escape(github_url_for_path(name)),
         escape(name)
     ))
+
+
+@register.simple_tag(takes_context=True)
+def fullpage_example(context, name):
+    t = context.template.engine.get_template(
+        'styleguide_fullpage_example_iframe.html')
+    url = _fullpage_example.get_url(name)
+    html = _fullpage_example.get_html_source(name)
+    return t.render(template.Context({'url': url, 'html': html}))
 
 
 @register.simple_tag(takes_context=True)

--- a/styleguide/urls.py
+++ b/styleguide/urls.py
@@ -2,12 +2,14 @@ from django.conf.urls import url, include
 
 from . import (
     views, ajaxform_example, date_example, radio_checkbox_example,
-    email_examples
+    email_examples, fullpage_example
 )
 
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
+    url(r'^fullpage-example/' + fullpage_example.REGEX + '$',
+        fullpage_example.view, name='fullpage_example'),
     url(r'^ajaxform$', ajaxform_example.view, name='ajaxform'),
     url(r'^date$', date_example.view, name='date'),
     url(r'^radio-checkbox$', radio_checkbox_example.view,


### PR DESCRIPTION
This is an attempt to fix #1771 by adding a new `{% fullpage_example %}` template tag.

## Instructions

The basic idea is that when you want to include a full-page example in the style guide, you will:

1. Come up with a slug that identifies the example, e.g. `content-skinny`.

2. Add an HTML file for the example at:

    ```
    styleguide/templates/styleguide_fullpage_examples/<slug>.html
    ```

    The HTML file should just include the raw HTML for the example; it's what will be shown to readers of the styleguide as the example HTML.  So it should only include the `<body>` tag and everything inside it--no `<head>` or `<html>`.

3. In the styleguide, when you want to include the full-page example, use the following:

    ```
    {% fullpage_example "<slug>" %}
    ```

## Example

Here's an example of one of the snippets from #1744 converted to use the `{% fullpage_example %}` template tag:

> ![fullpage_example](https://user-images.githubusercontent.com/124687/38869750-b3adcbc4-4219-11e8-8b32-a4e8ba4f8311.png)

## To do

- [ ] Add tests.
- [ ] Ensure `{% fullpage_example "<slug>" %}` raises an exception if `<slug>` doesn't exist.
- [ ] Ensure the `styleguide:fullpage_example` route returns 404 for non-existent examples.
- [ ] Clean up the iframe styling so it's not all inlined
- [ ] Consider using DJDT's [`SHOW_TOOLBAR_CALLBACK`](https://django-debug-toolbar.readthedocs.io/en/stable/configuration.html#debug-toolbar-config) to not render the debug toolbar on full-page example iframes, rather than hiding the toolbar.
