### PR TITLE
Fix button active states

### DIFF
--- a/frontend/source/sass/components/_buttons.scss
+++ b/frontend/source/sass/components/_buttons.scss
@@ -114,4 +114,7 @@ input.usa-button-link[type="button"] {
     background-color: $color-green;
     box-shadow: none;
   }
+  &:active {
+    background-color: $color-green;
+  }
 }

--- a/frontend/source/sass/components/_buttons.scss
+++ b/frontend/source/sass/components/_buttons.scss
@@ -112,6 +112,7 @@ input.usa-button-link[type="button"] {
   &:active,
   &.usa-button-active {
     color: $color-primary-darker;
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
Against #1905, not develop

Closes #1952 for link buttons.

I also noticed that active states for secondary buttons is off. @ericronne, should I fix this while I'm at it?
<img width="280" alt="screen shot 2018-05-23 at 4 34 48 pm" src="https://user-images.githubusercontent.com/509309/40454751-42ca356e-5ea7-11e8-8b45-11e042fe3f00.png">
