### PR TITLE
Don't lint as part of JS compilation

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -103,10 +103,6 @@ string), the boolean is true; otherwise, it's false.
   will be sent messages whenever certain kinds of
   [events](../slackbot/signals.py) occur in the app.
 
-* `ESLINT_CHILL_OUT` is a boolean; if true, it will change the behavior
-  of gulp's watch mode such that it doesn't run `eslint` every time a
-  file changes.
-
 * `USE_POLLING` is a boolean; if true, this will force all the watchers
   to use filesystem polling instead of OS notifications, which works
   better with some configurations, such as Windows, VirtualBox, and

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,6 @@ const cleancss = require('gulp-clean-css');
 const concat = require('gulp-concat');
 const sourcemaps = require('gulp-sourcemaps');
 const rename = require('gulp-rename');
-const eslint = require('gulp-eslint');
 const gutil = require('gulp-util');
 const del = require('del');
 const uglify = require('gulp-uglify');
@@ -145,10 +144,6 @@ gulp.task('watch', ['set-watching', 'copy-uswds-assets', 'sass', 'js', 'sphinx']
   ], ['sphinx']);
   gulp.watch(path.join(dirs.src.style, paths.sass), ['sass']);
 
-  if (!('ESLINT_CHILL_OUT' in process.env)) {
-    gulp.watch(path.join(dirs.src.scripts, paths.js), ['lint']);
-  }
-
   // Note: wepback bundles set up their own watch handling
   // so we don't want to re-trigger them here, ref #437
   gulp.watch(path.join(dirs.src.scripts, 'vendor', paths.js), ['js:vendor']);
@@ -188,8 +183,8 @@ gulp.task('sass', () => gulp.src(path.join(dirs.src.style, paths.sass))
   .pipe(sourcemaps.write('./'))
   .pipe(gulp.dest(dirs.dest.style.built)));
 
-// Compile and lint JavaScript sources
-gulp.task('js', ['lint', 'js:vendor', 'js:webpack']);
+// Compile JavaScript sources
+gulp.task('js', ['js:vendor', 'js:webpack']);
 
 gulp.task('js:vendor', vendoredBundles);
 
@@ -205,10 +200,6 @@ gulp.task('js:webpack', () => {
     .pipe(webpackUtil.webpackify({ isWatching, isProd }))
     .pipe(gulp.dest(`${BUILT_FRONTEND_DIR}/js/`));
 });
-
-gulp.task('lint', () => gulp.src(path.join(dirs.src.scripts, paths.js))
-    .pipe(eslint())
-    .pipe(eslint.format()));
 
 // set up a SIGTERM handler for quick graceful exit from docker
 process.on('SIGTERM', () => {

--- a/meta/management/commands/ultratest.py
+++ b/meta/management/commands/ultratest.py
@@ -104,7 +104,7 @@ TestType = namedtuple('TestType', ['name', 'cmd'])
 
 TESTTYPES = [
     TestType(name='flake8', cmd='flake8 .'),
-    TestType(name='eslint', cmd='yarn failable-eslint'),
+    TestType(name='eslint', cmd='yarn eslint'),
     TestType(name='bandit', cmd='bandit -r .'),
     TestType(name='mypy', cmd='mypy .'),
     TestType(name='typescript', cmd='yarn typescript'),

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "gulp": "^3.9.1",
     "gulp-clean-css": "2.3.2",
     "gulp-concat": "^2.6.0",
-    "gulp-eslint": "^3.0.1",
     "gulp-if": "^2.0.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^4.0.1",
@@ -66,8 +65,7 @@
   },
   "scripts": {
     "gulp": "gulp",
-    "eslint": "eslint --ext .jsx --ext .js . || true",
-    "failable-eslint": "eslint --max-warnings 0 --ext .jsx --ext .js .",
+    "eslint": "eslint --max-warnings 0 --ext .jsx --ext .js .",
     "typescript": "tsc",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,12 +1524,6 @@ buffer@^4.1.0, buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-bufferstreams@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/bufferstreams/-/bufferstreams-1.1.1.tgz#0161373060ac5988eff99058731114f6e195d51e"
-  dependencies:
-    readable-stream "^2.0.2"
-
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -2843,7 +2837,7 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^3.0.0, eslint@^3.13.0:
+eslint@^3.13.0:
   version "3.16.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.16.1.tgz#9bc31fc7341692cf772e80607508f67d711c5609"
   dependencies:
@@ -3661,14 +3655,6 @@ gulp-concat@^2.6.0:
     through2 "^2.0.0"
     vinyl "^2.0.0"
 
-gulp-eslint@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/gulp-eslint/-/gulp-eslint-3.0.1.tgz#04e57e3e18c6974267c12cf6855dc717d4a313bd"
-  dependencies:
-    bufferstreams "^1.1.1"
-    eslint "^3.0.0"
-    gulp-util "^3.0.6"
-
 gulp-if@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/gulp-if/-/gulp-if-2.0.2.tgz#a497b7e7573005041caa2bc8b7dda3c80444d629"
@@ -3722,7 +3708,7 @@ gulp-uglify@^3.0.0:
     uglify-js "^3.0.5"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-util@^3.0.0, gulp-util@^3.0.6, gulp-util@^3.0.7:
+gulp-util@^3.0.0, gulp-util@^3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:


### PR DESCRIPTION
In the spirit of [aggressively rolling back eslint](https://github.com/18F/calc/pull/1852), this disables eslint when compiling JS, for the reasons outlined in #1511.  If folks want to see live eslint feedback during development, it's better for them to use an editor plugin than wait upwards of 10 seconds for gulp to annoy them. Note that `ultratest` _does_ still run eslint, so it's still part of our test suite.

I believe this also shaves a few seconds off our test suite, because until now we were actually running eslint _twice_: once during compilation of the JS, and again during a separate linting phase.