### PR TITLE
upgrade flake8/pyflakes; fix bare exceptions

### DIFF
--- a/data_capture/jobs.py
+++ b/data_capture/jobs.py
@@ -90,7 +90,7 @@ def process_bulk_upload_and_send_email(upload_source_id):
     try:
         num_contracts, num_bad_rows = _process_bulk_upload(upload_source)
         email.bulk_upload_succeeded(upload_source, num_contracts, num_bad_rows)
-    except:
+    except Exception:
         contracts_logger.exception(
             'An exception occurred during bulk upload processing '
             '(pk=%d).' % upload_source_id

--- a/data_capture/r10_spreadsheet_converter.py
+++ b/data_capture/r10_spreadsheet_converter.py
@@ -57,7 +57,7 @@ class Region10SpreadsheetConverter():
         '''
         try:
             self.get_heading_indices_map(raises=True)
-        except:
+        except Exception:
             return False
 
         return True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@
 
 # Testing and development dependencies
 bandit>=1.0,<2.0
-pyflakes==1.4.0
-flake8==3.2.1
+pyflakes==1.6.0
+flake8==3.5.0
 pytest==3.0.6
 pytest-cov==2.4.0
 pytest-django==3.1.2


### PR DESCRIPTION
Fixes #1788 

Updates CALC to the latest `flake8` and `pyflakes`.
Fixes two flake8 errors around the use of bare `except` statements.