### PR TITLE
Move “Analyze prices” functionality behind authorization.

### DIFF
--- a/data_capture/management/commands/initgroups.py
+++ b/data_capture/management/commands/initgroups.py
@@ -6,6 +6,7 @@ from calc.utils import get_permissions_from_ns_codenames
 
 BULK_UPLOAD_PERMISSION = 'contracts.add_bulkuploadcontractsource'
 PRICE_LIST_UPLOAD_PERMISSION = 'data_capture.add_submittedpricelist'
+ANALYZE_PRICES_PERMISSION = PRICE_LIST_UPLOAD_PERMISSION  # May change later.
 VIEW_ATTEMPT_PERMISSION = 'data_capture.change_attemptedpricelistsubmission'
 
 ROLES = {}
@@ -14,6 +15,7 @@ ROLES = {}
 # the "Authentication and Authorization" section of docs/auth.md.
 
 ROLES['Data Administrators'] = set([
+    ANALYZE_PRICES_PERMISSION,
     'auth.add_user',
     'auth.change_user',
     BULK_UPLOAD_PERMISSION,
@@ -29,6 +31,7 @@ ROLES['Data Administrators'] = set([
 ])
 
 ROLES['Contract Officers'] = set([
+    ANALYZE_PRICES_PERMISSION,
     PRICE_LIST_UPLOAD_PERMISSION,
     'data_capture.add_submittedpricelistrow',
 ])

--- a/data_capture/views/price_list_analyze.py
+++ b/data_capture/views/price_list_analyze.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required, permission_required
 from django.views.decorators.http import require_http_methods
 from django.shortcuts import redirect, render
 
@@ -5,6 +6,7 @@ from .common import (add_generic_form_error,
                      get_nested_item, get_deserialized_gleaned_data)
 from .. import forms
 from ..decorators import handle_cancel
+from ..management.commands.initgroups import ANALYZE_PRICES_PERMISSION
 from frontend import ajaxform
 from frontend.steps import Steps
 from ..schedules import registry
@@ -26,6 +28,8 @@ class AnalyzeStep1Form(forms.Step1Form):
 
 
 @steps.step(label='Select a schedule')
+@login_required
+@permission_required(ANALYZE_PRICES_PERMISSION, raise_exception=True)
 @require_http_methods(["GET", "POST"])
 def analyze_step_1(request, step):
     if request.method == 'GET':
@@ -50,6 +54,8 @@ def analyze_step_1(request, step):
 
 
 @steps.step(label='Upload a price list to analyze')
+@login_required
+@permission_required(ANALYZE_PRICES_PERMISSION, raise_exception=True)
 @require_http_methods(["GET", "POST"])
 @handle_cancel
 def analyze_step_2(request, step):
@@ -139,6 +145,8 @@ def analyze_step_2_errors(request):
 
 
 @steps.step(label='Analysis')
+@login_required
+@permission_required(ANALYZE_PRICES_PERMISSION, raise_exception=True)
 @require_http_methods(["GET"])
 def analyze_step_3(request, step):
     gleaned_data = get_deserialized_gleaned_data(
@@ -155,6 +163,8 @@ def analyze_step_3(request, step):
 
 
 @require_http_methods(["GET"])
+@login_required
+@permission_required(ANALYZE_PRICES_PERMISSION, raise_exception=True)
 def export_analysis(request):
     gleaned_data = get_deserialized_gleaned_data(
         request,

--- a/data_explorer/templates/_nav.html
+++ b/data_explorer/templates/_nav.html
@@ -2,6 +2,9 @@
     <ul>
       <li><a href="{% url 'index' %}">Explore data</a></li>
       {% if user.is_staff %}
+      {% endif %}
+      {% if perms.data_capture.add_submittedpricelist %}
+      {# I would prefer to use ANALYZE_PRICES_PERMISSION here, but the magic of django.contrib.auth doesn't seem to allow that, so this will need to be manually changed if ANALYZE_PRICES_PERMISSION ever diverges from data_capture.add_submittedpricelist #}
       <li{% if current_selected_tab == 'analyze_price_data'%} class="selected"{% endif %}><a href="{% url 'data_capture:analyze_step_1' %}">Analyze prices</a></li>
       {% endif %}
       {% if perms.data_capture.add_submittedpricelist %}


### PR DESCRIPTION
Not everyone should
Analyze prices, and so
Restrict it to some.

Requires users to be logged in to see or access the price analysis functionality.

Note that currently this assumes that users allowed to upload price lists are the same users allowed to analyze prices.