### PR TITLE
Allow fullpage examples to use template tags, optionally hide their HTML

### DIFF
--- a/styleguide/fullpage_example.py
+++ b/styleguide/fullpage_example.py
@@ -1,4 +1,6 @@
+import re
 from pathlib import Path
+from typing import Optional
 from django.utils.safestring import SafeString
 from django.shortcuts import render
 from django.urls import reverse
@@ -7,31 +9,52 @@ from django.http import Http404
 
 MY_DIR = Path(__file__).parent.resolve()
 
-EXAMPLES_DIR = MY_DIR / 'templates' / 'styleguide_fullpage_examples'
+EXAMPLES_DIRNAME = 'styleguide_fullpage_examples'
 
+EXAMPLES_DIR = MY_DIR / 'templates' / EXAMPLES_DIRNAME
+
+# We need to be careful to make this regular expression for
+# example names very restrictive, because we use the name
+# as part of file paths; so we don't e.g. want to allow
+# periods or dashes.
 REGEX = r'([0-9A-Za-z_\-]+)'
 
+# Code in full-page examples between BEGIN_SNIPPET and END_SNIPPET
+# will be treated as the HTML source of the example, for display
+# in the style guide. If they're not found in the example, then
+# the entire contents of the example will be used.
+BEGIN_SNIPPET = r'{# BEGIN SNIPPET #}'
 
-def to_path(name):
+END_SNIPPET = r'{# END SNIPPET #}'
+
+SNIPPET_RE = re.compile(
+    r'.*' + BEGIN_SNIPPET + r'\n(.*)' + END_SNIPPET + r'.*',
+    re.MULTILINE | re.DOTALL)
+
+
+def to_path(name: str) -> Path:
     return EXAMPLES_DIR / f'{name}.html'
 
 
-def get_html_source(name):
-    return SafeString(to_path(name).read_text())
+def _get_snippet(text: str) -> Optional[str]:
+    match = SNIPPET_RE.match(text)
+    return match.group(1) if match else None
 
 
-def get_url(name):
+def get_html_source(name: str) -> SafeString:
+    text = to_path(name).read_text()
+    return SafeString(_get_snippet(text) or text)
+
+
+def get_url(name: str) -> str:
     return reverse('styleguide:fullpage_example', args=(name,))
 
 
-def exists(name):
+def exists(name: str) -> bool:
     return to_path(name).exists()
 
 
-def view(request, name):
+def view(request, name: str):
     if not exists(name):
         raise Http404("fullpage example does not exist")
-    html = get_html_source(name)
-    return render(request, 'styleguide_fullpage_example.html', {
-        'html': html,
-    })
+    return render(request, f'{EXAMPLES_DIRNAME}/{name}.html')

--- a/styleguide/templates/styleguide_fullpage_example.html
+++ b/styleguide/templates/styleguide_fullpage_example.html
@@ -5,5 +5,5 @@
     {% load staticfiles %}
     <link rel="stylesheet" href="{% static 'frontend/built/style/main.min.css' %}"/>
   </head>
-{{ html }}
+  {% block body %}{% endblock %}
 </html>

--- a/styleguide/templates/styleguide_fullpage_example_iframe.html
+++ b/styleguide/templates/styleguide_fullpage_example_iframe.html
@@ -8,5 +8,7 @@
       <iframe src="{{ url }}" class="fullpage-example" title="{{ title }}"></iframe>
     </div>
   </div>
+  {% if show_html %}
   <pre><code class="language-html">{% filter force_escape %}{{ html }}{% endfilter %}</pre></code>
+  {% endif %}
 </div>

