### PR TITLE
Fix accessibility regressions

### DIFF
--- a/frontend/source/sass/components/_inputs.scss
+++ b/frontend/source/sass/components/_inputs.scss
@@ -10,6 +10,11 @@ input[type="radio"] + label {
   margin-top: 0;
 }
 
+input[type="radio"]:focus + label::before,
+input[type="checkbox"]:focus + label::before {
+  @include focus-color($bg-color: "light-color");
+}
+
 label {
   font-weight: 700;
   margin-top: 0;

--- a/frontend/source/sass/data_explorer.scss
+++ b/frontend/source/sass/data_explorer.scss
@@ -223,6 +223,9 @@ dl.dropdown {
     line-height: 24px;
     overflow: hidden;
     padding: 6px 10px;
+    &:focus {
+      outline: #2d4d59 dotted 2px;
+    }
   }
   span.value {
     display:none;
@@ -585,7 +588,7 @@ label.radio {
 }
 
 label.checkbox :checked + span {
-  background-color: $color-blue-dark;
+  background-color: $color-blue-darker;
   box-shadow: 0 0 0 0 $color-white;
   position: relative;
   &:after {
@@ -599,7 +602,7 @@ label.checkbox :checked + span {
 }
 
 label.radio :checked + span {
-  background-color: $color-blue-dark;
+  background-color: $color-blue-darker;
   color: $color-white;
   position: relative;
 }
@@ -633,6 +636,11 @@ label.radio :checked + span {
 .checkbox-focus {
   background-color: $color-white;
   padding: 1px 8px;
+}
+
+input[type=radio]:focus+.checkbox-focus,
+input[type=checkbox]:focus+.checkbox-focus {
+  outline: #2d4d59 dotted 2px;
 }
 
 .contract-list-item {


### PR DESCRIPTION
Closes #1975.

- Fixes focus ring on tab around Education button.
- Adds back focus on contract year. Note that this is funky because the markup here is _super_ odd.
On click it looks like:
<img width="202" alt="screen shot 2018-05-30 at 1 54 06 pm" src="https://user-images.githubusercontent.com/509309/40744147-f3800d70-6410-11e8-95f2-31fd42ccfdf6.png">
But on tab it looks like:
<img width="200" alt="screen shot 2018-05-30 at 1 53 52 pm" src="https://user-images.githubusercontent.com/509309/40744179-0aa19d8e-6411-11e8-9758-e5f8423f096a.png">
This is because it's actually two different elements getting focus at different points, and I don't know how to reconcile the styles. >_<


To do:
- [x] Fix focus ring color around radio buttons
- [x] Fix focus ring color on education level checkboxes

Not doing:
- Fixing the tab focus on the slider handles. Because this is a component we're rendering from a library, we don't have much control over it, and nothing I've tried (mostly around `tabindex`) manages to take it out of the tab flow.