### PR TITLE
Link to /updates/ from sphinx docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ release-*-instructions.txt
 release-*-instructions.html
 jest/*
 Dockerfile.cloud
-docs/changelog.md
 docs/_build
 docs/static
 data_capture_uploaded_files/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,8 +25,6 @@ html: Makefile
 # wipe out the build directory between rebuilds.
 	rm -rf $(BUILDDIR)
 
-	cp $(ROOTDIR)/CHANGELOG.md $(SOURCEDIR)/changelog.md
-
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Note that $(DJANGODIR) might be a mounted volume, in which case it can't

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Welcome to CALC's developer documentation!
 
    monitoring
    analytics
-   changelog
+   Changelog <https://calc-dev.app.cloud.gov/updates/>
    release
    deploy
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Welcome to CALC's developer documentation!
 
    monitoring
    analytics
-   Changelog <https://calc-dev.app.cloud.gov/updates/>
+   Change log <https://calc-dev.app.cloud.gov/updates/>
    release
    deploy
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,6 @@ const dirs = {
     style: 'frontend/source/sass/',
     scripts: 'frontend/source/js/',
     sphinx: 'docs/',
-    root: './',
   },
   dest: {
     style: {
@@ -51,7 +50,6 @@ const paths = {
   sass: '**/*.scss',
   js: '**/*.@(js|jsx)',
   sphinx: '*.@(md|py|rst)',
-  changelog: 'CHANGELOG.md',
 };
 
 const bundles = {
@@ -141,7 +139,6 @@ gulp.task('build', ['copy-uswds-assets', 'sass', 'js', 'sphinx']);
 gulp.task('watch', ['set-watching', 'copy-uswds-assets', 'sass', 'js', 'sphinx'], () => {
   gulp.watch([
     path.join(dirs.src.sphinx, paths.sphinx),
-    path.join(dirs.src.root, paths.changelog),
   ], ['sphinx']);
   gulp.watch(path.join(dirs.src.style, paths.sass), ['sass']);
 


### PR DESCRIPTION
Linking to `CHANGELOG.md` from the Sphinx docs has always been weird and added complications to our build system (see e.g. #1658).

But I realized that since we have a snazzy version of it at `/updates/` (especially since #1816) so we can just link to that (like we link to `/styleguide/` and `/api/docs/`) instead of doing extra complicated stuff with `CHANGELOG.md`.

Additionally, I _think_ this might resolve some issues I've been having whereby running tests while having `docker-compose up` running in a separate terminal sometimes makes things explode.

Note also that after merging this PR, folks might have a `docs\CHANGELOG.md` file lying around their system that `git status` complains about. This can be deleted.