### PR TITLE
Fixes color of selected filter options

### DIFF
--- a/frontend/source/sass/data_explorer.scss
+++ b/frontend/source/sass/data_explorer.scss
@@ -588,7 +588,7 @@ label.radio {
 }
 
 label.checkbox :checked + span {
-  background-color: $color-blue-darker;
+  background-color: $color-blue-dark;
   box-shadow: 0 0 0 0 $color-white;
   position: relative;
   &:after {
@@ -602,7 +602,7 @@ label.checkbox :checked + span {
 }
 
 label.radio :checked + span {
-  background-color: $color-blue-darker;
+  background-color: $color-blue-dark;
   color: $color-white;
   position: relative;
 }


### PR DESCRIPTION
Was `$color-blue-darker`, should've been `$color-blue-dark`

![image](https://user-images.githubusercontent.com/9259185/40802292-d00745dc-64da-11e8-9806-3b794ad86fe7.png)
