### PR TITLE
Attempt to document API via Django REST Framework / Core API

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: node_modules,frontend/tests,api/tests,meta/management/commands,docker_django_management.py,data_capture/tests
+exclude: node_modules,frontend/tests,api/tests,meta/management/commands,docker_django_management.py,data_capture/tests,venv

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,5 +5,6 @@
 htmlcov/
 vendor/
 coverage/
+venv/
 
 frontend/static/frontend/built/

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = 
+    */migrations/*.py,
+    node_modules,
+    venv

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -6,8 +6,10 @@ from django.conf import settings
 
 class ContractPagination(pagination.PageNumberPagination):
 
-    def __init__(self, context):
+    def __init__(self, context=None):
         super().__init__()
+        if context is None:
+            context = {}
         self.context = context
         self.page_size = settings.PAGINATION
 

--- a/api/tests/test_docs.py
+++ b/api/tests/test_docs.py
@@ -1,0 +1,7 @@
+from django.test import TestCase
+
+
+class DocsTests(TestCase):
+    def test_docs_do_not_explode(self):
+        res = self.client.get('/api/docs/')
+        self.assertEqual(res.status_code, 200)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,8 +1,11 @@
 from django.conf.urls import url
+from rest_framework.documentation import include_docs_urls
+
 from api import views
 
 urlpatterns = [
     url(r'^rates/$', views.GetRates.as_view()),
     url(r'^rates/csv/$', views.GetRatesCSV.as_view()),
     url(r'^search/$', views.GetAutocomplete.as_view()),
+    url(r'^docs/', include_docs_urls(title='CALC API')),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -6,11 +6,34 @@ from decimal import Decimal
 
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework.schemas import AutoSchema
+from rest_framework.compat import coreapi, coreschema
 
 from api.pagination import ContractPagination
 from api.serializers import ContractSerializer
 from api.utils import get_histogram
 from contracts.models import Contract, EDUCATION_CHOICES
+
+
+SIMPLE_QUERYARG_TYPE_MAP = {
+    int: coreschema.Integer,
+    str: coreschema.String,
+}
+
+
+def queryarg(name, _type, description):
+    '''
+    A simple helper method to generate a coreapi field out of a
+    less verbose syntax.
+    '''
+
+    return coreapi.Field(
+        name,
+        location="query",
+        schema=SIMPLE_QUERYARG_TYPE_MAP[_type](
+            description=description,
+        )
+    )
 
 
 def parse_csv_style_string(s):
@@ -34,32 +57,57 @@ def parse_csv_style_string(s):
     return [qq.strip() for qq in list(reader)[0] if qq.strip()]
 
 
+Q_QUERYARG = queryarg("q", str, "Keywords to search by.")
+
+GET_CONTRACTS_QUERYARGS = [
+    Q_QUERYARG,
+    queryarg("experience_range", str,
+             "Filter by a range of years of experience."),
+    queryarg("min_experience", int,
+             "Filter by minimum years of experience."),
+    queryarg("max_experience", int,
+             "Filter by maximum years of experience."),
+    queryarg(
+        "min_education",
+        str,
+        "Filter by a minimum level of education: " + ', '.join([
+            f"{code} = {desc}"
+            for code, desc in EDUCATION_CHOICES
+        ])
+    ),
+    queryarg("schedule", str, "Filter by GSA schedule."),
+    queryarg("site", str, "Filter by worksite."),
+    queryarg("business_size", str,
+             "Filter by 's'(mall) or 'o'(ther)."),
+    queryarg("price", int, "Filter by exact price."),
+    queryarg("price__gte", int,
+             "Price must be greater than or equal to this integer."),
+    queryarg("price__lte", int,
+             "Price must be less than or equal to this integer."),
+    queryarg("sort", str,
+             "The column to sort on. Defaults to wage_field."),
+    queryarg(
+        "query_type",
+        str,
+        "Defines how the user's keyword search should work. "
+        "Can be match_all (default), match_phrase, or match_exact."
+    ),
+    queryarg(
+        "exclude",
+        str,
+        "Comma-separated list of ids to exclude from the search results."
+    )
+]
+
+
 def get_contracts_queryset(request_params, wage_field):
     """ Filters and returns contracts based on query params
 
     Args:
-        request_params (dict): the request query parameters
+        request_params (dict): the request query parameters, corresponding
+            to GET_CONTRACTS_QUERYARGS above.
         wage_field (str): the name of the field currently being used for
             wage calculations and sorting
-
-    Query Params:
-        q (str): keywords to search by
-        experience_range(str): filter by a range of years of experience
-        min_experience (int): filter by minimum years of experience
-        max_experience (int): filter by maximum years of experience
-        min_education (str): filter by a minimum level of education
-            (see EDUCATION_CHOICES)
-        schedule (str): filter by GSA schedule
-        site (str): filter by worksite
-        business_size (str): filter by 's'(mall) or 'o'(ther)
-        price (int): filter by exact price
-        price__gte (int): price must be greater than or equal to this integer
-        price__lte (int): price must be less than or equal to this integer
-        sort (str): the column to sort on, defaults to wage_field
-        query_type (str): defines how the user's keyword search should work.
-            [ match_all (default) | match_phrase | match_exact ]
-        exclude: (int): comma separated list of ids to exclude from the search
-            results
 
     Returns:
         QuerySet: a filtered and sorted QuerySet to retrieve Contract objects
@@ -164,6 +212,30 @@ def quantize(num, precision=2):
 
 
 class GetRates(APIView):
+    """
+    Get detailed information about all labor rates that match a search query.
+    """
+
+    # The AutoSchema will introspect this to ultimately generate
+    # documentation about our pagination query args.
+    pagination_class = ContractPagination
+
+    schema = AutoSchema(
+        manual_fields=[
+            queryarg(
+                "contract-year",
+                int,
+                "Return price for the given contract year (1 or 2). "
+                "Defaults to the current year pricing."
+            ),
+            queryarg(
+                "histogram",
+                int,
+                "Number of bins to divide a wage histogram into. "
+                "If not provided, no histogram data will be returned."
+            ),
+        ] + GET_CONTRACTS_QUERYARGS
+    )
 
     def get(self, request):
         bins = request.query_params.get('histogram', None)
@@ -189,7 +261,7 @@ class GetRates(APIView):
             values = contracts_all.values_list(wage_field, flat=True)
             page_stats['wage_histogram'] = get_histogram(values, int(bins))
 
-        pagination = ContractPagination(page_stats)
+        pagination = self.pagination_class(page_stats)
         results = pagination.paginate_queryset(contracts_all, request)
         serializer = ContractSerializer(results, many=True)
         return pagination.get_paginated_response(serializer.data)
@@ -206,19 +278,15 @@ class GetRates(APIView):
 
 
 class GetRatesCSV(APIView):
+    """
+    Returns a CSV of matched records and selected search and filter options.
+    """
+
+    schema = AutoSchema(
+        manual_fields=GET_CONTRACTS_QUERYARGS
+    )
 
     def get(self, request, format=None):
-        """
-        Returns a CSV of matched records and selected search and filter options
-
-        Query Params:
-            q (str): keywords to search by
-            min_experience (int): filter by minimum years of experience
-            min_education (str): filter by a minimum level of education
-            site (str): filter by worksite
-            business_size (str): filter by 's'(mall) or 'o'(ther)
-        """
-
         wage_field = 'current_price'
         contracts_all = get_contracts_queryset(request.GET, wage_field)
 
@@ -275,17 +343,25 @@ class GetRatesCSV(APIView):
 
 
 class GetAutocomplete(APIView):
+    """
+    Return autocomplete suggestions for a given query.
+    """
+
+    schema = AutoSchema(
+        manual_fields=[
+            Q_QUERYARG,
+            queryarg(
+                "query_type",
+                str,
+                "Defines how the search query should work. "
+                "Can be match_all (default) or match_phrase."
+            )
+        ]
+    )
 
     MAX_RESULTS = 20
 
     def get(self, request, format=None):
-        """
-        Query Params:
-            q (str): the search query
-            query_type (str): defines how the search query should work.
-                [ match_all (default) | match_phrase ]
-        """
-
         q = request.query_params.get('q', False)
         query_type = request.query_params.get('query_type', 'match_all')
 

--- a/data_capture/__init__.py
+++ b/data_capture/__init__.py
@@ -1,3 +1,4 @@
 import defusedxml
 
+
 defusedxml.defuse_stdlib()

--- a/meta/management/commands/ultratest.py
+++ b/meta/management/commands/ultratest.py
@@ -103,7 +103,7 @@ TESTTYPES_TO_REPORT_COVERAGE_ON = ['py.test']
 TestType = namedtuple('TestType', ['name', 'cmd'])
 
 TESTTYPES = [
-    TestType(name='flake8', cmd='flake8 --exclude=node_modules,migrations .'),
+    TestType(name='flake8', cmd='flake8 .'),
     TestType(name='eslint', cmd='yarn failable-eslint'),
     TestType(name='bandit', cmd='bandit -r .'),
     TestType(name='mypy', cmd='mypy @mypy-files.txt'),

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "npm": ">=3.10.0"
   },
   "jest": {
+    "roots": ["frontend"],
     "collectCoverage": true,
     "coverageReporters": [
       "lcov",

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ DJANGO_SETTINGS_MODULE=hourglass.settings
 python_classes=*Test Test*
 python_files=tests.py test_*.py
 addopts = --doctest-modules
-norecursedirs=node_modules production_tests
+norecursedirs=node_modules production_tests venv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@
 bandit>=1.0,<2.0
 pyflakes==1.6.0
 flake8==3.5.0
+pycodestyle==2.3.0
 pytest==3.0.6
 pytest-cov==2.4.0
 pytest-django==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-click==1.2.0
 Django==1.11.11
 django-cors-headers==2.0.2
 django-debug-toolbar==1.6
-djangorestframework==3.5.3
+djangorestframework==3.8.2
 gunicorn==19.6.0
 newrelic==2.78.0.57
 psycopg2==2.6.2
@@ -23,4 +23,5 @@ pytz==2016.10
 Markdown==2.6.8
 cg-django-uaa==1.3.0
 semantic_version==2.6.0
+coreapi==2.3.3
 git+git://github.com/18F/django-uswds-forms@c159b838357e61c0bdec2f5cd071398168d9e4d9


### PR DESCRIPTION
This attempts to implement the solution suggested by @jseppi in https://github.com/18F/calc/issues/1698#issuecomment-378401583, whereby we use [DRF's built-in support for API documentation](http://www.django-rest-framework.org/topics/documenting-your-api/).

Specifically, it adds an endpoint at `/api/docs/` that looks like this:

> ![api-docs](https://user-images.githubusercontent.com/124687/38961837-6c57dcd6-4338-11e8-91dc-8be68af16521.png)

Clicking the "INTERACT" button brings up a modal that allows users to tinker with a specific API endpoint:

> ![interact](https://user-images.githubusercontent.com/124687/38961877-aa3218e6-4338-11e8-8854-ae7771bf2767.png)

## Notes

* It seems like DRF has embraced something called [Core API](http://www.coreapi.org/), which is "a format-independent Document Object Model for representing Web APIs".  Sadly, it seems somewhat scant on documentation; for instance, [some code examples in the DRF docs](http://www.django-rest-framework.org/api-guide/schemas/#autoschema) use a module called `coreschema` which has [a githubo repo with no README](https://github.com/core-api/python-coreschema).

    Based on a cursory look, it seems like the plumbing provided by this API could be useful for automatic parameter validation, but given the apparent lack of maturity, I'm hesitant to start using it for anything other than documentation right now.

* I was having some problems running `flake8`.  Apparently the version we use is supposed to [require `pycodestyle` 2.3.0](https://gitlab.com/pycqa/flake8/merge_requests/212) but running `pip install -r requirements-dev.txt` left mine at 2.2.0, which was breaking `flake8`.  So for now I've just added `pycodestyle==2.3.0` to our dev requirements.

* It seems DRF has a whole [fancy filtering system](http://www.django-rest-framework.org/api-guide/filtering/).  Reworking our APIs to use this could make it so that DRF's `AutoSchema` automatically pulls querystring arg docs by introspecting our code, rather than requiring us to manually define fields as I'm doing in this PR.  This would help keep our code nice and DRY.

* As far as I can tell, it doesn't seem like coreapi / the auto-generated documentation provides any way to tell readers about the kind of data that an API endpoint _returns_, which is a bummer.  Although that said, it seems like a third-party library called [drf-yasg](https://github.com/axnsan12/drf-yasg/) _does_ provide response schemas, so in the future we could use that, maybe...

* I am not a big fan of how DRF is auto-naming all our GET methods "list", and using that as the heading for our INTERACT modals, but I can't figure out if there's a way to change that default.

## To do

- [ ] Consider mounting these docs at `/api/` instead of `/api/docs/`.  Currently `/api/` just 404s, and it's more easy to type and find that way.
- [ ] Link to `/api/docs/` from the Sphinx docs.
- [ ] Consider making the docs a bit more robust. Right now they're fairly minimal and some fields are a bit vague (e.g. worksite).
- [ ] Consider either merging the existing `API.md` into these API docs or getting rid of them entirely.
- [ ] It'd be nice if these API docs were linked-to from (or even embedded in) the actual HTML views of the API endpoints.  So that e.g. if someone went to `/api/rates/` with their browser, aside from seeing the HTML-rendered version of the response, they'd also see a link to `/api/docs/` or something.
