### PR TITLE
Fix admin user search

### DIFF
--- a/hourglass/templates/admin/search_form.html
+++ b/hourglass/templates/admin/search_form.html
@@ -5,7 +5,7 @@
 <div id="toolbar"><form id="changelist-search" method="get">
 <div role="search" class="form__inline"><!-- DIV needed for valid HTML -->
   <label for="searchbar">Search</label>
-  <input type="search" name="search" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus />
+  <input type="search" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus />
   <input type="submit" class="button-primary" value="{% trans 'Search' %}" />
   {% if show_result_count %}
       <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>


### PR DESCRIPTION
Fixes #1726.

It took me a _really_ long time to figure out what was wrong.  At first I started comparing our `search_form.html` to [Django 1.11's](https://github.com/django/django/blob/stable/1.11.x/django/contrib/admin/templates/admin/search_form.html) and didn't notice anything different.  Then I started fiddling with our custom `UserAdmin` subclass, to no avail.  Then I just started deleting stuff, slowly reverting our custom Django admin back to the default one.

The user search field started working again when I _deleted_ `search_form.html`, which made Django fall back to the default one.  Which was weird, because that was the first thing that I'd looked at.  But it wasn't until I looked _really_ closely that I noticed that our search field had _two_ `name` attributes!  Oof.