### PR TITLE
Adds a bottom border to search selector

### DIFF
--- a/frontend/source/sass/components/_forms.scss
+++ b/frontend/source/sass/components/_forms.scss
@@ -317,6 +317,7 @@ label[for=query_type_match_exact] {
   padding: 0; // ul override
   color: $color-gray-dark;
   background: $color-gray-lightest;
+  border-bottom: 3px solid $color-gray-light;
   border-bottom-left-radius: $border-radius;
   border-bottom-right-radius: $border-radius;
 


### PR DESCRIPTION
The new search-selector design failed to account for the longer list of schedules which we have on the live site (dev has 9, prod has 13). Since the selector and the highlights block share a common background color, they visually fuse:

![image](https://user-images.githubusercontent.com/9259185/46170573-c657e500-c263-11e8-9739-448aadfd692f.png)

So I added a border to the bottom of the expanded selector:
![image](https://user-images.githubusercontent.com/9259185/46170798-6dd51780-c264-11e8-9b6e-4201fad5f3de.png)
