### PR TITLE
Fix ga.trackInterestingLink() on IE11

### DIFF
--- a/frontend/source/js/common/ga.js
+++ b/frontend/source/js/common/ga.js
@@ -94,9 +94,11 @@ function trackInterestingLink(el) {
     return;
   }
 
-  // Anchors on most modern browsers actually have properties on
-  // them that contain parsed values of the URLs, but not IE11,
-  // so we're going to parse the URL manually.
+  // The 'host' and 'hostname' properties on IE11 are
+  // unreliable, so we'll parse the URL manually.
+  //
+  // For more details, see:
+  // https://github.com/18F/calc/pull/2007#discussion_r195593715
   const { pathname, host, hostname } = urlParse(el.href);
 
   if (!(pathname && host && hostname)) {

--- a/frontend/source/js/tests/ga_tests.js
+++ b/frontend/source/js/tests/ga_tests.js
@@ -88,11 +88,16 @@ QUnit.test('autoTrackInterestingLinks() works', (assert) => {
     window.ga = (...args) => {
       log.push(args);
     };
-    a.dispatchEvent(new MouseEvent('click', {
-      view: window,
-      bubbles: true,
-      cancelable: true
-    }));
+
+    // There's an easier way to synthesize this event, but
+    // this is the only way that works on IE11.
+    const event = document.createEvent("MouseEvent");
+    event.initMouseEvent(
+      'click', true, true, window,
+      0, 0, 0, 0, 0, false, false, false, false, 1, null
+    );
+
+    a.dispatchEvent(event);
     assert.deepEqual(log, expectedLog, msg);
   }
 


### PR DESCRIPTION
Fixes #2005, explanations are in the comments of the PR.