### PR TITLE
[BLOCKED ON DESIGN STUDIO] Add Contracts.objects.get_schedule_stats().

### DIFF
--- a/contracts/models.py
+++ b/contracts/models.py
@@ -92,8 +92,8 @@ class ScheduleStats(NamedTuple):
     # The following fields represent that earliest and latest
     # known date of a schedule being updated. If no date is known,
     # however, these values can be None.
-    earliest_update: Optional[datetime]
-    latest_update: Optional[datetime]
+    earliest_update: Optional[datetime] = None
+    latest_update: Optional[datetime] = None
 
 
 class CurrentContractManager(models.Manager):

--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -91,8 +91,10 @@ class ScheduleUpdateInfoTests(TestCase):
             schedule='MOBIS', idv_piid='b', upload_source=mar_source)
 
         self.assertEqual(Contract.objects.get_schedule_stats(), [
-            ScheduleStats('Consolidated', 1, 1, None, None),
-            ScheduleStats('MOBIS', 3, 2, feb_source.updated_at, mar_source.updated_at),
+            ScheduleStats('Consolidated', labor_rates=1, contracts=1),
+            ScheduleStats('MOBIS', labor_rates=3, contracts=2,
+                          earliest_update=feb_source.updated_at,
+                          latest_update=mar_source.updated_at),
         ])
 
 

--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -10,7 +10,7 @@ from contracts.mommy_recipes import get_contract_recipe
 
 from ..models import (
     Contract, convert_to_tsquery, CashField, BulkUploadContractSource,
-    ScheduleUpdateInfo
+    ScheduleStats
 )
 
 
@@ -84,15 +84,15 @@ class ScheduleUpdateInfoTests(TestCase):
         get_contract_recipe().make(
             schedule='Consolidated', upload_source=None)
         get_contract_recipe().make(
-            schedule='MOBIS', upload_source=None)
+            schedule='MOBIS', idv_piid='a', upload_source=None)
         get_contract_recipe().make(
-            schedule='MOBIS', upload_source=feb_source)
+            schedule='MOBIS', idv_piid='b', upload_source=feb_source)
         get_contract_recipe().make(
-            schedule='MOBIS', upload_source=mar_source)
+            schedule='MOBIS', idv_piid='b', upload_source=mar_source)
 
-        self.assertEqual(Contract.objects.get_schedule_update_info(), [
-            ScheduleUpdateInfo('Consolidated', None, None),
-            ScheduleUpdateInfo('MOBIS', feb_source.updated_at, mar_source.updated_at),
+        self.assertEqual(Contract.objects.get_schedule_stats(), [
+            ScheduleStats('Consolidated', 1, 1, None, None),
+            ScheduleStats('MOBIS', 3, 2, feb_source.updated_at, mar_source.updated_at),
         ])
 
 

--- a/contracts/tests/test_contract.py
+++ b/contracts/tests/test_contract.py
@@ -59,7 +59,7 @@ class NormalizeLaborCategoryTests(SimpleTestCase):
         self.assertEqual(_normalize('JR. PERSON'), 'junior person')
 
 
-class ScheduleUpdateInfoTests(TestCase):
+class ScheduleStatsTests(TestCase):
     def make_upload_source(self, year, month):
         source = BulkUploadContractSource(
             has_been_loaded=True,


### PR DESCRIPTION
This adds a ~~`ScheduleUpdateInfo`~~ `ScheduleStats` named tuple along with a ~~`get_schedule_update_info()`~~ `get_schedule_stats()` method on our `CurrentContractManager` class that allows us to easily get information about when a schedule was last updated, how many contracts it has, and how many labor rates are in those contracts.

In the future, this can be used to determine how current CALC's data is (see #1836), perhaps via a data quality report or some other mechanism.

## Notes

* I could have just had `get_schedule_stats()` return a `dict`, but then I would have had to document what was in the dict, and it felt easier to simply create a self-documenting `NamedTuple` instead.  This is both more convenient, as we can use standard attributes rather than dictionary lookups (e.g. `info.schedule` instead of `info['schedule']`), and it also provides mypy with more type annotations, which can lead to more type-safe code.
