### PR TITLE
Upgrade d3-timer to 1.0.7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "d3-format": "^1.0.2",
     "d3-scale": "^1.0.4",
     "d3-selection": "^1.0.4",
+    "d3-timer": "1",
     "d3-transition": "^1.0.3",
     "del": "^2.2.1",
     "document-register-element": "^1.0.0",
@@ -86,7 +87,9 @@
     "npm": ">=3.10.0"
   },
   "jest": {
-    "roots": ["frontend"],
+    "roots": [
+      "frontend"
+    ],
     "collectCoverage": true,
     "coverageReporters": [
       "lcov",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,8 +2194,8 @@ d3-time@1:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.6.tgz#a55b13d7d15d3a160ae91708232e0835f1d5e945"
 
 d3-timer@1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.5.tgz#b266d476c71b0d269e7ac5f352b410a3b6fe6ef0"
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.7.tgz#df9650ca587f6c96607ff4e60cc38229e8dd8531"
 
 d3-transition@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
Fixes #1976.

So the problem responsible for #1976 was fixed by https://github.com/d3/d3-timer/pull/23.

A challenge here is that we don't use that package, d3-timer, directly; we use d3-transition, which specifies that it needs `d3-timer@1`, which I think means "anything that is version 1".  Until now it was using 1.0.5, which does not include the aforementioned PR.

This PR is the result of running `yarn upgrade d3-timer@1`, which changes the version of d3-timer used by d3-transition. Apparently it also adds d3-timer to our `package.json` too, I guess.