--- a/styleguide/templates/styleguide_fullpage_examples/card-collapse-header.html
+++ b/styleguide/templates/styleguide_fullpage_examples/card-collapse-header.html
@@ -1,3 +1,7 @@
+{% extends "styleguide_fullpage_example.html" %}
+
+{% block body %}
+{# BEGIN SNIPPET #}
 <body>
   <main class="card--collapse-header">
     <div class="container">
@@ -15,3 +19,5 @@
     </div>
   </main>
 </body>
+{# END SNIPPET #}
+{% endblock %}

--- a/styleguide/templates/styleguide_fullpage_examples/card-footer.html
+++ b/styleguide/templates/styleguide_fullpage_examples/card-footer.html
@@ -1,3 +1,7 @@
+{% extends "styleguide_fullpage_example.html" %}
+
+{% block body %}
+{# BEGIN SNIPPET #}
 <body>
   <main>
     <div class="container">
@@ -18,3 +22,5 @@
     </div>
   </main>
 </body>
+{# END SNIPPET #}
+{% endblock %}

--- a/styleguide/templates/styleguide_fullpage_examples/card-skinny.html
+++ b/styleguide/templates/styleguide_fullpage_examples/card-skinny.html
@@ -1,3 +1,7 @@
+{% extends "styleguide_fullpage_example.html" %}
+
+{% block body %}
+{# BEGIN SNIPPET #}
 <body class="content--skinny">
   <main>
     <div class="container">
@@ -15,3 +19,5 @@
     </div>
   </main>
 </body>
+{# END SNIPPET #}
+{% endblock %}

--- a/styleguide/templates/styleguide_fullpage_examples/card.html
+++ b/styleguide/templates/styleguide_fullpage_examples/card.html
@@ -1,3 +1,7 @@
+{% extends "styleguide_fullpage_example.html" %}
+
+{% block body %}
+{# BEGIN SNIPPET #}
 <body>
   <main>
     <div class="container">
@@ -15,3 +19,5 @@
     </div>
   </main>
 </body>
+{# END SNIPPET #}
+{% endblock %}

--- a/styleguide/templatetags/styleguide.py
+++ b/styleguide/templatetags/styleguide.py
@@ -237,16 +237,20 @@ def pathname(name):
 
 
 @register.simple_tag(takes_context=True)
-def fullpage_example(context, name):
+def fullpage_example(context, name, show_html=True):
     t = context.template.engine.get_template(
         'styleguide_fullpage_example_iframe.html')
     url = _fullpage_example.get_url(name)
     title = f"Example for {name}"
-    html = _fullpage_example.get_html_source(name)
+    if show_html:
+        html = _fullpage_example.get_html_source(name)
+    else:
+        html = ''
     return t.render(template.Context({
         'url': url,
         'html': html,
-        'title': title
+        'title': title,
+        'show_html': show_html,
     }))
 
 

--- a/styleguide/tests.py
+++ b/styleguide/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, SimpleTestCase
 from django.template import engines
 
-from styleguide import email_examples
+from styleguide import email_examples, fullpage_example
 from styleguide.templatetags.styleguide import (
     template_tag_library,
     github_url_for_path,
@@ -47,6 +47,12 @@ class FullpageExampleTests(TestCase):
     def test_returns_404_if_name_is_invalid(self):
         response = self.client.get('/styleguide/fullpage-example/lololol')
         self.assertEqual(response.status_code, 404)
+
+    def test_get_snippet_works(self):
+        self.assertEqual(fullpage_example._get_snippet(
+            'foo\n{# BEGIN SNIPPET #}\nblarg\n{# END SNIPPET #}\nbar'
+        ), 'blarg\n')
+        self.assertEqual(fullpage_example._get_snippet('flarg'), None)
 
 
 class TemplateTagsTests(SimpleTestCase):


### PR DESCRIPTION
This enhances the full-page examples in the style guide:

* They can now use template tags. However, in order to accomplish this, I had to make the files in `styleguide/templates/styleguide_fullpage_examples` regular templates, rather than purely HTML files (which actually makes more sense, since they are in the `templates` directory). A full-page example that once contained this HTML:

  ```html
  <p>boop</p>
  ```

  now looks like this:

  ```html
  {% extends "styleguide_fullpage_example.html" %}

  {% block body %}
  {# BEGIN SNIPPET #}
  <p>boop</p>
  {# END SNIPPET #}
  {% endblock %}
  ```

  This certainly looks less readable, but it's also more powerful. The `{# BEGIN SNIPPET #}` and `{# END SNIPPET #}` tell the styleguide where the beginning of the HTML source it should show to readers is (if they're not found, the whole file is used).

  I considered having it just find `{% block body %}` and `{% endblock %}` instead, but I thought this (A) made things seem a bit too magical and (B) made the system less flexible. But we can change it to that, or something else, if this looks too gross.

* The HTML source code of a snippet can optionally be hidden from readers entirely. This can be done by adding `show_html=False` to the `{% fullpage_example %}` template tag, e.g.:

  ```
  {% fullpage_example "card" show_html=False %}
  ```
