### PR TITLE
Remove template tags that are no longer used

### DIFF
--- a/data_capture/templates/data_capture/bulk_upload/region_10_step.html
+++ b/data_capture/templates/data_capture/bulk_upload/region_10_step.html
@@ -1,7 +1,5 @@
 {% extends 'data_capture/step.html' %}
 
-{% block title %}Upload Region 10 data / {{ step.description|capfirst }}: {% block subtitle %}{% endblock %}{% endblock %}
-
 {% block page_heading %}Upload Region 10 data{% endblock %}
 
 {% block steps %}

--- a/data_capture/templates/data_capture/replace_price_list/replace_step.html
+++ b/data_capture/templates/data_capture/replace_price_list/replace_step.html
@@ -1,9 +1,6 @@
 {% extends 'data_capture/step.html' %}
 
-{% block title %}Replace Price List / {{ step.description|capfirst }}: {% block subtitle %}{% endblock %}{% endblock %}
-
 {% block main_class %}card--collapse-header{% endblock %}
-
 
 {% block steps %}
 {# Intentionally left empty because we don't want to render #}


### PR DESCRIPTION
In attempting to fix #2114, I realized the bulk upload templates never got updated to reflect the work done to rejigger the `head_meta` block for price list upload templates. This just removes the old block tags that are no longer applicable (and showed up oddly at the very top of the page, as seen in #2114).