### PR TITLE
Install django-uswds-forms via PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ Markdown==2.6.8
 cg-django-uaa==1.3.0
 semantic_version==2.6.0
 coreapi==2.3.3
-git+git://github.com/18F/django-uswds-forms@6c2054a8e532bc417f9aa8ac4d744138eaebef3f
+django-uswds-forms==1.0.0


### PR DESCRIPTION
I recently published django-uswds-forms to PyPI, so this modifies our `requirements.txt` to install it from there, rather than via git.  It's the exact same code (only some documentation has changed).