### PR TITLE
Step indicator er visual tweaks

### DIFF
--- a/frontend/source/sass/components/_steps.scss
+++ b/frontend/source/sass/components/_steps.scss
@@ -47,24 +47,24 @@ ol.step-bar__bubbles {
 
   li {
     list-style: none;
-    border-top: 2px solid $color-gray-lighter;
+    border-top: 3px solid $color-gray-lighter;
     padding-top: 14px;
     position: relative;
     float: left;
     width: 46px; // width of :before psuedoclass + $space-3x (22px + 24px)
 
     a {
-      width: 2.2rem;
-      height: 2.2rem;
+      width: 2.6rem;
+      height: 2.6rem;
       display: inline-block;
-      padding: 0;
+      padding-top: .1rem;
       position: absolute;
       top: -12px;
       left: 0px;
       background-color: $color-gray-lighter;
       color: $color-gray-dark;
       border-radius: 30px;
-      border: 2px solid $color-gray-lighter;
+      border: 3px solid $color-gray-lighter;
       text-align: center;
       font-size: 80%;
       font-weight: 700;
@@ -79,7 +79,7 @@ ol.step-bar__bubbles {
 
     a:hover,
     &.current a:hover {
-      background-color: $color-white;
+      background-color: $color-gray-lighter;
       border-color: $color-gray-lighter;
       color: $color-gray-dark;
       &::before {

--- a/frontend/source/sass/components/_steps.scss
+++ b/frontend/source/sass/components/_steps.scss
@@ -11,6 +11,11 @@ ol.step-bar__bubbles li.current a {
   &::before {
     content: counter(li);
   }
+  &:hover {
+    background-color: $color-green-light;
+    border-color: $color-green-light;
+    color: $color-base;
+  }
 }
 
 ol.step-bar__labels {
@@ -51,7 +56,7 @@ ol.step-bar__bubbles {
     padding-top: 14px;
     position: relative;
     float: left;
-    width: 46px; // width of :before psuedoclass + $space-3x (22px + 24px)
+    width: 38px; // width of :before psuedoclass + $space-2x (22px + 16px)
 
     a {
       width: 2.6rem;
@@ -92,6 +97,9 @@ ol.step-bar__bubbles {
       color: $color-gray-dark;
       &::before {
         content: counter(li);
+      }
+      &:hover {
+        background-color: $color-gray-lighter;
       }
     }
 


### PR DESCRIPTION
Makes a few visual adjustments to the step indicator. Items best handled by the likes of @hbillings include:
- [ ] Current should remain green on hover (line 14 begins my attempt here; only works if i add !important; guessing it's a specificity thing; seems it could be added to the list in line 6, but my try at that dint work :/ )
- Connecting rule is too high
- Checkmark is a little high in the circle