### PR TITLE
Fixlocal frontend file watching

### DIFF
--- a/frontend/gulp/webpack-util.js
+++ b/frontend/gulp/webpack-util.js
@@ -23,7 +23,7 @@ exports.getLastFolderName = (file) => {
   return lastFolderName;
 };
 
-exports.webpackify = ({ isWatching, isProd }) => webpackStream({
+exports.webpackify = ({ isWatching, isProd }, cb, taskNum) => webpackStream({
   mode: isProd ? 'production' : 'development',
   watch: isWatching,
   watchOptions: USE_POLLING ? {
@@ -65,4 +65,11 @@ exports.webpackify = ({ isWatching, isProd }) => webpackStream({
     chunkFilename: '[name].bundle.js',
     publicPath: '/static/frontend/built/js/',
   },
-}, webpack);
+}, webpack, (err, stats) => {
+  // Only execute this callback the first time, so that gulp knows
+  // we're done.
+  if (taskNum === 1) {
+    cb();
+  }
+  taskNum++; // Increment the task counter
+});

--- a/frontend/gulp/webpack-util.js
+++ b/frontend/gulp/webpack-util.js
@@ -65,7 +65,7 @@ exports.webpackify = ({ isWatching, isProd }, cb, taskNum) => webpackStream({
     chunkFilename: '[name].bundle.js',
     publicPath: '/static/frontend/built/js/',
   },
-}, webpack, (err, stats) => {
+}, webpack, () => {
   // Only execute this callback the first time, so that gulp knows
   // we're done.
   if (taskNum === 1) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,9 +137,11 @@ gulp.task('clean', () => {
 });
 
 // boolean flag to indicate to webpack that it should set up its watching
+var taskNum = 1;
 let isWatching = false;
-gulp.task('set-watching', () => {
+gulp.task('set-watching', (done) => {
   isWatching = true;
+  done();
 });
 
 // compile SASS sources
@@ -161,11 +163,11 @@ gulp.task('sass', () => gulp.src(path.join(dirs.src.style, paths.sass))
 
 gulp.task('js:vendor', gulp.series(vendoredBundles));
 
-gulp.task('js:webpack', () => gulp.src(
+gulp.task('js:webpack', (done) => gulp.src(
   webpackUtil.scriptSources({ bundles, rootDir: dirs.src.scripts })
 )
   .pipe(named(webpackUtil.getLastFolderName))
-  .pipe(webpackUtil.webpackify({ isWatching, isProd }))
+  .pipe(webpackUtil.webpackify({ isWatching, isProd }, done, taskNum))
   .pipe(gulp.dest(`${BUILT_FRONTEND_DIR}/js/`)));
 
 // Compile JavaScript sources
@@ -177,22 +179,22 @@ gulp.task('js', gulp.parallel('js:vendor', 'js:webpack'));
 gulp.task('build', gulp.series('copy-uswds-assets', 'sass', 'js', 'sphinx'));
 
 // watch files for changes
-gulp.task('watch', gulp.parallel('set-watching', 'copy-uswds-assets', 'sass', 'js', 'sphinx'), () => {
+gulp.task('watch', gulp.series('set-watching', gulp.parallel('copy-uswds-assets', 'sass', 'js', 'sphinx'), () => {
   gulp.watch([
     path.join(dirs.src.sphinx, paths.sphinx),
-  ], ['sphinx']);
-  gulp.watch(path.join(dirs.src.style, paths.sass), ['sass']);
+  ], gulp.series('sphinx'));
+  gulp.watch(path.join(dirs.src.style, paths.sass), gulp.series('sass'));
 
   // Note: wepback bundles set up their own watch handling
   // so we don't want to re-trigger them here, ref #437
-  gulp.watch(path.join(dirs.src.scripts, 'vendor', paths.js), ['js:vendor']);
+  gulp.watch(path.join(dirs.src.scripts, 'vendor', paths.js), gulp.series('js:vendor'));
 
   const calcURL = `http://localhost:${process.env.DOCKER_EXPOSED_PORT}`;
 
   gutil.log("-----------------------------------------");
   gutil.log(`Visit your CALC at: ${calcURL}`);
   gutil.log("-----------------------------------------");
-});
+}));
 
 // default task
 // running `gulp` will default to watching and dist'ing files

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,7 @@ gulp.task('clean', () => {
 });
 
 // boolean flag to indicate to webpack that it should set up its watching
-var taskNum = 1;
+let taskNum = 1; // eslint-disable-line prefer-const
 let isWatching = false;
 gulp.task('set-watching', (done) => {
   isWatching = true;
@@ -163,7 +163,7 @@ gulp.task('sass', () => gulp.src(path.join(dirs.src.style, paths.sass))
 
 gulp.task('js:vendor', gulp.series(vendoredBundles));
 
-gulp.task('js:webpack', (done) => gulp.src(
+gulp.task('js:webpack', done => gulp.src(
   webpackUtil.scriptSources({ bundles, rootDir: dirs.src.scripts })
 )
   .pipe(named(webpackUtil.getLastFolderName))


### PR DESCRIPTION
We must be watchful.
But who watches the watchmen?
It's complicated…

Fix for #2087.

This turned out not to be simply that the SASS files weren't being watched, but also that the `gulp` build wasn't entirely finishing, as could be seen by the lack of the `Visit your CALC at:` line in the console output.

(Problems listed in order of discovery.)

**Problem 1**: The second argument to `gulp.watch` now has to be a function, not an array of function names.

Fixed by making `gulp.watch` invocations use `gulp.series` and/or `gulp.parallel`.

**Problem 2**: Putting the `set-watching` task in the set of arguments to `gulp.parallel` meant that it didn't finish executing first, which seemed to be necessary to truly finish the `watch` task (it would claim in the console output that it finished, but it wouldn't show the `Visit your CALC at:` line).

Fixed by surrounding the `gulp.parallel` call with a `gulp.series` call that runs `set-watching` first and then runs the rest in parallel.

**Problem 3**: Apparently older versions of `gulp` would regard tasks as finished if they returned (I don't know that this is true but am going by how the older code was written), but now they need to call a callback to register that they've finished. The `set-watching` tasks' function didn't have that, so `gulp` would never see it had finished.

Fixed by adding the callback as an argument and then calling it.

**Problem 4**: Similar to Problem 3 but wrapped in significantly more layers of indirection, the `webpackify` function in `frontend/gulp/webpack-util.js` also needs to call a callback to let `gulp` know that it has finished. Without this, it would never complete, leading to `gulp` (and possibly webpack also?) not watching for changes in the files it was supposed to be watching.

Fixed by adding a callback to the call to `webpack-stream` (because things weren't complicated already so we need a wrapper around webpack that plays nicely with `gulp`) and then a function that calls the callback if a new global variable, `taskNum`, equals `1` (apparently we don't want webpack, or rather `webpack-stream`, to run the callback outside of initial startup). I don't know enough about webpack or about what the intended behavior is here to be certain that webpack is now doing exactly what we want.
But after fixing this the `Visit your CALC at:` line appears in the console output, which seems to signify that `gulp` is actually doing everything that it's supposed to do for us, and changing a `.sass` file results in `gulp` re-running part of the build and the local server, thus reflecting the changes made in that file without needing to restart.
Hence I am declaring victory.
