### PR TITLE
Improve data capture schedule documentation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,15 @@
 [flake8]
+
 exclude = 
     */migrations/*.py,
     node_modules,
     venv
+
+ignore =
+    # E701, is intended to prevent one-liners like
+    # "if blah: continue", but we're getting false
+    # positives on Python 3.6 variable annotations,
+    # so we're going to disable it for now.
+    E701
+
+max-line-length = 100

--- a/api/tests/test_rates_api.py
+++ b/api/tests/test_rates_api.py
@@ -920,8 +920,8 @@ class GetRatesTests(TestCase):
     def test_query_type__match_exact(self):
         self.make_test_set()
         get_contract_recipe().make(
-                _quantity=1,
-                labor_category='Professional Legal Services I'
+            _quantity=1,
+            labor_category='Professional Legal Services I'
         )
         resp = self.c.get(
             self.path, {'q': 'legal services', 'query_type': 'match_exact'})

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -403,8 +403,8 @@ class Contract(models.Model):
             # if there is an escalation rate, increase the
             # previous year's value by the escalation rate
             if escalation_rate > 0:
-                escalation_factor = Decimal(1 + escalation_rate/100)
-                prev_rate = self.get_hourly_rate(i-1)
+                escalation_factor = Decimal(1 + escalation_rate / 100)
+                prev_rate = self.get_hourly_rate(i - 1)
                 next_rate = escalation_factor * prev_rate
 
             self.set_hourly_rate(i, next_rate)

--- a/data_capture/schedules/base.py
+++ b/data_capture/schedules/base.py
@@ -46,7 +46,7 @@ class ConcreteBasePriceListMethods:
 
     # Path to the template used for presenting an example of
     # what to upload.
-    upload_example_template = None  # type: Optional[str]
+    upload_example_template: Optional[str] = None
 
     # This is a list of Django Form objects representing
     # valid rows in the price list.
@@ -103,7 +103,7 @@ class BasePriceList(ConcreteBasePriceListMethods, metaclass=abc.ABCMeta):
     title = 'Unknown Schedule'
 
     # Extra instructions text to use for the upload widget.
-    upload_widget_extra_instructions = None  # type: Optional[str]
+    upload_widget_extra_instructions: Optional[str] = None
 
     @abc.abstractmethod
     def add_to_price_list(self, price_list: SubmittedPriceList) -> None:

--- a/data_capture/schedules/base.py
+++ b/data_capture/schedules/base.py
@@ -1,3 +1,13 @@
+'''
+This module contains BasePriceList, the abstract base class for
+price lists being imported into CALC.
+
+Different schedules will need different kinds of business logic for
+parsing their particular kinds of price lists and adding them to CALC;
+BasePriceList contains a variety of extension points to accommodate
+for these specifics while providing a common interface to clients.
+'''
+
 import re
 import abc
 from typing import Dict, Any, Optional, List

--- a/data_capture/schedules/base.py
+++ b/data_capture/schedules/base.py
@@ -1,19 +1,18 @@
 import re
 import abc
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
+
 from django.template.loader import render_to_string
 from django.core.validators import (
     MinValueValidator, RegexValidator)
 from django.http import HttpRequest
 from django.utils.safestring import SafeString, mark_safe
+from django.forms import Form
 from django.core.files.uploadedfile import UploadedFile
 
 from contracts.loaders.region_10 import FEDERAL_MIN_CONTRACT_RATE
 from ..models import SubmittedPriceList
 
-if False:
-    from django.forms import Form  # NOQA
-    from typing import List  # NOQA
 
 min_price_validator = MinValueValidator(
     FEDERAL_MIN_CONTRACT_RATE,
@@ -39,14 +38,17 @@ class ConcreteBasePriceListMethods:
     # what to upload.
     upload_example_template = None  # type: Optional[str]
 
-    def __init__(self) -> None:
-        # This is a list of Django Form objects representing
-        # valid rows in the price list.
-        self.valid_rows = []  # type: List[Form]
+    # This is a list of Django Form objects representing
+    # valid rows in the price list.
+    valid_rows: List[Form]
 
-        # This is a list of Django Form objects representing
-        # invalid rows in the price list.
-        self.invalid_rows = []  # type: List[Form]
+    # This is a list of Django Form objects representing
+    # invalid rows in the price list.
+    invalid_rows: List[Form]
+
+    def __init__(self) -> None:
+        self.valid_rows = []
+        self.invalid_rows = []
 
     def is_empty(self) -> bool:
         '''

--- a/data_capture/schedules/coercers.py
+++ b/data_capture/schedules/coercers.py
@@ -58,7 +58,7 @@ def gen_sublists(arr, size):
     arr_len = len(arr)
     for i in range(arr_len):
         if i + size <= arr_len:
-            yield arr[i:i+size]
+            yield arr[i:i + size]
 
 
 def extract_min_education(text):

--- a/data_capture/schedules/registry.py
+++ b/data_capture/schedules/registry.py
@@ -1,3 +1,16 @@
+'''
+This module manages the registration of different types of schedules whose
+price lists can be uploaded to CALC.
+
+Registering a schedule in CALC is a bit similar to adding an app to Django.
+Every schedule has a class that inherits from BasePriceList, and
+settings.DATA_CAPTURE_SCHEDULES refers to a list of strings that correspond
+to BasePriceList classes.
+
+Once a schedule is registered, it will appear as an option when a user
+chooses to upload a price list to CALC.
+'''
+
 from typing import Any, List, Dict, Iterator, NamedTuple, Type, Optional, Tuple
 
 from django.conf import settings
@@ -143,6 +156,9 @@ def smart_load_from_upload(classname: str, f: UploadedFile) -> BasePriceList:
 
 # A serialized price list is a tuple comprised of its fully-qualified
 # class name and its class-specific serialization data.
+#
+# This allows us to easily "route" a price list's serialized
+# representation to its class-specific deserializer.
 SerializedPriceList = Tuple[str, Any]
 
 

--- a/data_capture/schedules/registry.py
+++ b/data_capture/schedules/registry.py
@@ -36,10 +36,10 @@ def _classname(cls: type) -> str:
     return '%s.%s' % (cls.__module__, cls.__name__)
 
 
-def _init():
+def populate_from_settings():
     '''
-    Initialize the registry by loading from the list
-    of class names in Django's setting.DATA_CAPTURE_SCHEDULES.
+    Populate the registry by loading from the list
+    of class names in Django's settings.DATA_CAPTURE_SCHEDULES.
     '''
 
     global CHOICES, CLASSES
@@ -173,4 +173,4 @@ def deserialize(data: SerializedPriceList) -> BasePriceList:
     return CLASSES[classname].deserialize(d)
 
 
-_init()
+populate_from_settings()

--- a/data_capture/tests/test_forms.py
+++ b/data_capture/tests/test_forms.py
@@ -3,7 +3,6 @@ from django.test import TestCase, override_settings
 
 from .common import FAKE_SCHEDULE, uploaded_csv_file, r10_file
 from ..schedules.fake_schedule import FakeSchedulePriceList
-from ..schedules import registry
 from ..forms import (Step1Form, Step2Form, PriceListUploadForm, Step4Form,
                      PriceListDetailsForm, Region10BulkUploadForm)
 from ..models import SubmittedPriceList
@@ -11,9 +10,6 @@ from ..models import SubmittedPriceList
 
 @override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE])
 class Step1FormTests(TestCase):
-    def setUp(self):
-        registry._init()
-
     def make_form(self, contract_number='GS-BOOP'):
         return Step1Form({
             'contract_number': contract_number,
@@ -93,9 +89,6 @@ class Step2FormTests(TestCase):
 
 @override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE])
 class PriceListUploadFormTests(TestCase):
-    def setUp(self):
-        registry._init()
-
     def test_invalid_when_file_is_missing(self):
         form = PriceListUploadForm({}, schedule=FAKE_SCHEDULE)
         self.assertFalse(form.is_valid())

--- a/data_capture/tests/test_integration.py
+++ b/data_capture/tests/test_integration.py
@@ -8,7 +8,6 @@ from django.core.management import call_command
 from hourglass.urls import urlpatterns
 from hourglass.tests.common import BaseLoginTestCase
 from data_capture.tests.common import FAKE_SCHEDULE, FAKE_SCHEDULE_EXAMPLE_PATH
-from data_capture.schedules import registry
 from data_capture.models import SubmittedPriceList
 from .browsers import BrowserTestCase
 
@@ -57,7 +56,6 @@ class DataCaptureTests(BrowserTestCase):
         return self.get_title().split(' / ')[-1]
 
     def test_data_capture(self):
-        registry._init()
         call_command('initgroups', stdout=io.StringIO())
         t = BaseLoginTestCase()
         user = t.create_user(

--- a/data_capture/tests/test_models.py
+++ b/data_capture/tests/test_models.py
@@ -10,7 +10,6 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 
 from hourglass.tests.common import BaseLoginTestCase
 from contracts.models import Contract
-from ..schedules import registry
 from ..schedules.fake_schedule import FakeSchedulePriceList
 from ..models import (SubmittedPriceList, SubmittedPriceListRow,
                       HashedUploadedFile)
@@ -58,7 +57,6 @@ class ModelTestCase(BaseLoginTestCase):
 
     def setUp(self):
         super().setUp()
-        registry._init()
         self.setup_user()
 
     def setup_user(self):

--- a/data_capture/tests/test_price_list_replace_views.py
+++ b/data_capture/tests/test_price_list_replace_views.py
@@ -194,9 +194,9 @@ class ReplaceStep1Tests(ReplaceStepTest):
         self.assertRegexpMatches(json_data['form_html'],
                                  r'This field is required')
         self.assertHasMessage(
-           res,
-           'error',
-           'Oops! Please correct the following error.'
+            res,
+            'error',
+            'Oops! Please correct the following error.'
         )
 
 

--- a/data_capture/tests/test_price_list_upload_views.py
+++ b/data_capture/tests/test_price_list_upload_views.py
@@ -437,9 +437,9 @@ class Step3Tests(PriceListStepTestCase, HandleCancelMixin):
         self.assertRegexpMatches(json_data['form_html'],
                                  r'This field is required')
         self.assertHasMessage(
-           res,
-           'error',
-           'Oops! Please correct the following error.'
+            res,
+            'error',
+            'Oops! Please correct the following error.'
         )
 
 

--- a/data_capture/tests/test_price_list_upload_views.py
+++ b/data_capture/tests/test_price_list_upload_views.py
@@ -59,7 +59,6 @@ class PriceListStepTestCase(StepTestCase):
 
     def setUp(self):
         super().setUp()
-        registry._init()
 
     def login(self, **kwargs):
         perms = kwargs.get('permissions', [])
@@ -108,8 +107,6 @@ class Step1Tests(PriceListStepTestCase, HandleCancelMixin):
             'data_capture.schedules.s70.Schedule70PriceList'],
     )
     def test_valid_post_with_diff_schedule_removes_gleaned_data(self):
-        # re-init registry to take overridden settings into account
-        registry._init()
         self.login()
 
         # first, post with Fake Schedule selected

--- a/data_capture/tests/test_schedules_registry.py
+++ b/data_capture/tests/test_schedules_registry.py
@@ -9,13 +9,8 @@ from ..schedules.fake_schedule import FakeSchedulePriceList
 from .common import FAKE_SCHEDULE, uploaded_csv_file, create_csv_content
 
 
-class RegistryTestCase(TestCase):
-    def setUp(self):
-        registry._init()
-
-
 @override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE])
-class FakeScheduleOnlyTests(RegistryTestCase):
+class FakeScheduleOnlyTests(TestCase):
     def test_get_choices_works(self):
         self.assertEqual(
             [choice for choice in registry.get_choices()],
@@ -79,7 +74,7 @@ FOO_SCHEDULE = '%s.FooSchedulePriceList' % __name__
 
 
 @override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE, FOO_SCHEDULE])
-class FooScheduleTests(RegistryTestCase):
+class FooScheduleTests(TestCase):
     def test_get_choices_works(self):
         self.assertEqual(
             [choice for choice in registry.get_choices()],
@@ -89,7 +84,7 @@ class FooScheduleTests(RegistryTestCase):
 
 
 @override_settings(DATA_CAPTURE_SCHEDULES=[FAKE_SCHEDULE, FOO_SCHEDULE])
-class SmartLoadFromUploadTests(RegistryTestCase):
+class SmartLoadFromUploadTests(TestCase):
     def test_better_matches_are_found(self):
         p = smart_load_from_upload(FOO_SCHEDULE, uploaded_csv_file())
         self.assertTrue(isinstance(p, FakeSchedulePriceList))

--- a/data_capture/views/price_list_replace.py
+++ b/data_capture/views/price_list_replace.py
@@ -166,7 +166,7 @@ def replace_step_2(request, id, step):
             'uploaded_filename']
 
         price_list.serialized_gleaned_data = json.dumps(
-                registry.serialize(gleaned_data))
+            registry.serialize(gleaned_data))
 
         # delete the old rows
         price_list.rows.all().delete()

--- a/data_capture/views/price_list_upload.py
+++ b/data_capture/views/price_list_upload.py
@@ -241,11 +241,11 @@ def step_3_errors(request):
     return render(request,
                   'data_capture/price_list/step_3_errors.html',
                   step.context({
-                    'form': form,
-                    'gleaned_data': gleaned_data,
-                    'is_preferred_schedule': isinstance(gleaned_data,
-                                                        preferred_schedule),
-                    'preferred_schedule_title': preferred_schedule.title,
+                      'form': form,
+                      'gleaned_data': gleaned_data,
+                      'is_preferred_schedule': isinstance(gleaned_data,
+                                                          preferred_schedule),
+                      'preferred_schedule_title': preferred_schedule.title,
                   }, request))
 
 

--- a/hourglass/changelog.py
+++ b/hourglass/changelog.py
@@ -138,22 +138,18 @@ def bump_version(contents, new_version, date=None):
     new_version_header = '## [{}][] - {}'.format(new_version, date)
     new_unreleased_diff_link = unreleased_diff_link.replace(
         'v' + old_version,
-        'v' + new_version
-        )
+        'v' + new_version)
     new_version_diff_link = '[{}]: {}'.format(
         new_version,
-        unreleased_diff_link.replace('HEAD', 'v' + new_version)
-        )
+        unreleased_diff_link.replace('HEAD', 'v' + new_version))
 
     contents = contents.replace(
         UNRELEASED_HEADER,
-        UNRELEASED_HEADER + '\n\n' + new_version_header
-        )
+        UNRELEASED_HEADER + '\n\n' + new_version_header)
 
     contents = contents.replace(
         unreleased_diff_link,
-        new_unreleased_diff_link + '\n' + new_version_diff_link
-        )
+        new_unreleased_diff_link + '\n' + new_version_diff_link)
 
     return contents
 

--- a/hourglass/tests/test_changelog.py
+++ b/hourglass/tests/test_changelog.py
@@ -61,18 +61,15 @@ class UtilTests(TestCase):
         self.assertEqual(
             changelog.bump_version(self.BEFORE_BUMP, '1.0.1',
                                    datetime.date(2017, 1, 3)),
-            self.AFTER_BUMP
-            )
+            self.AFTER_BUMP)
 
     def test_get_unreleased_notes_works(self):
         self.assertEqual(
             changelog.get_unreleased_notes(self.BEFORE_BUMP).strip(),
-            '- Fixed some stuff.'
-            )
+            '- Fixed some stuff.')
         self.assertEqual(
             changelog.get_unreleased_notes(self.AFTER_BUMP).strip(),
-            ''
-            )
+            '')
 
     def test_replace_heading_leaders_works(self):
         txt = '### h #\n\n## b\n\nbop #'
@@ -84,26 +81,22 @@ class UtilTests(TestCase):
     def test_strip_preamble_includes_unreleased_when_nonempty(self):
         self.assertEqual(
             changelog.strip_preamble('BLARG\n' + self.BEFORE_BUMP)[:10],
-            '## [Unrele'
-            )
+            '## [Unrele')
 
     def test_strip_preamble_removes_unreleased_when_empty(self):
         self.assertEqual(
             changelog.strip_preamble('BLARG\n' + self.AFTER_BUMP)[:10],
-            '## [1.0.1]'
-            )
+            '## [1.0.1]')
 
     def test_release_header_re_matches_unbracketed_version(self):
         self.assertEqual(
             changelog.RELEASE_HEADER_RE.search('## 1.2.3 ').group(1),
-            '1.2.3'
-            )
+            '1.2.3')
 
     def test_release_header_re_matches_bracketed_version(self):
         self.assertEqual(
             changelog.RELEASE_HEADER_RE.search('## [1.2.3][]').group(1),
-            '1.2.3'
-            )
+            '1.2.3')
 
 
 class DjangoViewTests(DjangoTestCase):
@@ -126,14 +119,12 @@ class ChangelogMdTests(TestCase):
         self.assertIn(changelog.UNRELEASED_HEADER, changetext)
         self.assertEqual(
             changelog.get_unreleased_link(changetext),
-            f'{settings.BASE_GITHUB_URL}/compare/v{__version__}...HEAD'
-            )
+            f'{settings.BASE_GITHUB_URL}/compare/v{__version__}...HEAD')
 
     def test_latest_changelog_version_is_current_version(self):
         self.assertEqual(
             changelog.get_latest_release(changetext),
-            __version__
-            )
+            __version__)
 
     def test_changelog_versions_and_dates_are_valid(self):
         version_headers = changesoup.find_all('h2')[1:]

--- a/meta/management/commands/bump_changelog.py
+++ b/meta/management/commands/bump_changelog.py
@@ -31,14 +31,12 @@ def command():
     if new_version <= old_version:
         raise CommandError(
             'Please change hourglass/version.py to reflect the new '
-            'version you\'d like to bump CHANGELOG.md to.'
-            )
+            'version you\'d like to bump CHANGELOG.md to.')
 
     if base_release_notes == '':
         raise CommandError(
             'The new release has no release notes! Please add some '
-            'under the "Unreleased" section of CHANGELOG.md.'
-            )
+            'under the "Unreleased" section of CHANGELOG.md.')
 
     click.echo('Modifying CHANGELOG.md to reflect new '
                'release %s.' % new_version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@
 # the same rules as our .flake8 configuration.
 
 ignore = E701
+max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[pep8]
+
+# These instructions are solely for CodeClimate, but should reflect
+# the same rules as our .flake8 configuration.
+
+ignore = E701

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -22,8 +22,7 @@ def post_to_webhook(payload: Dict[str, str]):
     res = requests.post(
         settings.SLACKBOT_WEBHOOK_URL,
         data={'payload': json.dumps(payload)},
-        timeout=TIMEOUT,
-        )
+        timeout=TIMEOUT)
     res.raise_for_status()
 
 


### PR DESCRIPTION
From the beginning of CALC II, we knew that we'd want to support multiple schedules, so we built this into the architecture.  However, the architecture could use a bit more documentation/explanation, so I've added some here, via comments, docstrings, and type annotations.  I've also simplified a few things to make them easier to maintain in the future.

Other notes:

* I went ahead and changed the maximum line length from 80 characters to 100, as per #1818.

* When we first wrote some of this code, we were using python 3.5, not 3.6.  In this PR I've updated some of our type annotations to use [python 3.6 variable annotations](https://docs.python.org/3/whatsnew/3.6.html#pep-526-syntax-for-variable-annotations) instead of `# type:` comments.

* It seems flake8 / pycodestyle doesn't quite have full support for [python 3.6 variable annotations](https://docs.python.org/3/whatsnew/3.6.html#pep-526-syntax-for-variable-annotations) (specifically, the latest version of pycodestyle supports them, but the latest version of flake8 doesn't seem to support the latest version of pycodestyle).  So I disabled a false positive that was being triggered by flake8, which bizarrely made flake8 notice a bunch of other, unrelated PEP8 violations that it wasn't noticing before, for some reason.  So then I had to fix _those_, which muddles this PR up a bit, unfortunately.

* We now use the [`setting_changed`](https://docs.djangoproject.com/en/2.0/ref/signals/#setting-changed) signal to automatically re-populate the schedule registry whenever tests change it via `override_settings()`.  This relieves the tests from having to manually re-initialize the registry, which was annoying to read, hard to remember to do, and confusing to debug if one forgot to do it.
