### PR TITLE
Lock bandit version to temporarly avoid issues with 1.5.0 version.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 -r requirements.txt
 
 # Testing and development dependencies
-bandit>=1.0,<2.0
+bandit==1.4.0
 pyflakes==1.6.0
 flake8==3.5.0
 pycodestyle==2.3.0


### PR DESCRIPTION
Bandits everywhere
Even integration tests
So we must roll back.

We should fix the issues 1.5.0 is reporting later.