### PR TITLE
Add continuous integration docs, simplify code climate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,20 +1,5 @@
 ---
 version: 2
-plugins:
-  eslint:
-    enabled: true
-    channel: "eslint-3"
-    checks:
-      import/no-unresolved:
-        enabled: false
-      import/extensions:
-        enabled: false
-    config:
-      extensions:
-      - .js
-      - .jsx
-  pep8:
-    enabled: true
 
 exclude_patterns:
 - "frontend/source/js/vendor/*"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,12 +1,11 @@
 ## Continuous integration
 
-CALC uses a number of third-party services to ensure that its code quality
-is not so bad.
+CALC uses a number of third-party services to ensure consistent code quality.
 
 ### CircleCI
 
-[CircleCI][] is used to ensure that all tests still pass as CALC's codebase
-changes. Its configuration is stored in [.circleci/config.yml][].
+[CircleCI][] ensures that, when CALC's codebase changes, all tests still pass.
+Its configuration is stored in [.circleci/config.yml][].
 
 Aside from running tests, CircleCI is also used to automatically deploy
 CALC; see the [Release process](release.md) documentation for further
@@ -16,7 +15,7 @@ Finally, CircleCI is also used for some [monitoring](monitoring.md) tasks.
 
 #### Disabling tests
 
-Because test passing on CircleCI blocks deployment, it's important to
+Because a single failing test on CircleCI blocks deployment, it's important to
 know how to disable some of them in emergencies. In particular:
 
 * Selenium has a history of acting up on CI and sometimes needs

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,46 @@
+## Continuous integration
+
+CALC uses a number of third-party services to ensure that its code quality
+is not so bad.
+
+### CircleCI
+
+[CircleCI][] is used to ensure that all tests still pass as CALC's codebase
+changes. Its configuration is stored in [.circleci/config.yml][].
+
+Aside from running tests, CircleCI is also used to automatically deploy
+CALC; see the [Release process](release.md) documentation for further
+details.
+
+Finally, CircleCI is also used for some [monitoring](monitoring.md) tasks.
+
+#### Disabling tests
+
+Because test passing on CircleCI blocks deployment, it's important to
+know how to disable some of them in emergencies. In particular:
+
+* Selenium has a history of acting up on CI and sometimes needs
+  to be disabled outright. See [commit 191f5789a8](https://github.com/18F/calc/commit/191f5789a8f477f493552ef9046baab0e4fb0c02)
+  for an example of how to do this.
+
+* CALC uses a number of static analysis tools to ensure that its
+  code works as expected. However, in the case that any of them
+  ever cause trouble whose causes can't be diagnosed, they can
+  be disabled during CI: in [.circleci/config.yml][], search for
+  `ultratest` and remove any of the arguments that are triggering
+  failures.
+
+### Code Climate
+
+[Code Climate][] is used to ensure that CALC's code stays maintainable,
+and that test coverage across our Python and JavaScript source
+generally doesn't go down.
+
+Its configuration is located in [.codeclimate.yml](../.codeclimate.yml).
+
+Its checks are largely advisory, however. Sometimes false positives
+are triggered and need to be silenced via its admin interface.
+
+[CircleCI]: https://circleci.com/gh/18F/calc
+[Code Climate]: https://codeclimate.com/github/18F/calc
+[.circleci/config.yml]: ../.circleci/config.yml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Welcome to CALC's developer documentation!
 
    monitoring
    analytics
+   ci
    Change log <https://calc-dev.app.cloud.gov/updates/>
    release
    deploy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[pep8]
-
-# These instructions are solely for CodeClimate, but should reflect
-# the same rules as our .flake8 configuration.
-
-ignore = E701
-max-line-length = 100


### PR DESCRIPTION
This adds documentation for our continuous integration tools, CircleCI and Code Climate.

(Ok, technically Code Climate might not be a CI tool, I'm not sure, but for our purposes I'm treating any of the third-party services listed under the "checks" section of our GitHub PRs to be CI tools.)

This also fixes #1839 by documenting how to disable some of CALC's funky tests.

It also simplifies our Code Climate configuration by:

* Removing `pep8`. This was originally added in #322, before `ultratest` existed. But once `ultratest` was added in #379, running the linter on CC became redundant.

  Not only that, it actually uses a subtly different command-line tool than we do--and one that is more out-of-date than ours--which makes it hard to anticipate or reproduce its errors locally.

  As if that wasn't enough, CC's pep8 config is also stored in a different file than the one we use, which means we need to manually ensure that both configurations stay in-sync.

* Removing `eslint`. This was added way back in https://github.com/vzvenyach/calc-fork/pull/1 (by Dave Z, who I didn't even know worked on CALC). Once `ultratest` was added this became redundant too.

  It potentially uses a different version of eslint than we use, which bit us in the past with #403, so we might as well just disable it to ensure this kind of thing doesn't happen again in the future.
