### PR TITLE
Add exact match checkbox

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,5 +19,11 @@
     "react/forbid-prop-types": [0],
     "react/destructuring-assignment": [0],
     "jsx-a11y/label-has-for": [0],
+    "jsx-a11y/label-has-associated-control": [ 2, {
+      "labelComponents": ["label"],
+      "labelAttributes": ["htmlFor"],
+      "controlComponents": ["input", "select"],
+      "depth": 3,
+    }],
   }
 }

--- a/frontend/source/js/data-explorer/actions.js
+++ b/frontend/source/js/data-explorer/actions.js
@@ -12,6 +12,7 @@ export const TOGGLE_EDU_LEVEL = 'TOGGLE_EDU_LEVEL';
 export const SET_SCHEDULE = 'SET_SCHEDULE';
 export const SET_CONTRACT_YEAR = 'SET_CONTRACT_YEAR';
 export const SET_QUERY_TYPE = 'SET_QUERY_TYPE';
+export const TOGGLE_MATCH_EXACT = 'TOGGLE_MATCH_EXACT';
 export const SET_SITE = 'SET_SITE';
 export const SET_BUSINESS_SIZE = 'SET_BUSINESS_SIZE';
 export const SET_QUERY = 'SET_QUERY';
@@ -78,6 +79,10 @@ export function setContractYear(year) {
 
 export function setQueryType(queryType) {
   return { type: SET_QUERY_TYPE, queryType };
+}
+
+export function toggleMatchExact(matchExact) {
+  return { type: TOGGLE_MATCH_EXACT, matchExact };
 }
 
 export function setSite(site) {

--- a/frontend/source/js/data-explorer/actions.js
+++ b/frontend/source/js/data-explorer/actions.js
@@ -12,7 +12,6 @@ export const TOGGLE_EDU_LEVEL = 'TOGGLE_EDU_LEVEL';
 export const SET_SCHEDULE = 'SET_SCHEDULE';
 export const SET_CONTRACT_YEAR = 'SET_CONTRACT_YEAR';
 export const SET_QUERY_TYPE = 'SET_QUERY_TYPE';
-export const TOGGLE_MATCH_EXACT = 'TOGGLE_MATCH_EXACT';
 export const SET_SITE = 'SET_SITE';
 export const SET_BUSINESS_SIZE = 'SET_BUSINESS_SIZE';
 export const SET_QUERY = 'SET_QUERY';
@@ -79,10 +78,6 @@ export function setContractYear(year) {
 
 export function setQueryType(queryType) {
   return { type: SET_QUERY_TYPE, queryType };
-}
-
-export function toggleMatchExact(matchExact) {
-  return { type: TOGGLE_MATCH_EXACT, matchExact };
 }
 
 export function setSite(site) {

--- a/frontend/source/js/data-explorer/components/experience.jsx
+++ b/frontend/source/js/data-explorer/components/experience.jsx
@@ -99,7 +99,7 @@ export class Experience extends React.Component {
           />
           <div className="experience_range">
             <label htmlFor={minId} className="usa-sr-only">
-Minimum Years
+              Minimum Years
             </label>
             <select
               id={minId}
@@ -112,7 +112,7 @@ Minimum Years
             </select>
             {' - '}
             <label htmlFor={maxId} className="usa-sr-only">
-Maximum Years
+              Maximum Years
             </label>
             <select
               id={maxId}

--- a/frontend/source/js/data-explorer/components/query-type.jsx
+++ b/frontend/source/js/data-explorer/components/query-type.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { setQueryType as setQueryTypeAction } from '../actions';
-import { toggleMatchExact as toggleMatchExactAction } from '../actions';
 import {
+  QUERY_TYPE_MATCH_ALL,
   QUERY_TYPE_MATCH_EXACT,
   QUERY_TYPE_LABELS,
 } from '../constants';
@@ -15,10 +15,11 @@ const INPUT_INFOS = {
   },
 };
 
-export function QueryType({ matchExact, toggleMatchExact, idPrefix }) {
+export function QueryType({ queryType, setQueryType, idPrefix }) {
   const input = (type) => {
     const { idSuffix } = INPUT_INFOS[type];
     const id = `${idPrefix}${idSuffix}`;
+    const matchExactIsChecked = (queryType === QUERY_TYPE_MATCH_EXACT ? true : false);
 
     return (
       <li>
@@ -26,9 +27,9 @@ export function QueryType({ matchExact, toggleMatchExact, idPrefix }) {
           id={id}
           type="checkbox"
           name="query_type"
-          value={type}
-          checked={matchExact}
-          onChange={() => { toggleMatchExact(matchExact); }}
+          value={queryType}
+          checked={matchExactIsChecked}
+          onChange={() => { setQueryType(queryType); }}
         />
         <label htmlFor={id}>
           {QUERY_TYPE_LABELS[type]}
@@ -55,6 +56,6 @@ QueryType.defaultProps = {
 };
 
 export default connect(
-  state => ({ matchExact: state.match_exact }),
-  { toggleMatchExact: toggleMatchExactAction },
+  state => ({ queryType: state.query_type }),
+  { setQueryType: setQueryTypeAction },
 )(QueryType);

--- a/frontend/source/js/data-explorer/components/query-type.jsx
+++ b/frontend/source/js/data-explorer/components/query-type.jsx
@@ -3,22 +3,19 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { setQueryType as setQueryTypeAction } from '../actions';
+import { toggleMatchExact as toggleMatchExactAction } from '../actions';
 import {
-  QUERY_TYPE_MATCH_ALL,
   QUERY_TYPE_MATCH_EXACT,
   QUERY_TYPE_LABELS,
 } from '../constants';
 
 const INPUT_INFOS = {
-  [QUERY_TYPE_MATCH_ALL]: {
-    idSuffix: 'match_all',
-  },
   [QUERY_TYPE_MATCH_EXACT]: {
     idSuffix: 'match_exact',
   },
 };
 
-export function QueryType({ queryType, setQueryType, idPrefix }) {
+export function QueryType({ matchExact, toggleMatchExact, idPrefix }) {
   const input = (type) => {
     const { idSuffix } = INPUT_INFOS[type];
     const id = `${idPrefix}${idSuffix}`;
@@ -27,11 +24,11 @@ export function QueryType({ queryType, setQueryType, idPrefix }) {
       <li>
         <input
           id={id}
-          type="radio"
+          type="checkbox"
           name="query_type"
           value={type}
-          checked={type === queryType}
-          onChange={() => { setQueryType(type); }}
+          checked={matchExact}
+          onChange={() => { toggleMatchExact(matchExact); }}
         />
         <label htmlFor={id}>
           {QUERY_TYPE_LABELS[type]}
@@ -42,7 +39,6 @@ export function QueryType({ queryType, setQueryType, idPrefix }) {
 
   return (
     <ul role="group" aria-label="Labor category query type">
-      {input(QUERY_TYPE_MATCH_ALL)}
       {input(QUERY_TYPE_MATCH_EXACT)}
     </ul>
   );
@@ -59,6 +55,6 @@ QueryType.defaultProps = {
 };
 
 export default connect(
-  state => ({ queryType: state.query_type }),
-  { setQueryType: setQueryTypeAction },
+  state => ({ matchExact: state.match_exact }),
+  { toggleMatchExact: toggleMatchExactAction },
 )(QueryType);

--- a/frontend/source/js/data-explorer/components/query-type.jsx
+++ b/frontend/source/js/data-explorer/components/query-type.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 
 import { setQueryType as setQueryTypeAction } from '../actions';
 import {
-  QUERY_TYPE_MATCH_ALL,
   QUERY_TYPE_MATCH_EXACT,
   QUERY_TYPE_LABELS,
 } from '../constants';
@@ -19,7 +18,7 @@ export function QueryType({ queryType, setQueryType, idPrefix }) {
   const input = (type) => {
     const { idSuffix } = INPUT_INFOS[type];
     const id = `${idPrefix}${idSuffix}`;
-    const matchExactIsChecked = (queryType === QUERY_TYPE_MATCH_EXACT ? true : false);
+    const matchExactIsChecked = (queryType === QUERY_TYPE_MATCH_EXACT);
 
     return (
       <li>

--- a/frontend/source/js/data-explorer/constants.js
+++ b/frontend/source/js/data-explorer/constants.js
@@ -71,7 +71,6 @@ export const SORT_KEYS = [
 
 export const QUERY_TYPE_MATCH_ALL = 'match_all';
 
-
 export const QUERY_TYPE_MATCH_EXACT = 'match_exact';
 
 export const DEFAULT_QUERY_TYPE = QUERY_TYPE_MATCH_ALL;

--- a/frontend/source/js/data-explorer/reducers.js
+++ b/frontend/source/js/data-explorer/reducers.js
@@ -25,6 +25,7 @@ import {
   SET_SCHEDULE,
   SET_CONTRACT_YEAR,
   SET_QUERY_TYPE,
+  TOGGLE_MATCH_EXACT,
   SET_SITE,
   SET_BUSINESS_SIZE,
   SET_QUERY,
@@ -162,6 +163,13 @@ function queryType(state = DEFAULT_QUERY_TYPE, action) {
   return state;
 }
 
+function matchExact(state = false, action) {
+  if (action.type === TOGGLE_MATCH_EXACT) {
+    return !action.matchExact;
+  }
+  return state;
+}
+
 const combinedReducer = combineReducers({
   exclude,
   q,
@@ -176,6 +184,7 @@ const combinedReducer = combineReducers({
   'proposed-price': proposedPrice,
   sort,
   query_type: queryType,
+  match_exact: matchExact,
 });
 
 export default (state, action) => {

--- a/frontend/source/js/data-explorer/reducers.js
+++ b/frontend/source/js/data-explorer/reducers.js
@@ -7,6 +7,8 @@ import {
   EMPTY_RATES_DATA,
   DEFAULT_SORT,
   DEFAULT_QUERY_TYPE,
+  QUERY_TYPE_MATCH_ALL,
+  QUERY_TYPE_MATCH_EXACT,
   MAX_QUERY_LENGTH,
 } from './constants';
 
@@ -25,7 +27,6 @@ import {
   SET_SCHEDULE,
   SET_CONTRACT_YEAR,
   SET_QUERY_TYPE,
-  TOGGLE_MATCH_EXACT,
   SET_SITE,
   SET_BUSINESS_SIZE,
   SET_QUERY,
@@ -158,14 +159,13 @@ function sort(state = DEFAULT_SORT, action) {
 
 function queryType(state = DEFAULT_QUERY_TYPE, action) {
   if (action.type === SET_QUERY_TYPE) {
-    return action.queryType;
-  }
-  return state;
-}
-
-function matchExact(state = false, action) {
-  if (action.type === TOGGLE_MATCH_EXACT) {
-    return !action.matchExact;
+    // since the match_exact checkbox toggles these,
+    // set the state equal to the opposite of what is currently set.
+    if (action.queryType === QUERY_TYPE_MATCH_ALL) {
+      return QUERY_TYPE_MATCH_EXACT;
+    } else {
+      return QUERY_TYPE_MATCH_ALL;
+    }
   }
   return state;
 }
@@ -184,7 +184,6 @@ const combinedReducer = combineReducers({
   'proposed-price': proposedPrice,
   sort,
   query_type: queryType,
-  match_exact: matchExact,
 });
 
 export default (state, action) => {

--- a/frontend/source/js/data-explorer/reducers.js
+++ b/frontend/source/js/data-explorer/reducers.js
@@ -163,9 +163,8 @@ function queryType(state = DEFAULT_QUERY_TYPE, action) {
     // set the state equal to the opposite of what is currently set.
     if (action.queryType === QUERY_TYPE_MATCH_ALL) {
       return QUERY_TYPE_MATCH_EXACT;
-    } else {
-      return QUERY_TYPE_MATCH_ALL;
-    }
+    } 
+    return QUERY_TYPE_MATCH_ALL;
   }
   return state;
 }


### PR DESCRIPTION
Closes #2058.

Since we already removed the "match phrase" option and "match all" is the default, this just simplifies the options further. Required adding a bit of logic to `setQueryType` to return `match_all` by default and `match_exact` on toggle.

<img width="699" alt="screen shot 2018-08-29 at 8 54 29 am" src="https://user-images.githubusercontent.com/509309/44795779-bff12300-ab68-11e8-885c-3ceb8270b1a5.png">
