### PR TITLE
Add working basic search by vendor_name or idv_piid, plus simple tests.

### DIFF
--- a/api/tests/test_rates_api.py
+++ b/api/tests/test_rates_api.py
@@ -945,10 +945,6 @@ class GetRatesTests(TestCase):
 
     def test_query_by_vendor_name(self):
         self.make_test_set()
-        get_contract_recipe().make(
-            _quantity=1,
-            vendor_name="ACME Corp."
-        )
         resp = self.c.get(
             self.path, {'q': 'ACME', 'query_by': 'vendor_name'})
         self.assertEqual(resp.status_code, 200)
@@ -961,6 +957,56 @@ class GetRatesTests(TestCase):
                                   'min_years_experience': 10,
                                   'hourly_rate_year1': 18.0,
                                   'current_price': 18.0,
+                                  'schedule': None,
+                                  'contractor_site': None,
+                                  'business_size': None}])
+
+        resp = self.c.get(
+            self.path, {'q': 'numbers', 'query_by': 'vendor_name'})
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertResultsEqual(resp.data['results'],
+                                [{'idv_piid': 'ABC234',
+                                  'vendor_name': 'Numbers R Us',
+                                  'labor_category': 'Accounting, CPA',
+                                  'education_level': 'Masters',
+                                  'min_years_experience': 5,
+                                  'hourly_rate_year1': 50.0,
+                                  'current_price': 50.0,
+                                  'schedule': None,
+                                  'contractor_site': None,
+                                  'business_size': None}])
+
+    def test_query_by_vendor_id(self):
+        self.make_test_set()
+        resp = self.c.get(
+            self.path, {'q': 'ABC123', 'query_by': 'idv_piid'})
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertResultsEqual(resp.data['results'],
+                                [{'idv_piid': 'ABC123',
+                                  'vendor_name': 'ACME Corp.',
+                                  'labor_category': 'Legal Services',
+                                  'education_level': None,
+                                  'min_years_experience': 10,
+                                  'hourly_rate_year1': 18.0,
+                                  'current_price': 18.0,
+                                  'schedule': None,
+                                  'contractor_site': None,
+                                  'business_size': None}])
+
+        resp = self.c.get(
+            self.path, {'q': 'ABC234', 'query_by': 'idv_piid'})
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertResultsEqual(resp.data['results'],
+                                [{'idv_piid': 'ABC234',
+                                  'vendor_name': 'Numbers R Us',
+                                  'labor_category': 'Accounting, CPA',
+                                  'education_level': 'Masters',
+                                  'min_years_experience': 5,
+                                  'hourly_rate_year1': 50.0,
+                                  'current_price': 50.0,
                                   'schedule': None,
                                   'contractor_site': None,
                                   'business_size': None}])

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -136,6 +136,10 @@ class CurrentContractManager(models.Manager):
             for phrase in phrases:
                 filter_by = {query_by + '__iexact': phrase}
                 matches = matches | qs.filter(**filter_by)
+        elif query_by != '_normalized_labor_category':
+            for phrase in phrases:
+                filter_by = {query_by + '__icontains': phrase}
+                matches = matches | qs.filter(**filter_by)
         else:
             # Match any: Break phrases down into individual words
             # So "business manager" finds results with "business" AND "manager"


### PR DESCRIPTION
Vendors have ids
Also, they often have names.
Those should be useful.

This adds to the API the ability to search by `vendor_name` or `idv_piid`. It's a naive implementation, but it might be enough—I'm not sure what the longer-term requirements are.

The tests are also fairly basic.