### PR TITLE
Style refinements for the 2084 search ui work

### DIFF
--- a/frontend/source/sass/components/_forms.scss
+++ b/frontend/source/sass/components/_forms.scss
@@ -258,7 +258,7 @@ input[type].form__inline,
   background: $color-gray-lightest;
   border-radius: $border-radius;
   button {
-    background-position: right $space-2x top 1.9rem;
+    background-position: right .6rem top 1.6rem;
     background-repeat: no-repeat;
     background-size: 1em;
     border-radius: $border-radius;
@@ -289,7 +289,7 @@ input[type].form__inline,
 
 
 .html-dropdown__trigger {
-  padding: $space-2x $space-6x $space-2x $space-2x;
+  padding: $space-3x/2 3.5rem $space-3x/2 $space-3x/2;
   font-size: $base-font-size;
   span {
     margin-left: $space-half;

--- a/frontend/source/sass/components/_forms.scss
+++ b/frontend/source/sass/components/_forms.scss
@@ -187,7 +187,7 @@ dl.contract-details {
   display: flex;
   padding: 0;
   margin-top: $space-1x;
-  margin-bottom: $space-3x;
+  margin-bottom: 7px;
   border-radius: $border-radius;
   border-top: 1px solid $color-gray;
   border-right: none;
@@ -283,7 +283,7 @@ input[type].form__inline,
 
   // allot for data explorer search dropdown
   + .search-group {
-    margin-top: $space-8x;
+    margin-top: 5.6rem;
   }
 }
 

--- a/frontend/source/sass/components/_forms.scss
+++ b/frontend/source/sass/components/_forms.scss
@@ -300,7 +300,7 @@ input[type].form__inline,
 .html-dropdown__choices {
   z-index: 9999;
   padding: 0; // ul override
-  color: $color-gray-darker;
+  color: $color-gray-dark;
   background: $color-gray-lightest;
   border-bottom-left-radius: $border-radius;
   border-bottom-right-radius: $border-radius;

--- a/frontend/source/sass/data_explorer.scss
+++ b/frontend/source/sass/data_explorer.scss
@@ -23,6 +23,7 @@ body {
   }
   h2 {
     margin-top: $space-8x;
+    margin-bottom: $space-4x;
   }
 }
 


### PR DESCRIPTION
Changes:
- Added space below "Search CALC" header
- Reduced padding in selector in order to make its height match the search box
- Lightened the selector-list-item default text color a notch, for better contrast with the selected option (because sketch does a better job representing colors than chrome does!)
- Other vertical spacing adjustments