### PR TITLE
Give data explorer table more room to breathe

### DIFF
--- a/data_explorer/templates/index.html
+++ b/data_explorer/templates/index.html
@@ -33,7 +33,7 @@
 {% endblock header_extension %}
 
 {% block body %}
-<div data-embed-jsx-app-here class="card">
+<div data-embed-jsx-app-here style="background-color: #fff; border-bottom-color: #c5d6de; margin-bottom: 8rem;">
   <div class="content">
     <noscript>
       Please enable JavaScript to use this page's functionality.

--- a/frontend/source/js/data-explorer/components/app.jsx
+++ b/frontend/source/js/data-explorer/components/app.jsx
@@ -91,7 +91,7 @@ class App extends React.Component {
       >
         <TitleTagSynchronizer />
         <section className="search">
-          <div className="container">
+          <div className="container clearfix">
             <p className="help-text">
               Enter your search terms below, separated by commas.
               {' '}

--- a/frontend/source/sass/data_explorer.scss
+++ b/frontend/source/sass/data_explorer.scss
@@ -9,6 +9,12 @@ body {
   background-color: $color-gray-lighter; //override to steps.scss
 }
 
+// temp styles to mimic .card without indenting the table
+section.search,
+.results .container .row:first-child {
+  margin-left: $space-3x;
+}
+
 // to fake selection of home link
 nav li:first-child {
   border-bottom: $space-1x solid $color-green-bright;


### PR DESCRIPTION
Closes #1764.

After playing around with a few things, I think the best way to do this is to remove the `.card` classes from the data explorer for now and simply write similar styles that behave the way we want them to. There's a little inline CSS on the index page now to mimic the card look, which I think is OK because we don't want to encourage use of this elsewhere and we want to rewrite a bunch of this anyhow.