### PR TITLE
Set memory constraints of docker containers to match deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     command: sh -c "python manage.py collectstatic --noinput ; gunicorn -b :${DOCKER_EXPOSED_PORT} hourglass.wsgi:application"
     ports:
       - "${DOCKER_EXPOSED_PORT}:${DOCKER_EXPOSED_PORT}"
+    mem_limit: 1G
   db:
     image: postgres:9.5.4
     volumes:
@@ -27,6 +28,7 @@ services:
       - db
       - redis
     command: python manage.py rqworker
+    mem_limit: 512M
   rq_scheduler:
     extends:
       file: docker-services.yml
@@ -37,6 +39,7 @@ services:
     command: python manage.py rqscheduler
     environment:
       - IS_RQ_SCHEDULER=yup
+    mem_limit: 512M
 volumes:
   node-modules:
   python-venv:

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -24,3 +24,5 @@ services:
       # server to work, as it makes the app connect to itself (which will
       # cause the app to hang if only one worker exists).
       - WEB_CONCURRENCY=2
+    mem_limit: 1G
+    memswap_limit: 0


### PR DESCRIPTION
To improve dev/prod parity and better anticipate potential problems like #1601 during development, we can use Docker's [user memory constraints](https://docs.docker.com/engine/reference/run/#user-memory-constraints) to simulate the kind of resource limits that our production environment has.

I'm not actually sure if our production environment disables swap like this PR does, but [Brendan Gregg's Linux Performance Tools talk](https://www.youtube.com/watch?v=FJW8nGV4jxY) claims that most production environments do.  It also makes it a lot easier to tell when we're using too much memory, since our app just crashes, instead of slowly thrashing about as the kernel swaps memory to disk.

To test this out, you can create a new Python file with the following content and run it in a container:

```python
from ctypes import c_int

Chunk = c_int * 1_000_000

chunks = []

while True:
    chunks.append(Chunk())
    print(f"Allocated {len(chunks)}M")
```

You should see it get killed by the kernel after it's allocated some amount of memory that's commensurate to its container's `mem_limit`.

I also tried uploading Kelly's latest R10 bulk data with these constraints in-place and it works, so that's a good sign.

In the future, we can also add a configuration test that ensures the container memory limits are identical to the ones specified in the manifests, but I'm going to leave that for a later PR for now.