### PR TITLE
Update search UI to reflect search API changes

### DIFF
--- a/frontend/source/js/data-explorer/components/query-type.jsx
+++ b/frontend/source/js/data-explorer/components/query-type.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { setQueryType as setQueryTypeAction } from '../actions';
 import {
   QUERY_TYPE_MATCH_ALL,
-  QUERY_TYPE_MATCH_PHRASE,
   QUERY_TYPE_MATCH_EXACT,
   QUERY_TYPE_LABELS,
 } from '../constants';
@@ -13,9 +12,6 @@ import {
 const INPUT_INFOS = {
   [QUERY_TYPE_MATCH_ALL]: {
     idSuffix: 'match_all',
-  },
-  [QUERY_TYPE_MATCH_PHRASE]: {
-    idSuffix: 'match_phrase',
   },
   [QUERY_TYPE_MATCH_EXACT]: {
     idSuffix: 'match_exact',
@@ -47,7 +43,6 @@ export function QueryType({ queryType, setQueryType, idPrefix }) {
   return (
     <ul role="group" aria-label="Labor category query type">
       {input(QUERY_TYPE_MATCH_ALL)}
-      {input(QUERY_TYPE_MATCH_PHRASE)}
       {input(QUERY_TYPE_MATCH_EXACT)}
     </ul>
   );

--- a/frontend/source/js/data-explorer/constants.js
+++ b/frontend/source/js/data-explorer/constants.js
@@ -71,7 +71,6 @@ export const SORT_KEYS = [
 
 export const QUERY_TYPE_MATCH_ALL = 'match_all';
 
-export const QUERY_TYPE_MATCH_PHRASE = 'match_phrase';
 
 export const QUERY_TYPE_MATCH_EXACT = 'match_exact';
 
@@ -79,7 +78,6 @@ export const DEFAULT_QUERY_TYPE = QUERY_TYPE_MATCH_ALL;
 
 export const QUERY_TYPE_LABELS = {
   [QUERY_TYPE_MATCH_ALL]: 'Contains words',
-  [QUERY_TYPE_MATCH_PHRASE]: 'Contains phrase',
   [QUERY_TYPE_MATCH_EXACT]: 'Exact match',
 };
 

--- a/frontend/source/js/data-explorer/tests/__snapshots__/query-type.test.jsx.snap
+++ b/frontend/source/js/data-explorer/tests/__snapshots__/query-type.test.jsx.snap
@@ -22,21 +22,6 @@ exports[`<QueryType> matches snapshot 1`] = `
   </li>
   <li>
     <input
-      checked={false}
-      id="zzz_match_phrase"
-      name="query_type"
-      onChange={[Function]}
-      type="radio"
-      value="match_phrase"
-    />
-    <label
-      htmlFor="zzz_match_phrase"
-    >
-      Contains phrase
-    </label>
-  </li>
-  <li>
-    <input
       checked={true}
       id="zzz_match_exact"
       name="query_type"

--- a/frontend/source/js/data-explorer/tests/query-type.test.jsx
+++ b/frontend/source/js/data-explorer/tests/query-type.test.jsx
@@ -16,23 +16,21 @@ describe('<QueryType>', () => {
     const { wrapper } = setup();
     expect(wrapper.find('#zzz_match_all').prop('value')).toBe('match_all');
     expect(wrapper.find('#zzz_match_exact').prop('value')).toBe('match_exact');
-    expect(wrapper.find('#zzz_match_phrase').prop('value')).toBe('match_phrase');
   });
 
   it('matching queryType is checked', () => {
     const { wrapper } = setup();
     expect(wrapper.find('#zzz_match_all').prop('checked')).toBe(false);
-    expect(wrapper.find('#zzz_match_phrase').prop('checked')).toBe(false);
     expect(wrapper.find('#zzz_match_exact').prop('checked')).toBe(true);
   });
 
   it('calls setQueryType fn onChange', () => {
     const { props, mounted } = setup();
     expect(props.setQueryType.mock.calls.length).toBe(0);
-    mounted.find('#zzz_match_phrase')
+    mounted.find('#zzz_match_exact')
       .simulate('change', { target: { checked: true } });
     expect(props.setQueryType.mock.calls.length).toBe(1);
-    expect(props.setQueryType.mock.calls[0][0]).toBe('match_phrase');
+    expect(props.setQueryType.mock.calls[0][0]).toBe('match_exact');
   });
 
   it('matches snapshot', () => {

--- a/frontend/source/js/data-explorer/tests/serialization.test.js
+++ b/frontend/source/js/data-explorer/tests/serialization.test.js
@@ -148,7 +148,6 @@ describe('deserializers', () => {
     it('deserializes various values', () => {
       const { query_type } = deserializers;
       expect(query_type('whatever')).toBe(DEFAULT_QUERY_TYPE);
-      expect(query_type('match_phrase')).toBe('match_phrase');
       expect(query_type('match_exact')).toBe('match_exact');
     });
   });


### PR DESCRIPTION
In #2061, we removed the `match_phrase` option, but we never updated the UI to reflect that. This does that + updates the tests to match (and it sets us up nicely to move to the "exact match" checkbox design we're doing next).